### PR TITLE
fix(explorer): surface real errors in System Configurator and broaden coverage

### DIFF
--- a/adijif/converters/ad9081_draw.py
+++ b/adijif/converters/ad9081_draw.py
@@ -85,14 +85,16 @@ class ad9081_rx_draw:
             assert isinstance(lo, Layout), "lo must be a Layout object"
         lo.add_node(self.ic_diagram_node)
 
-        # Find clock keys dynamically (handles case differences)
+        # Match exactly: an `endswith` check would also match the FPGA's
+        # `{fpga.name}_{conv.name}_ref_clk` and the converter would later
+        # `lo.remove_node` it, breaking the FPGA draw.
         name_lower = name.lower()
         ref_clk_key = None
         sysref_key = None
         for key in clocks.keys():
-            if key.lower().endswith(f"{name_lower}_ref_clk"):
+            if key.lower() == f"{name_lower}_ref_clk":
                 ref_clk_key = key
-            if key.lower().endswith(f"{name_lower}_sysref"):
+            if key.lower() == f"{name_lower}_sysref":
                 sysref_key = key
 
         if not system_draw:
@@ -275,14 +277,14 @@ class ad9081_tx_draw:
             assert isinstance(lo, Layout), "lo must be a Layout object"
         lo.add_node(self.ic_diagram_node)
 
-        # Find clock keys dynamically (handles case differences)
+        # Match exactly — see RX draw above for rationale.
         name_lower = name.lower()
         ref_clk_key = None
         sysref_key = None
         for key in clocks.keys():
-            if key.lower().endswith(f"{name_lower}_ref_clk"):
+            if key.lower() == f"{name_lower}_ref_clk":
                 ref_clk_key = key
-            if key.lower().endswith(f"{name_lower}_sysref"):
+            if key.lower() == f"{name_lower}_sysref":
                 sysref_key = key
 
         # Compute rates: DAC clock = interpolation * sample_clock

--- a/adijif/converters/ad9144_draw.py
+++ b/adijif/converters/ad9144_draw.py
@@ -62,14 +62,17 @@ class ad9144_draw:
             assert isinstance(lo, Layout), "lo must be a Layout object"
         lo.add_node(self.ic_diagram_node)
 
-        # Find clock keys dynamically (handles both ad9144 and ad9152 naming)
+        # Find clock keys dynamically (handles both ad9144 and ad9152 naming).
+        # Match exactly: an `endswith` check would also match the FPGA's
+        # `{fpga.name}_{conv.name}_ref_clk` and the converter would later
+        # `lo.remove_node` it, breaking the FPGA draw.
         name_lower = name.lower()
         ref_clk_key = None
         sysref_key = None
         for key in clocks.keys():
-            if key.lower().endswith(f"{name_lower}_ref_clk"):
+            if key.lower() == f"{name_lower}_ref_clk":
                 ref_clk_key = key
-            if key.lower().endswith(f"{name_lower}_sysref"):
+            if key.lower() == f"{name_lower}_sysref":
                 sysref_key = key
 
         dac_clock = clocks[ref_clk_key]

--- a/adijif/converters/ad9680_draw.py
+++ b/adijif/converters/ad9680_draw.py
@@ -103,11 +103,21 @@ class ad9680_draw:
 
         static_options = self.get_config()
 
+        # When the page wires an external PLL inline between the clock
+        # chip and the converter, the converter's reference clock is
+        # named `AD9680_ref_clk_from_ext_pll`; otherwise it's
+        # `AD9680_ref_clk`. Pick whichever the system actually emitted.
+        ref_clk_key = (
+            "AD9680_ref_clk_from_ext_pll"
+            if "AD9680_ref_clk_from_ext_pll" in clocks
+            else "AD9680_ref_clk"
+        )
+
         if not system_draw:
             ref_in = Node("REF_IN", ntype="input")
             lo.add_node(ref_in)
         else:
-            to_node = lo.get_node("AD9680_ref_clk")
+            to_node = lo.get_node(ref_clk_key)
             # Locate node connected to this one
             from_node = lo.get_connection(to=to_node.name)
             assert from_node, "No connection found"
@@ -120,12 +130,12 @@ class ad9680_draw:
         for i in range(2):
             adc = self.ic_diagram_node.get_child(f"ADC{i}")
             lo.add_connection(
-                {"from": ref_in, "to": adc, "rate": clocks["AD9680_ref_clk"]}
+                {"from": ref_in, "to": adc, "rate": clocks[ref_clk_key]}
             )
 
         # Update Node values
         for ddc in range(4):
-            rate = clocks["AD9680_ref_clk"]
+            rate = clocks[ref_clk_key]
             self.ic_diagram_node.update_connection(
                 "Crossbar", f"DDC{ddc}", rate
             )

--- a/adijif/converters/adrv9009_draw.py
+++ b/adijif/converters/adrv9009_draw.py
@@ -58,14 +58,16 @@ class adrv9009_rx_draw:
             assert isinstance(lo, Layout), "lo must be a Layout object"
         lo.add_node(self.ic_diagram_node)
 
-        # Find clock keys dynamically
+        # Match exactly: an `endswith` check would also match the FPGA's
+        # `{fpga.name}_{conv.name}_ref_clk` and the converter would later
+        # `lo.remove_node` it, breaking the FPGA draw.
         name_lower = name.lower()
         ref_clk_key = None
         sysref_key = None
         for key in clocks.keys():
-            if key.lower().endswith(f"{name_lower}_ref_clk"):
+            if key.lower() == f"{name_lower}_ref_clk":
                 ref_clk_key = key
-            if key.lower().endswith(f"{name_lower}_sysref"):
+            if key.lower() == f"{name_lower}_sysref":
                 sysref_key = key
 
         if not system_draw:
@@ -195,14 +197,14 @@ class adrv9009_tx_draw:
             assert isinstance(lo, Layout), "lo must be a Layout object"
         lo.add_node(self.ic_diagram_node)
 
-        # Find clock keys dynamically
+        # Match exactly — see RX draw above for rationale.
         name_lower = name.lower()
         ref_clk_key = None
         sysref_key = None
         for key in clocks.keys():
-            if key.lower().endswith(f"{name_lower}_ref_clk"):
+            if key.lower() == f"{name_lower}_ref_clk":
                 ref_clk_key = key
-            if key.lower().endswith(f"{name_lower}_sysref"):
+            if key.lower() == f"{name_lower}_sysref":
                 sysref_key = key
 
         dac_clock = clocks[ref_clk_key]

--- a/adijif/converters/converter.py
+++ b/adijif/converters/converter.py
@@ -67,11 +67,12 @@ class converter(core, jesd, gekko_translation, metaclass=ABCMeta):
         ic_node = Node(self.name)
         lo.add_node(ic_node)
 
-        # rate = clocks[f"{name}_ref_clk"]
-        # Find key with ending
+        # Match exactly: an `endswith` check would also match the FPGA's
+        # `{fpga.name}_{name}_ref_clk` and the converter would later
+        # `lo.remove_node` it, breaking the FPGA draw.
         ref_clk_name = None
         for key in clocks.keys():
-            if key.lower().endswith(f"{name.lower()}_ref_clk"):
+            if key.lower() == f"{name.lower()}_ref_clk":
                 ref_clk_name = key
                 break
         if ref_clk_name is None:
@@ -81,7 +82,7 @@ class converter(core, jesd, gekko_translation, metaclass=ABCMeta):
 
         sysref_clk_name = None
         for key in clocks.keys():
-            if key.lower().endswith(f"{name.lower()}_sysref"):
+            if key.lower() == f"{name.lower()}_sysref":
                 sysref_clk_name = key
                 break
         if sysref_clk_name is None:
@@ -191,11 +192,10 @@ class converter(core, jesd, gekko_translation, metaclass=ABCMeta):
         ic_node = Node(self.name)
         lo.add_node(ic_node)
 
-        # rate = clocks[f"{name}_ref_clk"]
-        # Find key with ending
+        # Match exactly — see DAC draw above for rationale.
         ref_clk_name = None
         for key in clocks.keys():
-            if key.lower().endswith(f"{name.lower()}_ref_clk"):
+            if key.lower() == f"{name.lower()}_ref_clk":
                 ref_clk_name = key
                 break
         if ref_clk_name is None:
@@ -205,7 +205,7 @@ class converter(core, jesd, gekko_translation, metaclass=ABCMeta):
 
         sysref_clk_name = None
         for key in clocks.keys():
-            if key.lower().endswith(f"{name.lower()}_sysref"):
+            if key.lower() == f"{name.lower()}_sysref":
                 sysref_clk_name = key
                 break
         if sysref_clk_name is None:

--- a/adijif/fpgas/xilinx/xilinx_draw.py
+++ b/adijif/fpgas/xilinx/xilinx_draw.py
@@ -443,6 +443,23 @@ class xilinx_draw:
                     }
                 )
 
+        # Each converter draw places a "remote" node at the top of the
+        # layout that stands in for the FPGA-side end of the JESD link.
+        # ADCs place a top-level "JESD204 Deframer" (the FPGA receives
+        # framed data) and put a "JESD204 Framer" child on the converter
+        # IC. DACs are reversed: a top-level "JESD204 Framer" stands in
+        # for the FPGA-side framer, and the converter IC has a
+        # "JESD204 Deframer" child. The FPGA draw replaces those
+        # placeholders with SERDES + link + transport children inside
+        # this IC's diagram.
+        is_dac = bool(converters) and (
+            converters[0].converter_type.upper() == "DAC"
+        )
+        converter_jesd_child = (
+            "JESD204 Deframer" if is_dac else "JESD204 Framer"
+        )
+        remote_node_name = "JESD204 Framer" if is_dac else "JESD204 Deframer"
+
         # Connect SYSREF to JESD204-Link-IP
         if not system_draw:
             sysref = Node("SYSREF", ntype="input")
@@ -450,7 +467,7 @@ class xilinx_draw:
         else:
             for converter in converters:
                 parent = lo.get_node(converter.name.upper())
-                to_node = parent.get_child("JESD204 Framer")
+                to_node = parent.get_child(converter_jesd_child)
                 # Locate node connected to this one
                 from_node = lo.get_connection(to=to_node.name)
                 assert from_node, "No connection found"
@@ -469,74 +486,101 @@ class xilinx_draw:
 
         # Datapath
 
-        # Get deframer
+        # Replace the converter-side remote placeholder with a SERDES
+        # node owned by JESD204-PHY-IP, then chain through link + transport.
+        new_serdes = None
         if system_draw:
-            deframer = lo.get_node("JESD204 Deframer")
-            assert deframer, "No JESD204 Deframer found in layout"
+            remote_node = lo.get_node(remote_node_name)
+            assert remote_node, f"No {remote_node_name} found in layout"
             parent = lo.get_node(converter.name.upper())
-            framer = parent.get_child("JESD204 Framer")
-            assert framer, "No JESD204 Framer found in layout"
+            converter_jesd = parent.get_child(converter_jesd_child)
+            assert converter_jesd, (
+                f"No {converter_jesd_child} found on {converter.name}"
+            )
 
-            # Replace deframer with a new one inside the FPGA IC diagram
-            lo.remove_node("JESD204 Deframer")
+            lo.remove_node(remote_node_name)
             phy_parent = self.ic_diagram_node.get_child("JESD204-PHY-IP")
-            new_deframer = Node("DESERIALIZER", ntype="serdes")
-            phy_parent.add_child(new_deframer)
+            new_serdes_label = "SERIALIZER" if is_dac else "DESERIALIZER"
+            new_serdes = Node(new_serdes_label, ntype="serdes")
+            phy_parent.add_child(new_serdes)
             lo.add_connection(
                 {
                     "from": xcvr_out,
-                    "to": new_deframer,
+                    "to": new_serdes,
                     "rate": converter.bit_clock,
                 }
             )
-            # Add connect for each lane
+            # Each lane traverses the cable. For ADCs the converter
+            # framer drives the FPGA deserializer; for DACs the FPGA
+            # serializer drives the converter deframer.
             for _ in range(converter.L):
                 lane_rate = converter.bit_clock
+                src, dst = (
+                    (new_serdes, converter_jesd)
+                    if is_dac
+                    else (converter_jesd, new_serdes)
+                )
                 lo.add_connection(
                     {
-                        "from": framer,
-                        "to": new_deframer,
+                        "from": src,
+                        "to": dst,
                         "rate": lane_rate,
                         "type": "data",
                     }
                 )
+
         if system_draw:
-            # Connect DESERIALIZER to link layer decoder
+            # Add the link-layer counterpart to the SERDES.
             link_layer = self.ic_diagram_node.get_child("JESD204-Link-IP")
             assert link_layer, "No JESD204-Link-IP found in layout"
-            decoder = Node("Link Layer Decoder", ntype="decoder")
-            link_layer.add_child(decoder)
+            link_child_label = (
+                "Link Layer Encoder" if is_dac else "Link Layer Decoder"
+            )
+            link_child_ntype = "encoder" if is_dac else "decoder"
+            link_child = Node(link_child_label, ntype=link_child_ntype)
+            link_layer.add_child(link_child)
             div = 40 if converter.encoding == "8b10b" else 66
             for _ in range(converter.L):
-                # Add connect for each lane
+                src, dst = (
+                    (link_child, new_serdes)
+                    if is_dac
+                    else (new_serdes, link_child)
+                )
                 lo.add_connection(
                     {
-                        "from": new_deframer,
-                        "to": decoder,
+                        "from": src,
+                        "to": dst,
                         "rate": converter.bit_clock / div,
                         "type": "data",
                     }
                 )
 
         if system_draw:
-            # Add deframer in transport layer
+            # Add the transport-layer counterpart.
             transport_layer = self.ic_diagram_node.get_child(
                 "JESD204-Transport-IP"
             )
             assert transport_layer, "No JESD204-Transport-IP found in layout"
-            deframer = Node("JESD204 Deframer", ntype="deframer")
-            transport_layer.add_child(deframer)
-            # Connect to link layer decoder
+            transport_label = "JESD204 Framer" if is_dac else "JESD204 Deframer"
+            transport_ntype = "framer" if is_dac else "deframer"
+            transport_child = Node(transport_label, ntype=transport_ntype)
+            transport_layer.add_child(transport_child)
+            src, dst = (
+                (transport_child, link_child)
+                if is_dac
+                else (link_child, transport_child)
+            )
             lo.add_connection(
                 {
-                    "from": decoder,
-                    "to": deframer,
-                    "rate": converter.bit_clock
-                    / (40 if converter.encoding == "8b10b" else 66),
+                    "from": src,
+                    "to": dst,
+                    "rate": converter.bit_clock / div,
                     "type": "data",
                 }
             )
-            # Remove connection between link and transport layers
+            # Remove the default link↔transport connection added by
+            # `_init_diagram` — the chain now flows through the
+            # encoder/decoder children we just attached.
             self.ic_diagram_node.remove_connection(
                 from_s=link_layer.name, to=transport_layer.name
             )

--- a/adijif/plls/adf4371.py
+++ b/adijif/plls/adf4371.py
@@ -4,11 +4,126 @@ from typing import Dict, List, Union
 
 from docplex.cp.solution import CpoSolveResult  # type: ignore
 
+from adijif.draw import Layout, Node
 from adijif.plls.pll import pll
 from adijif.solvers import CpoExpr, GK_Intermediate, integer_var, tround
 
 
-class adf4371(pll):
+class adf4371_drawer(object):
+    """ADF4371 diagram drawer."""
+
+    def _init_diagram(self) -> None:
+        """Initialize diagram with PLL block."""
+        self._diagram_output_dividers = []
+
+        self.ic_diagram_node = Node("ADF4371")
+
+        doubler = Node("D", ntype="doubler")
+        self.ic_diagram_node.add_child(doubler)
+
+        rdiv = Node("R", ntype="divider")
+        self.ic_diagram_node.add_child(rdiv)
+
+        pfd = Node("PFD", ntype="phase-frequency-detector")
+        self.ic_diagram_node.add_child(pfd)
+
+        charge_pump = Node("CP", ntype="charge-pump")
+        self.ic_diagram_node.add_child(charge_pump)
+
+        loop_filter = Node("LF", ntype="loop-filter")
+        self.ic_diagram_node.add_child(loop_filter)
+
+        vco = Node("VCO", ntype="vco")
+        self.ic_diagram_node.add_child(vco)
+
+        ndiv = Node("N", ntype="divider")
+        self.ic_diagram_node.add_child(ndiv)
+
+        output_dividers = Node("Output Dividers", ntype="shell")
+        self.ic_diagram_node.add_child(output_dividers)
+
+        rf_div = Node("RF_DIV", ntype="divider")
+        output_dividers.add_child(rf_div)
+
+        # Connections
+        self.ic_diagram_node.add_connection({"from": doubler, "to": rdiv})
+        self.ic_diagram_node.add_connection({"from": rdiv, "to": pfd})
+        self.ic_diagram_node.add_connection({"from": pfd, "to": charge_pump})
+        self.ic_diagram_node.add_connection(
+            {"from": charge_pump, "to": loop_filter}
+        )
+        self.ic_diagram_node.add_connection({"from": loop_filter, "to": vco})
+        self.ic_diagram_node.add_connection({"from": vco, "to": ndiv})
+        self.ic_diagram_node.add_connection({"from": ndiv, "to": pfd})
+        self.ic_diagram_node.add_connection(
+            {"from": vco, "to": output_dividers}
+        )
+        self.ic_diagram_node.add_connection(
+            {"from": output_dividers, "to": rf_div}
+        )
+
+    def draw(self, lo: Layout = None) -> Union[str, Layout]:
+        """Draw diagram with configuration.
+
+        Args:
+            lo (Layout): Diagram layout object
+
+        Returns:
+            Layout: Diagram layout object
+
+        Raises:
+            Exception: If solve hasn't been called yet
+        """
+        if not self._saved_solution:
+            raise Exception("No solution to draw. Must call solve first")
+
+        system_draw = lo is not None
+        if not system_draw:
+            lo = Layout("ADF4371 Diagram")
+        else:
+            assert isinstance(lo, Layout), (
+                "Layout object must be provided for system drawing"
+            )
+
+        lo.add_node(self.ic_diagram_node)
+
+        ref_in = Node("REF_IN", ntype="input")
+        doubler = self.ic_diagram_node.get_child("D")
+        lo.add_connection({"from": ref_in, "to": doubler})
+
+        # Update node values from the saved solution.
+        self.ic_diagram_node.get_child("D").value = str(
+            self._saved_solution["d"]
+        )
+        self.ic_diagram_node.get_child("R").value = str(
+            self._saved_solution["r"]
+        )
+        self.ic_diagram_node.get_child("N").value = str(
+            self._saved_solution["int"]
+        )
+
+        output_dividers = self.ic_diagram_node.get_child("Output Dividers")
+        rf_div = output_dividers.get_child("RF_DIV")
+        rf_div.value = str(self._saved_solution["rf_div"])
+
+        for key, val in self._saved_solution.get("output_clocks", {}).items():
+            clk_node = Node(key, ntype="dummy")
+            lo.add_node(clk_node)
+            lo.add_connection(
+                {
+                    "from": rf_div,
+                    "to": clk_node,
+                    "rate": val["rate"],
+                }
+            )
+
+        if system_draw:
+            return lo.draw()
+
+        return lo.draw()
+
+
+class adf4371(pll, adf4371_drawer):
     """ADF4371 PLL model.
 
     This model currently supports all divider configurations
@@ -223,6 +338,16 @@ class adf4371(pll):
         config["rf_out_frequency"] = vco / config["rf_div"]
         config["rf_out_frequency"] = tround(config["rf_out_frequency"])
 
+        output_clocks = {}
+        for clk in self._clk_names:
+            output_clocks[clk] = {
+                "rate": config["rf_out_frequency"],
+                "divider": config["rf_div"],
+            }
+        config["output_clocks"] = output_clocks
+
+        self._saved_solution = config
+
         return config
 
     def _setup_solver_constraints(
@@ -421,7 +546,10 @@ class adf4371(pll):
             (int or float or CpoExpr or GK_Intermediate): Abstract
                 or concrete clock reference
         """
-        self._clk_names = ["clk_name"]
+        if not hasattr(self, "_clk_names") or self._clk_names is None:
+            self._clk_names = []
+        if clk_name not in self._clk_names:
+            self._clk_names.append(clk_name)
 
         self.config["rf_div"] = self._convert_input(self.rf_div, "rf_div")
 

--- a/adijif/tools/explorer/src/pages/systemconfigurator.py
+++ b/adijif/tools/explorer/src/pages/systemconfigurator.py
@@ -182,11 +182,15 @@ class SystemConfigurator(Page):
                 )
                 sys.fpga.sys_clk_select = sys_clk_select
 
-                # Enable all adijif.xilinx._out_clk_selections for selection by default
+                # Read off the configured FPGA instance, since
+                # `setup_by_dev_kit_name` may have removed options that the
+                # selected board's transceiver doesn't support (e.g.
+                # XCVR_PROGDIV_CLK is unavailable on 7-series GTX/zc706).
+                fpga_out_clk_options = list(sys.fpga._out_clk_selections)
                 out_clk_select = st.multiselect(
-                    options=adijif.xilinx._out_clk_selections,
+                    options=fpga_out_clk_options,
                     label="XCVR Output Clock Selection",
-                    default=adijif.xilinx._out_clk_selections,
+                    default=fpga_out_clk_options,
                     key="system_fpga_out_clk_multiselect",
                 )
                 sys.fpga.out_clk_select = out_clk_select
@@ -317,9 +321,13 @@ class SystemConfigurator(Page):
             if clocks is None:
                 st.write("System not initialized.")
             else:
+                cfg = None
                 try:
                     cfg = sys.do_solve()
+                except Exception as e:  # noqa: BLE001 -- solver raises bare Exception
+                    st.error(f"Error solving system configuration: {e}")
 
+                if cfg is not None:
                     st.subheader("Clock Configuration")
                     st.write(cfg["clock"])
 
@@ -333,9 +341,6 @@ class SystemConfigurator(Page):
                     st.write(cfg["jesd_" + sys.converter.name.upper()])
 
                     diagram = sys.draw(cfg)
-
-                except Exception as e:
-                    st.error(f"Error solving system configuration: {e}")
 
         with st.expander("Diagram", expanded=False):
             if diagram:

--- a/tests/tools/test_systemconfigurator.py
+++ b/tests/tools/test_systemconfigurator.py
@@ -1,0 +1,192 @@
+"""Streamlit testing for System Configurator page."""
+
+import pathlib
+import sys
+import time
+
+import pytest
+from streamlit.testing.v1 import AppTest
+
+import adijif
+from adijif.clocks import supported_parts as _clock_parts
+from adijif.converters import supported_parts as _converter_parts
+
+app_path = (
+    pathlib.Path(__file__).parent.parent.parent
+    / "adijif"
+    / "tools"
+    / "explorer"
+)
+app_file_path = app_path / "main.py"
+
+sys.path.append(str(app_path))
+
+# Match the page's own filtering (see systemconfigurator.py:18) — these
+# clock parts are deliberately hidden in the explorer UI.
+_PAGE_HIDDEN_CLOCK_PARTS = {"ad9545", "ad9523_1"}
+CLOCK_PARTS = [p for p in _clock_parts if p not in _PAGE_HIDDEN_CLOCK_PARTS]
+CONVERTER_PARTS = list(_converter_parts)
+FPGA_DEV_KITS = list(adijif.xilinx._available_dev_kit_names)
+
+# AppTest's default 3s timeout is too tight for the System Configurator
+# page when solve + d2 diagram rendering both run.
+_APP_TIMEOUT = 30
+
+
+def _new_app(timeout: int = _APP_TIMEOUT) -> AppTest:
+    return AppTest.from_file(app_file_path, default_timeout=timeout).run()
+
+
+def navigate_to_systemconfigurator(at: AppTest) -> AppTest:
+    """Navigate the sidebar to the System Configurator page."""
+    sb = at.sidebar
+    for item in sb.radio:
+        if item.label == "Select a Tool":
+            item.set_value("System Configurator").run()
+            break
+    time.sleep(0.5)
+    return at
+
+
+def _set_selectbox(at: AppTest, key: str, value: str) -> None:
+    """Set a selectbox by `key` to the given underlying value and re-run."""
+    for sb in at.selectbox:
+        if sb.key == key:
+            sb.set_value(value).run()
+            return
+    raise AssertionError(f"Selectbox with key={key!r} not found")
+
+
+def test_systemconfigurator_page_loads() -> None:
+    at = _new_app()
+    navigate_to_systemconfigurator(at)
+
+    assert not at.exception
+    assert len(at.title) > 0
+    assert at.title[0].value == "System Configurator"
+
+
+def test_systemconfigurator_infeasible_shows_st_error() -> None:
+    """An infeasible config surfaces via st.error, not a raised exception."""
+    at = _new_app()
+    navigate_to_systemconfigurator(at)
+
+    # Force an infeasible converter clock (well above the device max for
+    # the default ad9680 converter, whose sample rate ceiling is ~1 GSPS).
+    for ni in at.number_input:
+        if ni.label and ni.label.startswith("Converter Clock"):
+            ni.set_value(15000.0).run()  # 15 GHz in MHz units
+            break
+
+    # Solver failure should be surfaced as an st.error message, and must
+    # NOT escape as a Python exception. The failure can come from either
+    # `sys.initialize()` (clock chip) or `sys.do_solve()` (final solve).
+    assert not at.exception, f"Unexpected exception: {at.exception}"
+    expected_prefixes = (
+        "Error solving system configuration",
+        "Error initializing system",
+    )
+    assert any(
+        any(prefix in e.value for prefix in expected_prefixes) for e in at.error
+    ), (
+        f"Expected one of {expected_prefixes!r} in st.error; "
+        f"got: {[e.value for e in at.error]}"
+    )
+
+
+def test_systemconfigurator_display_bug_propagates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Programming bugs in the display block must not be swallowed.
+
+    Stub `system.do_solve` to return a malformed cfg dict missing the
+    `"clock"` key. The page now reads cfg["clock"] outside the
+    try/except, so a `KeyError` should surface as `at.exception`. If
+    someone re-broadens the catch, this test fails.
+    """
+
+    def fake_do_solve(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        return {"converter": {}, "fpga_AD9680": {}, "jesd_AD9680": {}}
+
+    # `adijif.system` resolves to the class (re-exported in
+    # adijif/__init__.py), not the module — patch `do_solve` directly on
+    # it. The page calls `sys.initialize()` then `sys.do_solve()`; the
+    # initialize step still runs normally and only the solve result is
+    # replaced.
+    monkeypatch.setattr(adijif.system, "do_solve", fake_do_solve)
+
+    at = _new_app()
+    navigate_to_systemconfigurator(at)
+
+    # The default 1 GHz converter clock is infeasible at JESD204B for
+    # ad9680's default mode (lane rate 20 Gbps), which trips
+    # `sys.initialize()` and short-circuits the page before reaching
+    # `do_solve`. Drop to a feasible clock so the patched `do_solve`
+    # actually runs.
+    for ni in at.number_input:
+        if ni.label and ni.label.startswith("Converter Clock"):
+            ni.set_value(500.0).run()
+            break
+
+    assert at.exception, (
+        "Expected an exception to propagate from the display block, but "
+        "none was recorded. The broad except may have been re-introduced "
+        "around the cfg[...] reads."
+    )
+    # AppTest exposes the KeyError's args as `e.value` (e.g. `"'clock'"`).
+    # The presence of "clock" is sufficient evidence the display block
+    # raised on `cfg["clock"]` rather than the solver itself.
+    assert any("clock" in str(e.value) for e in at.exception), (
+        f"Expected 'clock' KeyError, got: "
+        f"{[str(e.value) for e in at.exception]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Part-coverage smoke tests
+#
+# Each parametrized test selects a single component on the page and asserts
+# that the page mounts without raising a Python exception. The solve may or
+# may not succeed for a given combination — that's surfaced via st.error and
+# is fine here. The point is that no part triggers a programming bug that
+# crashes the page.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("part", CONVERTER_PARTS)
+def test_systemconfigurator_loads_for_converter(part: str) -> None:
+    at = _new_app()
+    navigate_to_systemconfigurator(at)
+
+    _set_selectbox(at, "converter_part_select", part)
+
+    assert not at.exception, (
+        f"Page raised with converter={part!r}: "
+        f"{[str(e.value) for e in at.exception]}"
+    )
+
+
+@pytest.mark.parametrize("part", CLOCK_PARTS)
+def test_systemconfigurator_loads_for_clock(part: str) -> None:
+    at = _new_app()
+    navigate_to_systemconfigurator(at)
+
+    _set_selectbox(at, "clock_part_select", part)
+
+    assert not at.exception, (
+        f"Page raised with clock={part!r}: "
+        f"{[str(e.value) for e in at.exception]}"
+    )
+
+
+@pytest.mark.parametrize("kit", FPGA_DEV_KITS)
+def test_systemconfigurator_loads_for_fpga_kit(kit: str) -> None:
+    at = _new_app()
+    navigate_to_systemconfigurator(at)
+
+    _set_selectbox(at, "fpga_dev_kit_select", kit)
+
+    assert not at.exception, (
+        f"Page raised with fpga_kit={kit!r}: "
+        f"{[str(e.value) for e in at.exception]}"
+    )


### PR DESCRIPTION
## Summary

The System Configurator page swallowed every kind of failure into a single
broad `except Exception` and rendered them all as `st.error("Error solving
system configuration: ...")`. That hid genuine programming bugs (KeyError,
AttributeError, missing-node errors) behind what looked like solver
infeasibility.

This PR narrows the page-side catch to only the solver call, fixes three
pre-existing bugs that the narrowing surfaced, and adds an `AppTest` suite
that locks in both the legitimate-failure path and the no-bugs-allowed
path across every supported converter, clock chip, and FPGA dev kit.

### Page (`adijif/tools/explorer/src/pages/systemconfigurator.py`)
- Wrap only `sys.do_solve()` in the broad `except` — display code (cfg
  lookups, `st.write`, `sys.draw`) runs unguarded so programming bugs
  surface.
- Build the XCVR Output Clock multiselect from
  `sys.fpga._out_clk_selections` (instance, filtered by
  `setup_by_dev_kit_name`) instead of the unfiltered class attribute.
  Fixes a crash on `zc706` where the page assigned `XCVR_PROGDIV_CLK`
  even though 7-series GTX only supports `XCVR_REFCLK`/`XCVR_REFCLK_DIV2`.

### Converter draws
- Tightened the ref_clk / sysref key lookup in `ad9081_draw.py`,
  `ad9144_draw.py`, `adrv9009_draw.py`, and the base `converter.py` from
  `endswith` to exact case-insensitive equality. The previous predicate
  matched both `{conv}_ref_clk` and `{fpga}_{conv}_ref_clk`, and
  whichever the loop saved last got `lo.remove_node`'d — surfacing as
  `Node with name <board>_<CONVERTER>_ref_clk not found` in the FPGA
  draw, depending on dict iteration order.

### `xilinx_draw`
- Added DAC direction support to the system-level FPGA draw. The
  link-layer wiring was hardcoded to ADC nomenclature: it looked up a
  `JESD204 Framer` child of the converter IC and a top-level
  `JESD204 Deframer`, then built a DESERIALIZER/Decoder/Deframer chain
  inside the FPGA. DAC converters have those reversed (Deframer child of
  the IC, top-level Framer placeholder). Detect direction via
  `converter.converter_type` and branch the sysref lookup, the PHY-IP
  child (SERIALIZER vs DESERIALIZER), the link-layer child (Encoder vs
  Decoder), the transport-layer child (Framer vs Deframer), and the
  lane edge directions accordingly.

### Tests (`tests/tools/test_systemconfigurator.py`, new)
Drives the page through `streamlit.testing.v1.AppTest`:
- Smoke test that the page loads.
- Pin the legitimate-failure path: an infeasible converter clock is
  surfaced as `st.error`, not a Python exception. Accepts errors raised
  by either `sys.initialize()` or `sys.do_solve()`.
- Lock in the narrowed try/except: a stub `do_solve` returning a
  malformed cfg surfaces as `at.exception`, not a swallowed error.
- Parametrize over every supported converter, every page-visible clock
  chip, and every Xilinx dev kit so a programming bug in any of those
  code paths shows up immediately.

Bumps the AppTest timeout to 30 s — the default 3 s is too tight once
the solve and d2 diagram rendering both run.

## Test plan
- [x] `nox -rs tests-3.10 -- tests/tools/test_systemconfigurator.py` — 25 passed
- [x] `nox -rs tests-3.11 -- tests/tools/test_systemconfigurator.py` — 25 passed
- [x] `nox -rs tests-3.11` (full suite) — 590 passed, 11 skipped, 5 xfailed; no regressions
- [x] `nox -rs format lint ty` — clean