### PR TITLE
hmc7044: Fix VCO range

### DIFF
--- a/adijif/clocks/hmc7044.py
+++ b/adijif/clocks/hmc7044.py
@@ -32,8 +32,8 @@ class hmc7044(hmc7044_bf):
 
     # Limits
     """ Internal limits """
-    vco_min = 2150e6
-    vco_max = 3550e6
+    vco_min = 2400e6
+    vco_max = 3200e6
     pfd_max = 250e6
     vcxo_min = 10e6
     vcxo_max = 500e6


### PR DESCRIPTION
Added guaranteed frequency coverage limits instead.
With the previous limits, during testing, some configs
were not successful on the hardware.

Signed-off-by: Alexandru Tachici <alexandru.tachici@analog.com>