### PR TITLE
Fix flaky e2e test and pytest warning

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -223,7 +223,7 @@ def testsnb(session):
         "nbmake",
         "pandas",
         "itables",
-        "git+https://github.com/analogdevicesinc/pyadi-dt.git",
+        "git+https://github.com/analogdevicesinc/pyadi-dt.git@b0c91ce",
         "jinja2",
         "pillow",
         "mpmath",

--- a/tests/tools/e2e/pages/base_page.py
+++ b/tests/tools/e2e/pages/base_page.py
@@ -292,21 +292,21 @@ class BasePage:
         """
         return self.page.screenshot(full_page=full_page)
 
-    def is_visible(self, text: str) -> bool:
-        """Check if text is visible on page.
+    def is_visible(self, text: str, timeout: int = 10000) -> bool:
+        """Check if text is visible on page, waiting for it to appear.
 
         Args:
             text: Text to search for
+            timeout: Maximum time to wait in milliseconds (default 10s)
 
         Returns:
-            bool: True if text is visible
+            bool: True if text is visible within the timeout
         """
         try:
-            # Use first() to avoid strict mode violation with multiple matches
             elem = self.page.get_by_text(text).first
-            return elem.is_visible()
+            elem.wait_for(state="visible", timeout=timeout)
+            return True
         except (TimeoutError, AttributeError):
-            # Element not found or not visible
             return False
 
     def get_text_value(self, label: str) -> str:

--- a/tests/tools/e2e/test_startup.py
+++ b/tests/tools/e2e/test_startup.py
@@ -4,6 +4,7 @@ import subprocess  # noqa: S404
 import sys
 import time
 
+import pytest
 import requests
 
 
@@ -34,13 +35,10 @@ def test_streamlit_startup():
         # Check if process is alive
         if process.poll() is not None:
             stdout, stderr = process.communicate()
-            print("❌ Process died!")
-            print(f"Return code: {process.poll()}")
-            if stderr:
-                print(f"Stderr: {stderr}")
-            if stdout:
-                print(f"Stdout: {stdout}")
-            return False
+            pytest.fail(
+                f"Process died! Return code: {process.poll()}\n"
+                f"Stderr: {stderr}\nStdout: {stdout}"
+            )
 
         # Try health check
         try:
@@ -59,17 +57,19 @@ def test_streamlit_startup():
                 process.terminate()
                 process.wait(timeout=5)
                 print("✓ Process terminated cleanly")
-                return True
+                return
         except requests.exceptions.RequestException as e:
             elapsed = time.time() - start_time
             print(f"  [{elapsed:.1f}s] Health check failed: {e}")
             time.sleep(0.5)
 
-    print("❌ Timeout: Streamlit app didn't respond within 60 seconds")
     process.terminate()
-    return False
+    pytest.fail("Timeout: Streamlit app didn't respond within 60 seconds")
 
 
 if __name__ == "__main__":
-    success = test_streamlit_startup()
-    sys.exit(0 if success else 1)
+    try:
+        test_streamlit_startup()
+        sys.exit(0)
+    except Exception:
+        sys.exit(1)


### PR DESCRIPTION
Use wait_for in BasePage.is_visible() to eliminate race condition causing intermittent test_system_page_layout failures. Replace return True/False with pytest.fail() in test_startup.py to fix PytestReturnNotNoneWarning.