### PR TITLE
Fix triton python example, sync ipynb with py

### DIFF
--- a/examples/triton/triton_vcu118.ipynb
+++ b/examples/triton/triton_vcu118.ipynb
@@ -138,6 +138,7 @@
     "\n",
     "# Use generate profile\n",
     "profile_json = \"id00_triton_M4_L2_RX13p2.json\"\n",
+    "profile_bin = profile_json.replace('.json','.bin')\n",
     "\n",
     "sys = adijif.system(\"ad9084_rx\", \"ltc6952\", \"xilinx\", vcxo, solver=\"CPLEX\")\n",
     "\n",
@@ -163,8 +164,7 @@
     "\n",
     "cfg = sys.solve()\n",
     "\n",
-    "pprint.pprint(cfg)\n",
-    "\n"
+    "pprint.pprint(cfg)"
    ]
   },
   {
@@ -187,12 +187,11 @@
      "output_type": "stream",
      "text": [
       "Make command:\n",
-      "JESD_MODE=64B66B RX_RATE=13.2000 TX_RATE=13.2000 RX_JESD_M=4 TX_JESD_M=4 RX_JESD_L=2 TX_JESD_L=2 RX_JESD_S=1 TX_JESD_S=1 RX_JESD_NP=16 TX_JESD_NP=16 \n"
+      "JESD_MODE=64B66B RX_RATE=13.2000 TX_RATE=13.2000 RX_JESD_M=4 TX_JESD_M=4 RX_JESD_L=2 TX_JESD_L=2 RX_JESD_S=1 TX_JESD_S=1 RX_JESD_NP=16 TX_JESD_NP=16"
      ]
     }
    ],
    "source": [
-    "\n",
     "mode = \"64B66B\" if sys.converter.jesd_class == \"jesd204c\" else \"8B10B\"\n",
     "make_cmd = (\n",
     "    f\"JESD_MODE={mode} \"\n",
@@ -203,7 +202,7 @@
     "    + f\"RX_JESD_NP={sys.converter.Np} TX_JESD_NP={sys.converter.Np} \"\n",
     ")\n",
     "print(\"Make command:\")\n",
-    "print(make_cmd)\n"
+    "print(make_cmd)"
    ]
   },
   {
@@ -530,17 +529,18 @@
     }
    ],
    "source": [
-    "# Install jinja2 if you don't have it with pip install jinja2\n",
-    "import jinja2 as j2\n",
+    "from importlib.util import find_spec\n",
     "\n",
-    "# Read template\n",
-    "with open(\"triton_dt.tmpl\", \"r\") as f:\n",
-    "    template = j2.Template(f.read())\n",
-    "    rendered = template.render(cfg=cfg, profile_filename=profile_json.replace('.json','.bin'))\n",
-    "print(rendered)\n",
-    "\n",
-    "with open(\"triton_dt.dts\", \"w\") as f:\n",
-    "    f.write(rendered)"
+    "if find_spec(\"jinja2\"):\n",
+    "    import jinja2\n",
+    "    # Read template\n",
+    "    with open(\"triton_dt.tmpl\", \"r\") as f:\n",
+    "        template = jinja2.Template(f.read())\n",
+    "        rendered = template.render(cfg=cfg, profile_filename=profile_bin)\n",
+    "    with open(\"triton_dt.dts\", \"w\") as f:\n",
+    "        f.write(rendered)\n",
+    "else:\n",
+    "    print(\"jinja2 not installed, install with pip install jinja2\")"
    ]
   }
  ],


### PR DESCRIPTION
I am not sure the usefulness of having to maintain both ipynb and python

To export the ipynb to py, this can be used:

```
jupyter nbconvert *.ipynb --to python
```
and then to run

```
ipython *.py
```