### PR TITLE
feat(explorer): add optimization controls to system configurator

### DIFF
--- a/adijif/tools/explorer/src/pages/helpers/optimization.py
+++ b/adijif/tools/explorer/src/pages/helpers/optimization.py
@@ -1,0 +1,253 @@
+"""Helper functions for the System Configurator's optimization controls."""
+
+from typing import Any
+
+import streamlit as st
+
+from adijif.sys.clocks_bundle import ClocksBundle
+
+_UNIT_MULT = {"Hz": 1.0, "kHz": 1e3, "MHz": 1e6, "GHz": 1e9}
+_KIND_LABELS = {
+    "equal_to": "equal to",
+    "range": "range",
+    "min": "min",
+    "max": "max",
+}
+
+
+def _next_id(state_key: str) -> int:
+    """Return a fresh monotonic id for a row in ``state_key`` rows."""
+    counter_key = f"{state_key}_next_id"
+    rid = st.session_state.get(counter_key, 1)
+    st.session_state[counter_key] = rid + 1
+    return rid
+
+
+def gen_clock_constraints(clocks: ClocksBundle) -> None:
+    """Render the clock-constraint editor and apply each row to ``clocks``.
+
+    Rows persist in ``st.session_state["sys_constraints"]``. Each constraint
+    row is rendered with a stable ``id`` so Streamlit widget state survives
+    additions and removals.
+
+    Args:
+        clocks: ClocksBundle from ``system.initialize()``. Constraints are
+            applied via :meth:`ClocksBundle.constrain`.
+    """
+    state_key = "sys_constraints"
+    st.session_state.setdefault(state_key, [])
+    rows = st.session_state[state_key]
+
+    clock_names = sorted(clocks.keys())
+    if not clock_names:
+        st.info("No inter-component clocks available for this configuration.")
+        return
+
+    st.markdown("**Clock Constraints**")
+    st.caption(
+        "Narrow which clock rates are valid (e.g. force the FPGA reference "
+        "clock into a range). Bad rows are skipped with a warning."
+    )
+
+    units = st.selectbox(
+        "Units (applied to all constraint values)",
+        options=list(_UNIT_MULT.keys()),
+        index=2,
+        key="sys_constraints_units",
+    )
+    mult = _UNIT_MULT[units]
+
+    to_remove = []
+    for idx, row in enumerate(rows):
+        rid = row["id"]
+        cols = st.columns([3, 2, 2, 2, 1])
+        with cols[0]:
+            default_clock = (
+                row["clock"] if row["clock"] in clock_names else clock_names[0]
+            )
+            st.selectbox(
+                "Clock",
+                options=clock_names,
+                index=clock_names.index(default_clock),
+                key=f"sys_c_clock_{rid}",
+            )
+        with cols[1]:
+            kind_keys = list(_KIND_LABELS.keys())
+            st.selectbox(
+                "Type",
+                options=kind_keys,
+                index=kind_keys.index(row["kind"]),
+                format_func=lambda k: _KIND_LABELS[k],
+                key=f"sys_c_kind_{rid}",
+            )
+        kind = st.session_state[f"sys_c_kind_{rid}"]
+        with cols[2]:
+            st.number_input(
+                f"Value ({units})" if kind != "range" else f"Min ({units})",
+                value=float(row["v1"]),
+                format="%g",
+                key=f"sys_c_v1_{rid}",
+            )
+        with cols[3]:
+            if kind == "range":
+                st.number_input(
+                    f"Max ({units})",
+                    value=float(row["v2"]),
+                    format="%g",
+                    key=f"sys_c_v2_{rid}",
+                )
+            else:
+                st.write("")
+        with cols[4]:
+            st.write("")
+            if st.button("✕", key=f"sys_c_rm_{rid}", help="Remove row"):
+                to_remove.append(idx)
+
+    if st.button("Add Constraint", key="sys_c_add"):
+        rows.append(
+            {
+                "id": _next_id(state_key),
+                "clock": clock_names[0],
+                "kind": "range",
+                "v1": 100.0,
+                "v2": 200.0,
+            }
+        )
+        st.rerun()
+
+    if to_remove:
+        for i in reversed(to_remove):
+            rows.pop(i)
+        st.rerun()
+
+    for row in rows:
+        rid = row["id"]
+        clock_name = st.session_state.get(f"sys_c_clock_{rid}", row["clock"])
+        kind = st.session_state.get(f"sys_c_kind_{rid}", row["kind"])
+        v1 = st.session_state.get(f"sys_c_v1_{rid}", row["v1"])
+        v2 = st.session_state.get(f"sys_c_v2_{rid}", row["v2"])
+        row["clock"] = clock_name
+        row["kind"] = kind
+        row["v1"] = v1
+        row["v2"] = v2
+        try:
+            if kind == "range":
+                clocks.constrain(clock_name, range=(v1 * mult, v2 * mult))
+            else:
+                clocks.constrain(clock_name, **{kind: v1 * mult})
+        except Exception as e:  # noqa: BLE001
+            st.warning(f"Skipping constraint on {clock_name!r}: {e}")
+
+
+def gen_clock_objectives(sys: Any, clocks: ClocksBundle) -> None:
+    """Render the clock-objective editor and register each row with ``sys``.
+
+    Rows persist in ``st.session_state["sys_objectives"]``. Each row is
+    applied via :meth:`adijif.system.system.add_objective`.
+
+    Args:
+        sys: The ``adijif.system`` instance to register objectives on.
+        clocks: ClocksBundle whose entries are used as objective expressions.
+    """
+    state_key = "sys_objectives"
+    st.session_state.setdefault(state_key, [])
+    rows = st.session_state[state_key]
+
+    clock_names = sorted(clocks.keys())
+    if not clock_names:
+        return
+
+    st.markdown("**Clock Objectives**")
+    st.caption(
+        "Rank valid configurations by minimizing or maximizing a clock. "
+        "Lower tier = higher priority; tier 1 only breaks ties left by "
+        "tier 0."
+    )
+
+    to_remove = []
+    for idx, row in enumerate(rows):
+        rid = row["id"]
+        cols = st.columns([3, 1, 1, 1, 2, 1])
+        with cols[0]:
+            default_clock = (
+                row["clock"] if row["clock"] in clock_names else clock_names[0]
+            )
+            st.selectbox(
+                "Clock",
+                options=clock_names,
+                index=clock_names.index(default_clock),
+                key=f"sys_o_clock_{rid}",
+            )
+        with cols[1]:
+            st.selectbox(
+                "Sense",
+                options=["min", "max"],
+                index=["min", "max"].index(row["sense"]),
+                key=f"sys_o_sense_{rid}",
+            )
+        with cols[2]:
+            st.number_input(
+                "Tier",
+                value=int(row["tier"]),
+                min_value=0,
+                step=1,
+                key=f"sys_o_tier_{rid}",
+            )
+        with cols[3]:
+            st.number_input(
+                "Weight",
+                value=float(row["weight"]),
+                format="%g",
+                key=f"sys_o_weight_{rid}",
+            )
+        with cols[4]:
+            st.text_input(
+                "Name (optional)",
+                value=row["name"],
+                key=f"sys_o_name_{rid}",
+            )
+        with cols[5]:
+            st.write("")
+            if st.button("✕", key=f"sys_o_rm_{rid}", help="Remove row"):
+                to_remove.append(idx)
+
+    if st.button("Add Objective", key="sys_o_add"):
+        rows.append(
+            {
+                "id": _next_id(state_key),
+                "clock": clock_names[0],
+                "sense": "min",
+                "tier": 0,
+                "weight": 1.0,
+                "name": "",
+            }
+        )
+        st.rerun()
+
+    if to_remove:
+        for i in reversed(to_remove):
+            rows.pop(i)
+        st.rerun()
+
+    for row in rows:
+        rid = row["id"]
+        clock_name = st.session_state.get(f"sys_o_clock_{rid}", row["clock"])
+        sense = st.session_state.get(f"sys_o_sense_{rid}", row["sense"])
+        tier = st.session_state.get(f"sys_o_tier_{rid}", row["tier"])
+        weight = st.session_state.get(f"sys_o_weight_{rid}", row["weight"])
+        name = st.session_state.get(f"sys_o_name_{rid}", row["name"])
+        row["clock"] = clock_name
+        row["sense"] = sense
+        row["tier"] = tier
+        row["weight"] = weight
+        row["name"] = name
+        try:
+            sys.add_objective(
+                clocks[clock_name],
+                sense=sense,
+                tier=int(tier),
+                weight=float(weight),
+                name=name or None,
+            )
+        except Exception as e:  # noqa: BLE001
+            st.warning(f"Skipping objective on {clock_name!r}: {e}")

--- a/adijif/tools/explorer/src/pages/systemconfigurator.py
+++ b/adijif/tools/explorer/src/pages/systemconfigurator.py
@@ -12,6 +12,7 @@ from adijif.converters import supported_parts as xsp
 # from adijif.utils import get_jesd_mode_from_params
 from ..utils import Page
 from .helpers.datapath import gen_datapath
+from .helpers.optimization import gen_clock_constraints, gen_clock_objectives
 
 # Clocks
 options_to_skip = ["list_references_available", "d_syspulse"]
@@ -295,27 +296,46 @@ class SystemConfigurator(Page):
             df = df.drop(columns=["Setting"])
             st.table(df)
 
+        try:
+            clocks = sys.initialize()
+        except Exception as e:
+            st.error(f"Error initializing system: {e}")
+            clocks = None
+
+        if clocks is not None:
+            with st.expander("Optimization Controls", expanded=False):
+                st.caption(
+                    "Layer custom clock constraints and objectives on top of "
+                    "the built-in defaults. See the Constraints and "
+                    "Optimization tutorial for the full API."
+                )
+                gen_clock_constraints(clocks)
+                gen_clock_objectives(sys, clocks)
+
+        diagram = None
         with st.expander("System Configuration", expanded=False):
-            try:
-                cfg = sys.solve()
+            if clocks is None:
+                st.write("System not initialized.")
+            else:
+                try:
+                    cfg = sys.do_solve()
 
-                st.subheader("Clock Configuration")
-                st.write(cfg["clock"])
+                    st.subheader("Clock Configuration")
+                    st.write(cfg["clock"])
 
-                st.subheader("Converter Configuration")
-                st.write(cfg["converter"])
+                    st.subheader("Converter Configuration")
+                    st.write(cfg["converter"])
 
-                st.subheader("FPGA Configuration")
-                st.write(cfg["fpga_" + sys.converter.name.upper()])
+                    st.subheader("FPGA Configuration")
+                    st.write(cfg["fpga_" + sys.converter.name.upper()])
 
-                st.subheader("Converter JESD Configuration")
-                st.write(cfg["jesd_" + sys.converter.name.upper()])
+                    st.subheader("Converter JESD Configuration")
+                    st.write(cfg["jesd_" + sys.converter.name.upper()])
 
-                diagram = sys.draw(cfg)
+                    diagram = sys.draw(cfg)
 
-            except Exception as e:
-                diagram = None
-                st.error(f"Error solving system configuration: {e}")
+                except Exception as e:
+                    st.error(f"Error solving system configuration: {e}")
 
         with st.expander("Diagram", expanded=False):
             if diagram:

--- a/tests/tools/test_systemconfigurator_optimization.py
+++ b/tests/tools/test_systemconfigurator_optimization.py
@@ -1,0 +1,206 @@
+"""Streamlit testing for System Configurator optimization controls."""
+
+import pathlib
+import sys
+
+from streamlit.testing.v1 import AppTest
+
+app_path = (
+    pathlib.Path(__file__).parent.parent.parent
+    / "adijif"
+    / "tools"
+    / "explorer"
+)
+app_file_path = app_path / "main.py"
+
+sys.path.append(str(app_path))
+
+
+_RUN_TIMEOUT = 60
+
+
+def _navigate_to_system_configurator(at: AppTest) -> AppTest:
+    """Navigate from the sidebar to the System Configurator page."""
+    sb = at.sidebar
+    for item in sb.radio:
+        if item.label == "Select a Tool":
+            item.set_value("System Configurator").run(timeout=_RUN_TIMEOUT)
+            break
+    return at
+
+
+def _click_button(at: AppTest, key: str) -> AppTest:
+    """Click a Streamlit button identified by ``key`` and rerun."""
+    for btn in at.button:
+        if btn.key == key:
+            btn.click().run(timeout=_RUN_TIMEOUT)
+            return at
+    raise AssertionError(f"Button with key {key!r} not found")
+
+
+def _expander_labels(at: AppTest) -> list:
+    return [str(exp.label) for exp in at.expander]
+
+
+def _selectbox_by_key(at: AppTest, key: str):
+    for sb in at.selectbox:
+        if sb.key == key:
+            return sb
+    return None
+
+
+def _number_input_by_key(at: AppTest, key: str):
+    for ni in at.number_input:
+        if ni.key == key:
+            return ni
+    return None
+
+
+def _make_app() -> AppTest:
+    """Return an AppTest navigated to System Configurator with a feasible setup.
+
+    The page's default JESD mode (L=1) at 1 GHz produces a 20 Gbps lane rate
+    that exceeds JESD204B limits and makes ``sys.initialize()`` raise. Lower
+    the converter clock so the default mode is solvable and the optimization
+    controls expander renders.
+    """
+    at = AppTest.from_file(app_file_path, default_timeout=_RUN_TIMEOUT)
+    at.run(timeout=_RUN_TIMEOUT)
+    _navigate_to_system_configurator(at)
+    for ni in at.number_input:
+        if ni.key == "system_converter_clock_input":
+            ni.set_value(400.0).run(timeout=_RUN_TIMEOUT)
+            break
+    return at
+
+
+def test_optimization_controls_expander_present() -> None:
+    """The new 'Optimization Controls' expander renders without errors."""
+    at = _make_app()
+    assert not at.exception, f"Page raised: {at.exception}"
+    assert "Optimization Controls" in _expander_labels(at)
+
+
+def test_initial_state_has_no_constraint_or_objective_rows() -> None:
+    """No constraint/objective rows exist on first load."""
+    at = _make_app()
+    assert _selectbox_by_key(at, "sys_c_clock_1") is None
+    assert _selectbox_by_key(at, "sys_o_clock_1") is None
+
+
+def test_add_constraint_creates_row_widgets() -> None:
+    """Clicking 'Add Constraint' appends a row with the expected widgets."""
+    at = _make_app()
+    _click_button(at, "sys_c_add")
+
+    assert not at.exception
+    clock_sb = _selectbox_by_key(at, "sys_c_clock_1")
+    assert clock_sb is not None, "Clock selectbox for new row not found"
+    # Default kind is 'range' so both v1 and v2 inputs should render.
+    assert _number_input_by_key(at, "sys_c_v1_1") is not None
+    assert _number_input_by_key(at, "sys_c_v2_1") is not None
+    # Bundle keys for the default ad9680 system include this clock.
+    assert "AD9680_fpga_ref_clk" in clock_sb.options
+
+
+def test_add_objective_creates_row_widgets() -> None:
+    """Clicking 'Add Objective' appends a row with the expected widgets."""
+    at = _make_app()
+    _click_button(at, "sys_o_add")
+
+    assert not at.exception
+    clock_sb = _selectbox_by_key(at, "sys_o_clock_1")
+    sense_sb = _selectbox_by_key(at, "sys_o_sense_1")
+    tier_ni = _number_input_by_key(at, "sys_o_tier_1")
+    weight_ni = _number_input_by_key(at, "sys_o_weight_1")
+    assert clock_sb is not None
+    assert sense_sb is not None and sense_sb.value == "min"
+    assert tier_ni is not None and tier_ni.value == 0
+    assert weight_ni is not None and weight_ni.value == 1.0
+
+
+def test_remove_constraint_row() -> None:
+    """A row created by Add Constraint can be removed via its 'Remove' button."""
+    at = _make_app()
+    _click_button(at, "sys_c_add")
+    assert _selectbox_by_key(at, "sys_c_clock_1") is not None
+
+    _click_button(at, "sys_c_rm_1")
+    assert not at.exception
+    assert _selectbox_by_key(at, "sys_c_clock_1") is None
+
+
+def test_two_constraint_rows_have_independent_keys() -> None:
+    """Adding two constraint rows yields rows keyed by separate ids."""
+    at = _make_app()
+    _click_button(at, "sys_c_add")
+    _click_button(at, "sys_c_add")
+    assert not at.exception
+    assert _selectbox_by_key(at, "sys_c_clock_1") is not None
+    assert _selectbox_by_key(at, "sys_c_clock_2") is not None
+
+
+def test_constraint_kind_switches_inputs() -> None:
+    """Switching the constraint kind to 'equal_to' hides the second value input."""
+    at = _make_app()
+    _click_button(at, "sys_c_add")
+
+    kind_sb = _selectbox_by_key(at, "sys_c_kind_1")
+    assert kind_sb is not None
+    kind_sb.set_value("equal_to").run()
+
+    assert not at.exception
+    assert _number_input_by_key(at, "sys_c_v1_1") is not None
+    # 'equal_to' renders a placeholder st.write() instead of v2 input.
+    assert _number_input_by_key(at, "sys_c_v2_1") is None
+
+
+def test_objective_min_clock_keeps_solve_succeeding() -> None:
+    """Adding a tier-0 'min' objective on a bundle clock keeps the solve healthy."""
+    at = _make_app()
+    _click_button(at, "sys_o_add")
+
+    # Defaults already set sense=min, tier=0, weight=1.0; just rerun.
+    at.run(timeout=30)
+    assert not at.exception, f"Solve failed with user objective: {at.exception}"
+
+
+def test_range_constraint_keeps_solve_succeeding() -> None:
+    """A wide range constraint on the FPGA ref clock leaves the solve healthy."""
+    at = _make_app()
+    _click_button(at, "sys_c_add")
+
+    clock_sb = _selectbox_by_key(at, "sys_c_clock_1")
+    assert clock_sb is not None
+    if "AD9680_fpga_ref_clk" not in clock_sb.options:
+        return  # Default page state shifted; skip rather than false-fail.
+    clock_sb.set_value("AD9680_fpga_ref_clk").run(timeout=30)
+    assert not at.exception
+
+    # Wide MHz-range that easily contains a default valid rate.
+    v1 = _number_input_by_key(at, "sys_c_v1_1")
+    v2 = _number_input_by_key(at, "sys_c_v2_1")
+    assert v1 is not None and v2 is not None
+    v1.set_value(50.0).run(timeout=30)
+    assert not at.exception
+    v2.set_value(500.0).run(timeout=30)
+    assert not at.exception
+
+
+def test_infeasible_constraint_does_not_crash_page() -> None:
+    """An infeasible equal_to=1 Hz constraint surfaces as an error, not a crash."""
+    at = _make_app()
+    _click_button(at, "sys_c_add")
+
+    kind_sb = _selectbox_by_key(at, "sys_c_kind_1")
+    kind_sb.set_value("equal_to").run(timeout=30)
+    assert not at.exception
+
+    # 1 Hz in the default MHz units is impossible for any of these clocks.
+    v1 = _number_input_by_key(at, "sys_c_v1_1")
+    v1.set_value(1.0).run(timeout=60)
+
+    # The page itself must not raise; the solver error is rendered as st.error.
+    assert not at.exception
+    # And the optimization controls expander must still be present.
+    assert "Optimization Controls" in _expander_labels(at)


### PR DESCRIPTION
## Summary
- Adds a new **Optimization Controls** expander to the System Configurator page that exposes the clock-bundle slice of the optimization API (`clocks.constrain(...)` and `sys.add_objective(clocks[name], ...)`).
- Multi-row editors persist across reruns via `st.session_state`; supports `equal_to` / `range` / `min` / `max` constraints and `min` / `max` objectives with per-row tier and weight.
- Splits `sys.solve()` into `sys.initialize()` + user controls + `sys.do_solve()` so bundle clock names can populate the dropdowns.
- Adds `tests/tools/test_systemconfigurator_optimization.py` with 10 `streamlit.testing.v1.AppTest` tests covering UI rendering, add/remove rows, constraint kind switching, and solve robustness (incl. an infeasible-input case).

## Test plan
- [x] `nox -rs lint` — clean
- [x] `pytest tests/tools/ --ignore=tests/tools/e2e` — 33 passed (10 new + 23 existing)
- [ ] Manual smoke: `nox -rs jiftools`, open System Configurator, add a range constraint on `<converter>_fpga_ref_clk`, verify resulting rate falls inside the range
- [ ] E2E baselines (`tests/tools/e2e/test_visual_regression_e2e.py`) may need refresh via `nox -rs teste2e_update_baselines` if the new expander shifts the layout