### PR TITLE
ad9545: Fix constraints for Gekko solver

### DIFF
--- a/adijif/clocks/ad9545.py
+++ b/adijif/clocks/ad9545.py
@@ -224,12 +224,14 @@ class ad9545(clock):
         for i in range(0, 4):
             if self.input_refs[i] != 0:
                 if self.solver == "gekko":
-                    self.config["PLL_in_rate_" + str(i)] = self.model.Intermediate(self.config["input_ref_" + str(i)] / self.config["r" + str(i)])
+
+                    self.config["PLL_in_rate_" + str(i)] = self.model.Var(integer=True, lb=self.PLL_in_min, ub=self.PLL_in_max)
                 elif self.solver == "CPLEX":
                     self.config["PLL_in_rate_" + str(i)] = exp.integer_var(int(self.PLL_in_min), int(self.PLL_in_max), "PLL_in_rate_" + str(i))
-                    equations = equations + [self.config["PLL_in_rate_" + str(i)] * self.config["r" + str(i)] == self.config["input_ref_" + str(i)]]
                 else:
                     raise Exception("Unknown solver {}".format(self.solver))
+
+                equations = equations + [self.config["PLL_in_rate_" + str(i)] * self.config["r" + str(i)] == self.config["input_ref_" + str(i)]]
 
                 """ Need to make sure here the PLLs do not receive more than 200 kHz input """
                 equations = equations + [self.config["PLL_in_rate_" + str(i)] < self.PLL_in_max]
@@ -317,7 +319,7 @@ class ad9545(clock):
 
                 self._add_equation(
                     [
-                        self.config["PLL" + str(pll_number) + "_rate"] / self.config["q" + str(i)] == self.config["out_rate_" + str(i)]
+                        self.config["PLL" + str(pll_number) + "_rate"] == self.config["out_rate_" + str(i)] * self.config["q" + str(i)]
                     ]
                 )
 


### PR DESCRIPTION
Removed divisions from ecuations. Otherwise multple
tests would fail with either a timeout or no solution found.

Signed-off-by: Alexandru Tachici <alexandru.tachici@analog.com>