### PR TITLE
feat: expose inter-component clocks from system.initialize() for further constraining

### DIFF
--- a/adijif/sys/__init__.py
+++ b/adijif/sys/__init__.py
@@ -1,1 +1,5 @@
 """Helper methods for system level models."""
+
+from adijif.sys.clocks_bundle import ClocksBundle
+
+__all__ = ["ClocksBundle"]

--- a/adijif/sys/clocks_bundle.py
+++ b/adijif/sys/clocks_bundle.py
@@ -1,0 +1,154 @@
+"""Bundle of inter-component clock expressions returned by ``system.initialize()``."""
+
+from typing import Any, Iterable, List, Optional, Tuple, Union
+
+
+class ClocksBundle(dict):
+    """Inter-component clock expressions returned by ``system.initialize()``.
+
+    Maps a clock name to the solver expression representing the rate of a clock
+    that flows between two high-level components in the system (clock chip to
+    converter, clock chip to FPGA, clock chip to inline / sysref PLL, etc.).
+
+    ``ClocksBundle`` is a regular ``dict``: ``clocks[name]`` returns the raw
+    solver expression, ``for k in clocks`` iterates clock names, and
+    ``dict()``-consuming code keeps working. ``constrain()`` is provided as a
+    convenience that hides the solver-backend differences.
+
+    Canonical clock names (created by ``system.initialize()``):
+
+    - ``{converter}_ref_clk`` -- clock chip to converter device clock.
+    - ``{converter}_ref_clk_from_ext_pll`` -- inline PLL output to converter
+      (when ``add_pll_inline`` is used).
+    - ``{converter}_sysref`` -- sysref to converter.
+    - ``{converter}_fpga_ref_clk`` -- clock chip to FPGA reference clock.
+    - ``{converter}_fpga_device_clk`` -- clock chip to FPGA link clock.
+    - ``{pll}_ref_clk`` -- clock chip to inline / sysref PLL reference.
+    - ``{pll}_bsync_reference`` -- clock chip to sysref PLL BSYNC reference.
+
+    For nested converters (MxFE / transceivers) the converter name is replaced
+    by the nested channel name (e.g. ``adc_sysref``, ``dac_fpga_ref_clk``).
+
+    Example:
+        clocks = sys.initialize()
+        clocks.constrain("AD9680_fpga_ref_clk", range=(250e6, 350e6))
+        clocks.constrain("AD9680_sysref", equal_to=7.8125e6)
+        cfg = sys.do_solve()
+    """
+
+    def __init__(self, items: dict, owner: Any) -> None:
+        """Wrap a dict of clock expressions with constraint helpers.
+
+        Args:
+            items: Mapping of clock name to solver expression.
+            owner: System instance that owns the solver model. Used to
+                forward constraints to the active solver via
+                ``owner.clock._add_equation``.
+        """
+        super().__init__(items)
+        self._owner = owner
+
+    def _resolve(self, value: Any) -> Any:
+        """Resolve ``value`` to a solver expression or scalar.
+
+        Strings are looked up as another clock name in this bundle so users
+        can express equality between two clocks without grabbing the
+        expression themselves.
+
+        Args:
+            value: Scalar, solver expression, or name of another clock.
+
+        Returns:
+            The solver expression / scalar to use in a constraint.
+
+        Raises:
+            KeyError: If ``value`` is a string that is not a clock name.
+        """
+        if isinstance(value, str):
+            if value not in self:
+                raise KeyError(self._unknown_message(value))
+            return self[value]
+        return value
+
+    def _unknown_message(self, name: str) -> str:
+        return (
+            f"Unknown clock name '{name}'. "
+            f"Available clocks: {sorted(self.keys())}"
+        )
+
+    def constrain(
+        self,
+        name: str,
+        *,
+        equal_to: Any = None,
+        min: Optional[Union[int, float]] = None,
+        max: Optional[Union[int, float]] = None,
+        range: Optional[Tuple[Union[int, float], Union[int, float]]] = None,
+        choices: Optional[Iterable[Union[int, float]]] = None,
+    ) -> None:
+        """Add a constraint on an inter-component clock.
+
+        Pass ``range=(lo, hi)`` as sugar for ``min=lo, max=hi``. Bounds and
+        ``equal_to`` may be combined (e.g. ``min=`` plus ``max=``); ``choices``
+        and ``equal_to`` are mutually exclusive with bounds.
+
+        Args:
+            name: Clock name. Must be a key in this bundle.
+            equal_to: Force the clock equal to a scalar, another solver
+                expression, or another clock by name.
+            min: Lower bound on the clock rate.
+            max: Upper bound on the clock rate.
+            range: ``(lo, hi)`` tuple; equivalent to ``min=lo, max=hi``.
+            choices: Iterable of allowed exact rates. Currently CPLEX only.
+
+        Raises:
+            KeyError: ``name`` is not in this bundle.
+            ValueError: No constraint kwarg was given, or ``range`` was passed
+                together with ``min`` / ``max``.
+            NotImplementedError: ``choices`` was passed with a non-CPLEX
+                solver backend.
+        """
+        if name not in self:
+            raise KeyError(self._unknown_message(name))
+        expr = self[name]
+        clk = self._owner.clock
+
+        if range is not None:
+            if min is not None or max is not None:
+                raise ValueError(
+                    "Pass either range=(lo, hi) or min=/max=, not both"
+                )
+            min, max = range[0], range[1]
+
+        added = False
+        if equal_to is not None:
+            other = self._resolve(equal_to)
+            clk._add_equation(expr == other)
+            added = True
+        if min is not None:
+            clk._add_equation(expr >= min)
+            added = True
+        if max is not None:
+            clk._add_equation(expr <= max)
+            added = True
+        if choices is not None:
+            choices_list: List[Union[int, float]] = list(choices)
+            if not choices_list:
+                raise ValueError("choices must be a non-empty iterable")
+            if self._owner.solver != "CPLEX":
+                raise NotImplementedError(
+                    "constrain(..., choices=...) currently requires the "
+                    "CPLEX solver. Use range=/equal_to= with GEKKO."
+                )
+            from docplex.cp.modeler import logical_or  # noqa: PLC0415
+
+            self._owner.model.add(
+                logical_or(*[expr == c for c in choices_list])
+            )
+            added = True
+
+        if not added:
+            raise ValueError(
+                "constrain() requires at least one of "
+                "equal_to=, min=, max=, range=, or choices="
+            )

--- a/adijif/system.py
+++ b/adijif/system.py
@@ -2,7 +2,7 @@
 
 import os
 import shutil  # noqa: F401
-from typing import Dict, List, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -11,6 +11,7 @@ import adijif.solvers as solvers
 from adijif.clocks.clock import clock as clockc
 from adijif.converters.converter import converter as convc
 from adijif.plls.pll import pll as pllc
+from adijif.sys.clocks_bundle import ClocksBundle
 from adijif.sys.s_plls import SystemPLL
 from adijif.system_draw import system_draw as system_draw
 from adijif.types import arb_source as arb_sourcec
@@ -37,6 +38,8 @@ class system(SystemPLL, system_draw):
     solution = None
 
     _plls = []
+    _initialized = False
+    _last_clocks: Optional[ClocksBundle] = None
 
     @property
     def plls(self) -> List[pllc]:
@@ -86,6 +89,8 @@ class system(SystemPLL, system_draw):
             self.converter.model = model
 
         self._plls = []
+        self._initialized = False
+        self._last_clocks = None
 
     def __init__(
         self,
@@ -126,6 +131,8 @@ class system(SystemPLL, system_draw):
         self.vcxo = vcxo
         self._plls = []
         self._plls_sysref = []
+        self._initialized = False
+        self._last_clocks = None
 
         # Validate arb_source compatibility with solver
         if isinstance(vcxo, arb_sourcec) and self.solver == "gekko":
@@ -313,32 +320,105 @@ class system(SystemPLL, system_draw):
         if not self.solution.is_solution():
             raise Exception("No solution found")
 
-    def solve(self, out_clock_constraints: dict = None) -> Dict:
-        """Defined clocking requirements in Solver model and start solvers routine.
+    def solve(
+        self,
+        out_clock_constraints: dict = None,
+        constrain: Optional[Callable[[ClocksBundle], None]] = None,
+    ) -> Dict:
+        """Define clocking requirements and run the active solver.
+
+        For richer constraints than equality (range bounds, rate equality
+        between two clocks, allowed-value lists), pass a ``constrain`` callback
+        that receives the :class:`ClocksBundle` returned by
+        :meth:`initialize`. Or call :meth:`initialize` yourself, add
+        constraints, then call :meth:`do_solve`.
 
         Args:
-            out_clock_constraints: Dict[Optional] of specific rates of generated clocks.
-                Must be dict of values or dict of dicts that contain 'rate' field
+            out_clock_constraints: Optional dict of exact target rates keyed by
+                clock name (the keys exposed by :meth:`initialize`). Values may
+                be a number or ``{"rate": number}``.
+            constrain: Optional callback invoked with the
+                :class:`ClocksBundle` after constraints have been wired but
+                before the solver runs. Use it to add custom range / equality
+                / OR constraints via ``clocks.constrain(...)`` or by passing
+                solver expressions directly to ``self.model``.
 
         Returns:
             Dict: Dictionary containing all clocking configuration for all components
         """
-        self.initialize(out_clock_constraints)
+        if not self._initialized:
+            clocks = self.initialize(out_clock_constraints)
+        else:
+            clocks = self._last_clocks
+            if out_clock_constraints:
+                self._apply_out_clock_constraints(clocks, out_clock_constraints)
+        if constrain is not None:
+            constrain(clocks)
         return self.do_solve()
 
-    def initialize(self, out_clock_constraints: dict = None) -> Dict:
-        """Internal call to setup system for solving.
+    def _apply_out_clock_constraints(
+        self, clocks: ClocksBundle, out_clock_constraints: dict
+    ) -> None:
+        """Apply equality constraints from ``out_clock_constraints`` to clocks.
+
+        Accepted value forms per key:
+        - number (float/int): treated as a target rate.
+        - dict with ``"rate"`` key: target rate.
+
+        Unknown clock names are skipped with a printed warning. Unknown value
+        types are skipped with a printed warning. This preserves the
+        pre-existing behavior of the ``out_clock_constraints`` kwarg.
+        """
+        for occ in out_clock_constraints:
+            if occ in clocks.keys():
+                if isinstance(out_clock_constraints[occ], dict):
+                    d = out_clock_constraints[occ]
+                    if "rate" in d:
+                        self.clock._add_equation([clocks[occ] == d["rate"]])
+                    else:
+                        print(f"Input constraint {occ} ignored. Bad type")
+                elif type(out_clock_constraints[occ]) in [float, int]:
+                    self.clock._add_equation(
+                        [clocks[occ] == out_clock_constraints[occ]]
+                    )
+                else:
+                    print(f"Input constraint {occ} ignored. Bad type")
+            else:
+                print(f"Input constraint {occ} not used")
+
+    def initialize(self, out_clock_constraints: dict = None) -> ClocksBundle:
+        """Wire all inter-component clock constraints into the solver model.
+
+        Returns a :class:`ClocksBundle` (a dict subclass) mapping each
+        inter-component clock name to the solver expression that represents
+        its rate. Use the bundle to add custom constraints before calling
+        :meth:`do_solve`. See :class:`ClocksBundle` for the canonical clock
+        names and :meth:`ClocksBundle.constrain` for the helper API.
+
+        Calling this method a second time without first calling
+        :meth:`_model_reset` will not re-wire constraints; the cached bundle
+        from the first call is returned. Use :meth:`solve` instead if you
+        want a single end-to-end call.
 
         Args:
-            out_clock_constraints: Dict of specific rates of generated clocks. Must
-                be dict of values or dict of dicts that contain 'rate' field
+            out_clock_constraints: Dict of exact target rates of generated
+                clocks. Must be dict of values or dict of dicts that contain
+                a ``rate`` field.
 
         Returns:
-            Dict: Dictionary containing all generate clock constraints between devices
+            ClocksBundle: Mapping of clock name to solver expression for all
+            clocks that flow between high-level components.
 
         Raises:
             Exception: FPGA and Converter disabled
         """
+        if self._initialized and self._last_clocks is not None:
+            if out_clock_constraints:
+                self._apply_out_clock_constraints(
+                    self._last_clocks, out_clock_constraints
+                )
+            return self._last_clocks
+
         if not self.enable_converter_clocks and not self.enable_fpga_clocks:
             raise Exception("Converter and/or FPGA clocks must be enabled")
 
@@ -545,26 +625,15 @@ class system(SystemPLL, system_draw):
                     else:
                         self.model.minimize(objectives[0])
 
+        clocks = ClocksBundle(config, owner=self)
+
         # Add user explicit constraints
         if out_clock_constraints:
-            for occ in out_clock_constraints:
-                if occ in config.keys():
-                    if isinstance(out_clock_constraints[occ], dict):
-                        d = out_clock_constraints[occ]
-                        if "rate" in d:
-                            self.clock._add_equation([config[occ] == d["rate"]])
-                        else:
-                            print(f"Input constraint {occ} ignored. Bad type")
-                    elif type(out_clock_constraints[occ]) in [float, int]:
-                        self.clock._add_equation(
-                            [config[occ] == out_clock_constraints[occ]]
-                        )
-                    else:
-                        print(f"Input constraint {occ} ignored. Bad type")
-                else:
-                    print(f"Input constraint {occ} not used")
+            self._apply_out_clock_constraints(clocks, out_clock_constraints)
 
-        return config
+        self._last_clocks = clocks
+        self._initialized = True
+        return clocks
 
     def do_solve(self) -> Dict:
         """Solve actual solver on model which has been fully configured.

--- a/doc/source/flow.md
+++ b/doc/source/flow.md
@@ -100,6 +100,64 @@ config = sys.solve()
 pprint.pprint(config['clock'])
 ```
 
+### Custom inter-component clock constraints
+
+`sys.solve()` accepts an `out_clock_constraints` dict that pins individual clocks to **exact** rates. For richer constraints &mdash; range bounds, equality between two clocks, allowed-value lists &mdash; call `sys.initialize()` to retrieve a `ClocksBundle` of solver expressions for every clock that flows between high-level components, add your own constraints, then call `sys.do_solve()`:
+
+```{exec_code}
+:caption_output: Constrained system output
+import adijif
+import pprint
+vcxo = 125000000
+sys = adijif.system("ad9680", "ad9523_1", "xilinx", vcxo)
+sys.converter.sample_clock = 1e9
+sys.converter.decimation = 1
+sys.converter.L = 4
+sys.converter.M = 2
+sys.converter.N = 14
+sys.converter.Np = 16
+sys.converter.K = 32
+sys.converter.F = 1
+sys.fpga.setup_by_dev_kit_name("zc706")
+
+clocks = sys.initialize()
+clocks.constrain("AD9680_fpga_ref_clk", range=(250e6, 350e6))
+clocks.constrain("AD9680_sysref", equal_to=7.8125e6)
+
+config = sys.do_solve()
+pprint.pprint(config['clock']['output_clocks'])
+```
+
+The same flow can be expressed as a callback to `sys.solve()`:
+
+```python
+def constrain(clocks):
+    clocks.constrain("AD9680_fpga_ref_clk", range=(250e6, 350e6))
+    clocks.constrain("AD9680_sysref", equal_to=7.8125e6)
+
+config = sys.solve(constrain=constrain)
+```
+
+The keys in the `ClocksBundle` are the inter-component clocks the system wires up:
+
+-   `{converter}_ref_clk` &mdash; clock chip to converter device clock.
+-   `{converter}_ref_clk_from_ext_pll` &mdash; inline PLL output to converter (when `add_pll_inline` is used).
+-   `{converter}_sysref` &mdash; sysref to converter.
+-   `{converter}_fpga_ref_clk` &mdash; clock chip to FPGA reference clock.
+-   `{converter}_fpga_device_clk` &mdash; clock chip to FPGA link clock.
+-   `{pll}_ref_clk`, `{pll}_bsync_reference` &mdash; clock chip to inline / sysref PLL inputs.
+
+For nested converters (MxFE / transceivers) the converter name is replaced by the nested channel name (e.g. `adc_sysref`, `dac_fpga_ref_clk`). Print `clocks.keys()` after `initialize()` to see the exact names available for your configuration.
+
+`ClocksBundle.constrain(name, ...)` accepts:
+
+-   `equal_to=` &mdash; a number, another solver expression, or another clock name in the bundle.
+-   `min=`, `max=` &mdash; lower / upper bound on the rate.
+-   `range=(lo, hi)` &mdash; sugar for `min=lo, max=hi`.
+-   `choices=[...]` &mdash; list of allowed exact rates (CPLEX only).
+
+For constraints not covered by these helpers, index the bundle directly and add the expression to `sys.model` using your solver's native API: e.g. `sys.model.add(clocks["AD9680_ref_clk"] == 2 * clocks["AD9680_sysref"])`.
+
 ## Solve Output
 
 The `solve()` method (at the system level) or the `get_config()` method (at the component level) returns a dictionary containing the final configuration of all solved variables and rates.

--- a/examples/system_custom_clock_constraints.py
+++ b/examples/system_custom_clock_constraints.py
@@ -1,0 +1,68 @@
+"""Apply custom constraints to the inter-component clocks of an adijif.system.
+
+`system.initialize()` returns a `ClocksBundle` (a dict) keyed by clock name
+that maps to the solver expression for every clock that flows between high
+level components (clock chip <-> converter, clock chip <-> FPGA, etc.). Use
+the bundle to add range / equality / OR constraints that go beyond the
+equality-only `out_clock_constraints` shortcut, then call `do_solve()`.
+
+Two equivalent flows are shown below: a manual two-step path, and a single
+`solve(constrain=...)` callback.
+"""
+
+import pprint
+
+import adijif
+from adijif.sys import ClocksBundle
+
+
+def _build_daq2_system() -> adijif.system:
+    sys = adijif.system("ad9680", "ad9523_1", "xilinx", 125e6)
+    sys.fpga.setup_by_dev_kit_name("zc706")
+    sys.converter.sample_clock = 1e9
+    sys.converter.decimation = 1
+    sys.converter.L = 4
+    sys.converter.M = 2
+    sys.converter.N = 14
+    sys.converter.Np = 16
+    sys.converter.K = 32
+    sys.converter.F = 1
+    return sys
+
+
+def two_step_example() -> dict:
+    """Initialize, constrain, then do_solve."""
+    sys = _build_daq2_system()
+
+    clocks = sys.initialize()
+    print("Inter-component clocks available for constraining:")
+    for name in sorted(clocks):
+        print(f"  - {name}")
+
+    # Force the FPGA reference clock into a 250-350 MHz window and pick an
+    # exact sysref rate.
+    clocks.constrain("AD9680_fpga_ref_clk", range=(250e6, 350e6))
+    clocks.constrain("AD9680_sysref", equal_to=7.8125e6)
+
+    return sys.do_solve()
+
+
+def callback_example() -> dict:
+    """Pass a constraint callback to solve()."""
+    sys = _build_daq2_system()
+
+    def constrain(clocks: ClocksBundle) -> None:
+        clocks.constrain("AD9680_fpga_ref_clk", range=(250e6, 350e6))
+        clocks.constrain("AD9680_sysref", equal_to=7.8125e6)
+
+    return sys.solve(constrain=constrain)
+
+
+if __name__ == "__main__":
+    print("=== Two-step initialize / constrain / do_solve ===")
+    cfg_two_step = two_step_example()
+    pprint.pprint(cfg_two_step["clock"]["output_clocks"])
+
+    print("\n=== solve(constrain=callback) ===")
+    cfg_callback = callback_example()
+    pprint.pprint(cfg_callback["clock"]["output_clocks"])

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -404,3 +404,118 @@ def test_system_solve_unknown_solver():
 
     with pytest.raises(Exception, match="Unknown solver"):
         sys.solve()
+
+
+def _build_daq2_system():
+    import adijif
+
+    sys = adijif.system("ad9680", "ad9523_1", "xilinx", 125e6)
+    sys.fpga.setup_by_dev_kit_name("zc706")
+    sys.converter.sample_clock = 1e9
+    sys.converter.decimation = 1
+    sys.converter.L = 4
+    sys.converter.M = 2
+    sys.converter.N = 14
+    sys.converter.Np = 16
+    sys.converter.K = 32
+    sys.converter.F = 1
+    return sys
+
+
+def test_system_initialize_returns_clocks_bundle():
+    from adijif.sys.clocks_bundle import ClocksBundle
+
+    sys = _build_daq2_system()
+    clocks = sys.initialize()
+
+    assert isinstance(clocks, ClocksBundle)
+    assert isinstance(clocks, dict)
+    expected = {
+        "AD9680_ref_clk",
+        "AD9680_sysref",
+        "AD9680_fpga_ref_clk",
+        "AD9680_fpga_device_clk",
+    }
+    assert expected.issubset(set(clocks.keys()))
+
+
+def test_system_initialize_is_idempotent():
+    sys = _build_daq2_system()
+    first = sys.initialize()
+    second = sys.initialize()
+    assert first is second
+
+
+def test_system_two_step_with_range_constraint():
+    sys = _build_daq2_system()
+    clocks = sys.initialize()
+    clocks.constrain("AD9680_fpga_ref_clk", range=(250e6, 350e6))
+    cfg = sys.do_solve()
+
+    rate = cfg["clock"]["output_clocks"]["zc706_AD9680_ref_clk"]["rate"]
+    assert 250e6 <= rate <= 350e6
+
+
+def test_system_solve_with_callback():
+    sys = _build_daq2_system()
+
+    def constrain(c):
+        c.constrain("AD9680_fpga_ref_clk", range=(250e6, 350e6))
+        c.constrain("AD9680_sysref", equal_to=7.8125e6)
+
+    cfg = sys.solve(constrain=constrain)
+    rate = cfg["clock"]["output_clocks"]["zc706_AD9680_ref_clk"]["rate"]
+    sysref = cfg["clock"]["output_clocks"]["AD9680_sysref"]["rate"]
+    assert 250e6 <= rate <= 350e6
+    assert sysref == 7.8125e6
+
+
+def test_clocks_bundle_constrain_equal_to_other_clock():
+    sys = _build_daq2_system()
+    clocks = sys.initialize()
+    # Force the FPGA refclk and FPGA device clk to be equal (already typical
+    # but here we lock it explicitly via the equal_to-by-name path).
+    clocks.constrain("AD9680_fpga_ref_clk", equal_to="AD9680_fpga_device_clk")
+    cfg = sys.do_solve()
+    out = cfg["clock"]["output_clocks"]
+    assert (
+        out["zc706_AD9680_ref_clk"]["rate"]
+        == out["zc706_AD9680_device_clk"]["rate"]
+    )
+
+
+def test_clocks_bundle_constrain_unknown_name_raises():
+    sys = _build_daq2_system()
+    clocks = sys.initialize()
+    with pytest.raises(KeyError, match="Unknown clock name"):
+        clocks.constrain("does_not_exist", range=(1e6, 2e6))
+
+
+def test_clocks_bundle_constrain_no_kwargs_raises():
+    sys = _build_daq2_system()
+    clocks = sys.initialize()
+    with pytest.raises(ValueError, match="at least one of"):
+        clocks.constrain("AD9680_ref_clk")
+
+
+def test_clocks_bundle_constrain_range_and_min_max_conflict():
+    sys = _build_daq2_system()
+    clocks = sys.initialize()
+    with pytest.raises(ValueError, match="not both"):
+        clocks.constrain("AD9680_ref_clk", range=(1e6, 2e6), min=1e6)
+
+
+def test_solve_after_manual_initialize_does_not_double_init():
+    """Calling solve() after a manual initialize() should reuse the bundle.
+
+    If initialize() ran twice, the second call would re-add equality
+    constraints between the converter clock and a fresh clock-chip variable,
+    making the model infeasible.
+    """
+    sys = _build_daq2_system()
+    clocks = sys.initialize()
+    clocks.constrain("AD9680_fpga_ref_clk", range=(250e6, 350e6))
+    cfg = sys.solve()  # must NOT re-run initialize()
+
+    rate = cfg["clock"]["output_clocks"]["zc706_AD9680_ref_clk"]["rate"]
+    assert 250e6 <= rate <= 350e6


### PR DESCRIPTION
## Summary

- Promote `system.initialize()` from an internal helper to a public entry point that returns a `ClocksBundle` (a dict subclass) of solver expressions for every clock that flows between high-level components (clock chip ↔ converter, clock chip ↔ FPGA, clock chip ↔ inline / sysref PLL, etc.).
- Add `ClocksBundle.constrain(name, equal_to=, min=, max=, range=, choices=)` — a single helper that hides the CPLEX vs gekko backend differences. Bounds, equality (including by another clock name), and CPLEX-only OR-of-equalities are supported.
- Add a `constrain=` callback to `system.solve()` so the same flow works in one call: `sys.solve(constrain=lambda c: c.constrain("...", range=(...)))`.
- Make `initialize()` idempotent — calling it twice (or `solve()` after a manual `initialize()`) reuses the cached bundle instead of re-wiring constraints.
- Document the new flow in `doc/source/flow.md` (with an `exec_code` block that runs during `nox -rs docs`), add a runnable `examples/system_custom_clock_constraints.py`, and 9 new tests covering the bundle and both flows.

The pre-existing `out_clock_constraints={"name": rate}` shortcut is unchanged; the new API covers the cases it could not (range bounds, equality between two clocks, allowed-value lists).

## Test plan

- [x] `nox -rs format lint ty` — clean
- [x] `nox -rs tests` — 557 passed on Python 3.10 and 3.11
- [x] `nox -rs docs` — `flow.md` `exec_code` blocks execute during build
- [x] `python examples/system_custom_clock_constraints.py` — both two-step and callback flows print rates respecting the constraints