### PR TITLE
Update doc.yml, add pr-closed.yml 

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,5 +1,8 @@
 name: Build and Deploy Doc
-on: push
+on:
+  push:
+  pull_request:
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -29,69 +32,26 @@ jobs:
         cd doc
         make linkcheck
 
-  deploy_dev:
-    name: Deploy master docs
+    - name: Store the generated doc
+      uses: actions/upload-artifact@v4
+      with:
+        name: python${{ matrix.python-version }}_html
+        path: doc/build/html
+
+  deploy-gh-pages:
     runs-on: ubuntu-latest
-    needs: [build]
-    if: github.ref == 'refs/heads/main'
+    needs: build
+    permissions:
+      contents: write
+    if: >
+      github.ref == 'refs/heads/main' ||
+      github.event_name == 'pull_request' ||
+      github.ref_type == 'tag'
+
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
+    - uses: analogdevicesinc/doctools/gh-pages-deploy@action
+      with:
+        new_tag: ${{ github.ref_type == 'tag' }}
+        tag: ${{ github.ref_name }}
+        name: python3.9_html
 
-      - name: Build and push doc
-        run: |
-         cd adijif/d2
-         chmod +x build.sh
-         ./build.sh
-         cd ../..
-         pip install ".[cplex]"
-         pip install -r requirements_dev.txt
-         pip install $(tail --lines=+2 doc/requirements.txt)
-         cd doc
-         export ADOC_TARGET_DEPTH=1
-         make html
-         cd ..
-
-      - name: Publish doc
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./doc/build/html
-          destination_dir: main
-
-  deploy:
-    name: Deploy docs
-    runs-on: ubuntu-latest
-    needs: [build]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
-
-      - name: Build Doc
-        run: |
-         cd adijif/d2
-         chmod +x build.sh
-         ./build.sh
-         cd ../..
-         pip install ".[cplex]"
-         pip install -r requirements_dev.txt
-         pip install $(tail --lines=+2 doc/requirements.txt)
-         cd doc
-         export ADOC_TARGET_DEPTH=1
-         make html
-         cd ..
-
-      - name: Publish doc
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./doc/build/html

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -1,0 +1,14 @@
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  clean-gh-pages:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - uses: analogdevicesinc/doctools/gh-pages-rm-path@action
+      with:
+        path: pull/${{ github.event.number }}


### PR DESCRIPTION
Use context aware shared-actions to reduce churn, and enable
pull_request doc deployment with embed checks (e.g. check if
third-party contributor).

Attention: pushes to main will write to root, and tag creating
to a <tag>/ folder (e.g., v0.1.1), changing the previous behavior.

A temporary head commit was added to not deploy the pull request
version of the doc while this pr is reviewed.