### PR TITLE
Jesd settings print

### DIFF
--- a/adijif/jesd.py
+++ b/adijif/jesd.py
@@ -1,6 +1,8 @@
 """JESD parameterization definitions and helper functions."""
 from abc import ABCMeta, abstractmethod
-from typing import List, Union
+from typing import Dict, List, Union
+
+from adijif.solvers import CpoSolveResult
 
 
 class jesd(metaclass=ABCMeta):
@@ -9,6 +11,19 @@ class jesd(metaclass=ABCMeta):
     # Lane rate min/max defaulting to JESD spec (parts may differ)
     bit_clock_min_available = {"jesd204b": 312.5e6, "jesd204c": 312.5e6}
     bit_clock_max_available = {"jesd204b": 12.5e9, "jesd204c": 32e9}
+
+    _parameters_to_return = [
+        "bit_clock",
+        "multiframe_clock",
+        "sample_clock",
+        "F",
+        "HD",
+        "K",
+        "L",
+        "M",
+        "Np",
+        "S",
+    ]
 
     solver = "CPLEX"
 
@@ -29,6 +44,21 @@ class jesd(metaclass=ABCMeta):
         self.M = M
         self.Np = Np
         # self.S = S
+
+    def get_jesd_config(self, solution: CpoSolveResult = None) -> Dict:
+        """Extract configurations from solver results.
+
+        Collect JESD related parameters, includes modes and clocks.
+
+        Args:
+            solution (CpoSolveResult): CPlex solution. Only needed for CPlex solver
+
+        Returns:
+            Dict: Dictionary of JESD parameters
+        """
+        if solution:  # type: ignore
+            self.solution = solution
+        return {p: getattr(self, p) for p in self._parameters_to_return}
 
     def validate_clocks(self) -> None:
         """Validate all clocks clock settings are within range."""

--- a/adijif/system.py
+++ b/adijif/system.py
@@ -158,6 +158,7 @@ class system:
                 solution=self.solution, converter=conv, fpga_ref=clk_ref
             )
             cfg["converter"] = conv.get_config(self.solution)  # type: ignore
+            cfg["jesd_" + conv.name] = conv.get_jesd_config(self.solution)
         return cfg
 
     def _filter_sysref(

--- a/examples/daq2_hmc7044.py
+++ b/examples/daq2_hmc7044.py
@@ -32,3 +32,6 @@ pprint.pprint(cfg["converter"])
 
 print("Converter config:")
 pprint.pprint(cfg["fpga_AD9680"])
+
+print("JESD config:")
+pprint.pprint(cfg["jesd_AD9680"])


### PR DESCRIPTION
Add JESD config to config exports in system class. An example output would look like:
```
{'F': 1,
 'HD': 1,
 'K': 32,
 'L': 4,
 'M': 2,
 'Np': 16,
 'S': 1,
 'bit_clock': 10000000000.0,
 'multiframe_clock': 31250000.0,
 'sample_clock': 1000000000.0}
```
This can be modified by any Converter or FPGA class by setting this prop: https://github.com/analogdevicesinc/pyadi-jif/blob/jesd-settings-print/adijif/jesd.py#L15
