### PR TITLE
refactor(clocks): rename for consistency and decouple solve/draw

### DIFF
--- a/adijif/clocks/ad9523.py
+++ b/adijif/clocks/ad9523.py
@@ -174,7 +174,7 @@ class ad9523_1(ad9523_1_bf):
                 raise Exception("Missing key: " + str(k))
 
         if solution:  # type: ignore
-            self.solution = solution
+            self._solution = solution
         config: Dict = {
             "m1": self._get_val(self.config["m1"]),
             "n2": self._get_val(self.config["n2"]),
@@ -188,7 +188,7 @@ class ad9523_1(ad9523_1_bf):
         # Handle different vcxo types
         if hasattr(self, "vcxo_arb") and self.vcxo_arb:
             # arb_source case
-            vcxo_cfg = self.vcxo_arb.get_config(self.solution)  # type: ignore
+            vcxo_cfg = self.vcxo_arb.get_config(self._solution)  # type: ignore
             config["vcxo"] = list(vcxo_cfg.values())[0]
         else:
             # int/float or range case
@@ -207,7 +207,7 @@ class ad9523_1(ad9523_1_bf):
         config["vco"] = clk
         config["part"] = "AD9523-1"
 
-        self._saved_solution = config
+        self._last_config = config
 
         return config
 
@@ -227,22 +227,8 @@ class ad9523_1(ad9523_1_bf):
             "m1": self._convert_input(self._m1, "m1"),
             "n2": self._convert_input(self._n2, "n2"),
         }
-        if not isinstance(vcxo, (int, float)):
-            vcxo_result = vcxo(self.model)  # type: ignore
-            # Handle range type (returns dict with "range" key)
-            if isinstance(vcxo_result, dict):
-                self.config["vcxo_set"] = vcxo_result
-                self.vcxo_arb = None
-                vcxo = self.config["vcxo_set"]["range"]
-            # Handle arb_source type (returns direct expression)
-            else:
-                self.vcxo_arb = vcxo  # Store original for get_config
-                self.config["vcxo_set"] = None
-                vcxo = vcxo_result
-        else:
-            self.vcxo_arb = None
-            self.config["vcxo_set"] = None
-        self.vcxo = vcxo
+        self.vcxo = self._parse_reference(vcxo)
+        vcxo = self.vcxo
 
         # PLL2 equations
         self._add_equation(
@@ -258,7 +244,7 @@ class ad9523_1(ad9523_1_bf):
             self.config["n2"], sense="min", tier=1, name="ad9523.n2_min"
         )
 
-    def _setup(self, vcxo: int) -> None:
+    def setup_constraints(self, vcxo: int) -> None:
         # Setup clock chip internal constraints
 
         # FIXME: ADD SPLIT m1 configuration support
@@ -271,7 +257,7 @@ class ad9523_1(ad9523_1_bf):
         self.config["out_dividers"] = []
         self._clk_names = []  # Reset clock names to be generated
 
-    def _get_clock_constraint(
+    def request_clock_constraint(
         self, clk_name: List[str]
     ) -> Union[int, float, CpoExpr, GK_Intermediate]:
         """Get abstract clock output.
@@ -311,7 +297,7 @@ class ad9523_1(ad9523_1_bf):
             raise Exception("clk_names is not the same size as out_freqs")
 
         # Setup clock chip internal constraints
-        self._setup(vcxo)
+        self.setup_constraints(vcxo)
         self._clk_names = clk_names
 
         # Add requested clocks to output constraints

--- a/adijif/clocks/ad9528.py
+++ b/adijif/clocks/ad9528.py
@@ -283,7 +283,7 @@ class ad9528(ad9528_bf):
             )
 
         if solution:
-            self.solution = solution
+            self._solution = solution
 
         # out_dividers = [solution.get_value(x) for x in self.config["out_dividers"]]
         out_dividers = [self._get_val(x) for x in self.config["out_dividers"]]
@@ -291,7 +291,7 @@ class ad9528(ad9528_bf):
         # Handle different vcxo types
         if hasattr(self, "vcxo_arb") and self.vcxo_arb:
             # arb_source case
-            vcxo_cfg = self.vcxo_arb.get_config(self.solution)  # type: ignore
+            vcxo_cfg = self.vcxo_arb.get_config(self._solution)  # type: ignore
             vcxo = list(vcxo_cfg.values())[0]
             self.vcxo = vcxo
         elif self.vcxo_i:
@@ -327,7 +327,7 @@ class ad9528(ad9528_bf):
 
         config["output_clocks"] = output_cfg
 
-        self._saved_solution = config
+        self._last_config = config
 
         return config
 
@@ -378,7 +378,7 @@ class ad9528(ad9528_bf):
             self.config["n2"], sense="min", tier=1, name="ad9528.n2_min"
         )
 
-    def _setup(self, vcxo: int) -> None:
+    def setup_constraints(self, vcxo: int) -> None:
         # Setup clock chip internal constraints
 
         # FIXME: ADD SPLIT m1 configuration support
@@ -392,7 +392,7 @@ class ad9528(ad9528_bf):
         self.config["out_dividers"] = []
         self._clk_names = []  # Reset clock names
 
-    def _get_clock_constraint(
+    def request_clock_constraint(
         self, clk_name: str
     ) -> Union[int, float, CpoExpr, GK_Intermediate]:
         """Get abstract clock output.
@@ -429,7 +429,7 @@ class ad9528(ad9528_bf):
             raise Exception("clk_names is not the same size as out_freqs")
 
         # Setup clock chip internal constraints
-        self._setup(vcxo)
+        self.setup_constraints(vcxo)
         self._clk_names = clk_names
 
         if self._sysref:

--- a/adijif/clocks/ad9545.py
+++ b/adijif/clocks/ad9545.py
@@ -149,7 +149,7 @@ class ad9545(clock):
             Dict: Dictionary of clocking rates and dividers for configuration
         """
         if solution:
-            self.solution = solution
+            self._solution = solution
 
         config: Dict = {
             "PLL0": {},
@@ -196,7 +196,7 @@ class ad9545(clock):
         for i in range(0, 10):
             config["q" + str(i)] = self._get_val(self.config["q" + str(i)])
 
-        self._saved_solution = config
+        self._last_config = config
 
         return config
 
@@ -212,10 +212,10 @@ class ad9545(clock):
         Raises:
             Exception: If no solution is saved
         """
-        if not self._saved_solution:
+        if not self._last_config:
             raise Exception("No solution to draw. Must call solve first.")
 
-        config = self._saved_solution
+        config = self._last_config
         system_draw = lo is not None
         if not system_draw:
             lo = Layout("AD9545 Example")
@@ -545,7 +545,7 @@ class ad9545(clock):
                     name=f"ad9545.r{i}_min",
                 )
 
-    def _setup(self, input_refs: List[int], out_freqs: List[int]) -> None:
+    def setup_constraints(self, input_refs: List[int], out_freqs: List[int]) -> None:
         # Setup clock chip internal constraints
         if self.solver == "gekko":
             raise Exception("Gekko solver not supported for AD9545")
@@ -574,7 +574,7 @@ class ad9545(clock):
         for out_ref in outs:
             out_freqs[out_ref[0]] = out_ref[1]
 
-        self._setup(input_refs, out_freqs)
+        self.setup_constraints(input_refs, out_freqs)
 
         """ Add output dividers as variables to the model """
         for i in range(0, 10):

--- a/adijif/clocks/clock.py
+++ b/adijif/clocks/clock.py
@@ -153,7 +153,7 @@ class clock(core, gekko_translation, metaclass=ABCMeta):
         # solve() retains its narrow "just solve the model" contract.
         try:
             self.get_config()
-        except Exception:
+        except Exception:  # noqa: S110 - intentional best-effort cache
             pass
         return result
 

--- a/adijif/clocks/clock.py
+++ b/adijif/clocks/clock.py
@@ -13,7 +13,32 @@ from adijif.solvers import CpoExpr
 
 
 class clock(core, gekko_translation, metaclass=ABCMeta):
-    """Parent metaclass for all clock chip classes."""
+    """Parent metaclass for all clock chip classes.
+
+    Two supported call orders:
+
+    Standalone mode (used in validation/exploration scripts)::
+
+        clk = HMC7044()
+        clk.n2 = 24                                       # optional divider constraints
+        clk.set_requested_clocks(vcxo, freqs, names)      # define requested outputs
+        clk.solve()                                       # caches config internally
+        cfg = clk.get_config()                            # optional: returns same dict
+        img = clk.draw()                                  # uses cached config
+
+    System mode (driven by ``adijif.system``)::
+
+        clk.setup_constraints(vcxo)                       # called by system.initialize()
+        expr = clk.request_clock_constraint(name)         # repeated for each output
+        # solver runs at the system level (system.do_solve)
+        cfg = clk.get_config(solution)
+        clk.draw(layout)
+
+    In both modes, ``set_requested_clocks`` / ``setup_constraints`` must be
+    called before ``solve``/``get_config``, and dividers must be configured
+    via properties (e.g. ``n2``, ``r2``, ``d``) before either entry point
+    if you want to constrain the search space.
+    """
 
     def _parse_reference(
         self, vcxo: Union[int, float, CpoExpr]
@@ -96,15 +121,17 @@ class clock(core, gekko_translation, metaclass=ABCMeta):
 
     def _solve_cplex(self) -> CpoSolveResult:
         apply_objectives(self.model, self.solver, self._objectives)
-        self.solution = self.model.solve(LogVerbosity="Quiet")
-        if self.solution.solve_status not in ["Feasible", "Optimal"]:
+        self._solution = self.model.solve(LogVerbosity="Quiet")
+        if self._solution.solve_status not in ["Feasible", "Optimal"]:
             raise Exception("Solution Not Found")
-        return self.solution
+        return self._solution
 
     def solve(self) -> Union[None, CpoSolveResult]:
         """Local solve method for clock model.
 
-        Call model solver with correct arguments.
+        Call the underlying solver and immediately cache the resulting
+        configuration so ``draw()`` can be invoked without an
+        intermediate ``get_config()`` call.
 
         Returns:
             [None,CpoSolveResult]: When cplex solver is used CpoSolveResult is returned
@@ -114,11 +141,21 @@ class clock(core, gekko_translation, metaclass=ABCMeta):
 
         """
         if self.solver == "gekko":
-            return self._solve_gekko()
+            result = self._solve_gekko()
         elif self.solver == "CPLEX":
-            return self._solve_cplex()
+            result = self._solve_cplex()
         else:
             raise Exception(f"Unknown solver {self.solver}")
+        # Best-effort cache of the config so draw() can be called after
+        # solve() alone in the standard standalone flow. Some chips
+        # (e.g. AD9545) impose extra requirements on get_config that may
+        # not be satisfied in minimal smoke tests; swallow those here so
+        # solve() retains its narrow "just solve the model" contract.
+        try:
+            self.get_config()
+        except Exception:
+            pass
+        return result
 
     def draw(self, lo: Layout = None) -> str:
         """Generic Draw converter model.
@@ -132,9 +169,9 @@ class clock(core, gekko_translation, metaclass=ABCMeta):
         Raises:
             Exception: If no solution is saved
         """
-        if not self._saved_solution:
+        if not self._last_config:
             raise Exception("No solution to draw. Must call solve first.")
-        clocks = self._saved_solution
+        clocks = self._last_config
         system_draw = lo is not None
         name = self.name.lower()
 

--- a/adijif/clocks/hmc7044.py
+++ b/adijif/clocks/hmc7044.py
@@ -44,7 +44,7 @@ class hmc7044(hmc7044_bf):
     vcxo_max = 500e6
 
     use_vcxo_double = True
-    vxco_doubler_available = [1, 2]
+    vcxo_doubler_available = [1, 2]
     _vcxo_doubler = [1, 2]
 
     # State management
@@ -142,7 +142,7 @@ class hmc7044(hmc7044_bf):
         self._r2 = value
 
     @property
-    def vxco_doubler(self) -> Union[int, List[int]]:
+    def vcxo_doubler(self) -> Union[int, List[int]]:
         """VCXO doubler.
 
         Valid dividers are 1,2
@@ -152,8 +152,8 @@ class hmc7044(hmc7044_bf):
         """
         return self._vcxo_doubler
 
-    @vxco_doubler.setter
-    def vxco_doubler(self, value: Union[int, List[int]]) -> None:
+    @vcxo_doubler.setter
+    def vcxo_doubler(self, value: Union[int, List[int]]) -> None:
         """VCXO doubler.
 
         Valid dividers are 1,2
@@ -162,7 +162,7 @@ class hmc7044(hmc7044_bf):
             value (int, list[int]): Allowable values for divider
 
         """
-        self._check_in_range(value, self.vxco_doubler_available, "vxco_doubler")
+        self._check_in_range(value, self.vcxo_doubler_available, "vcxo_doubler")
         self._vcxo_doubler = value
 
     def _init_diagram(self) -> None:
@@ -262,7 +262,7 @@ class hmc7044(hmc7044_bf):
         Raises:
             Exception: If no solution is saved
         """
-        if not self._saved_solution:
+        if not self._last_config:
             raise Exception("No solution to draw. Must call solve first.")
 
         system_draw = lo is not None
@@ -280,45 +280,45 @@ class hmc7044(hmc7044_bf):
             {
                 "from": ref_in,
                 "to": vcxo_double,
-                "rate": self._saved_solution["vcxo"],
+                "rate": self._last_config["vcxo"],
             }
         )
 
         # Update Node values
         node = self.ic_diagram_node.get_child("VCXO Doubler")
-        node.value = str(self._saved_solution["vcxo_doubler"])
+        node.value = str(self._last_config["vcxo_doubler"])
         node = self.ic_diagram_node.get_child("R2")
-        node.value = str(self._saved_solution["r2"])
+        node.value = str(self._last_config["r2"])
         node = self.ic_diagram_node.get_child("N2")
-        node.value = str(self._saved_solution["n2"])
+        node.value = str(self._last_config["n2"])
 
         # Update VCXO Doubler to R2
         # con = self.ic_diagram_node.get_connection("VCXO Doubler", "R2")
         rate = (
-            self._saved_solution["vcxo_doubler"] * self._saved_solution["vcxo"]
+            self._last_config["vcxo_doubler"] * self._last_config["vcxo"]
         )
         self.ic_diagram_node.update_connection("VCXO Doubler", "R2", rate)
 
         # Update R2 to PFD
         # con = self.ic_diagram_node.get_connection("R2", "PFD")
         rate = (
-            self._saved_solution["vcxo"]
-            * self._saved_solution["vcxo_doubler"]
-            / self._saved_solution["r2"]
+            self._last_config["vcxo"]
+            * self._last_config["vcxo_doubler"]
+            / self._last_config["r2"]
         )
         self.ic_diagram_node.update_connection("R2", "PFD", rate)
 
         # Update VCO
         # con = self.ic_diagram_node.get_connection("VCO", "Output Dividers")
         self.ic_diagram_node.update_connection(
-            "VCO", "Output Dividers", self._saved_solution["vco"]
+            "VCO", "Output Dividers", self._last_config["vco"]
         )
 
         # Update diagram with dividers and rates
         d = 0
         output_dividers = self.ic_diagram_node.get_child("Output Dividers")
 
-        for key, val in self._saved_solution["output_clocks"].items():
+        for key, val in self._last_config["output_clocks"].items():
             clk_node = Node(key, ntype="dummy")
             div_value = val["divider"]
             div = output_dividers.get_child(f"D{d}")
@@ -357,7 +357,7 @@ class hmc7044(hmc7044_bf):
             )
 
         if solution:
-            self.solution = solution
+            self._solution = solution
 
         out_dividers = [self._get_val(x) for x in self.config["out_dividers"]]
 
@@ -371,7 +371,7 @@ class hmc7044(hmc7044_bf):
         # Handle different vcxo types
         if hasattr(self, "vcxo_arb") and self.vcxo_arb:
             # arb_source case
-            vcxo_cfg = self.vcxo_arb.get_config(self.solution)  # type: ignore
+            vcxo_cfg = self.vcxo_arb.get_config(self._solution)  # type: ignore
             vcxo = list(vcxo_cfg.values())[0]
             self.vcxo = vcxo
         elif self.vcxo_i:
@@ -392,7 +392,7 @@ class hmc7044(hmc7044_bf):
         config["vcxo"] = self.vcxo
         config["vcxo_doubler"] = vd
 
-        self._saved_solution = config
+        self._last_config = config
 
         return config
 
@@ -450,7 +450,7 @@ class hmc7044(hmc7044_bf):
             self.config["r2"], sense="min", tier=1, name="hmc7044.r2_min"
         )
 
-    def _setup(self, vcxo: int) -> None:
+    def setup_constraints(self, vcxo: int) -> None:
         # Setup clock chip internal constraints
 
         # FIXME: ADD SPLIT m1 configuration support
@@ -463,7 +463,7 @@ class hmc7044(hmc7044_bf):
         self.config["out_dividers"] = []
         self._clk_names = []  # Reset
 
-    def _get_clock_constraint(
+    def request_clock_constraint(
         self, clk_name: List[str]
     ) -> Union[int, float, CpoExpr, GK_Intermediate]:
         """Get abstract clock output.
@@ -521,12 +521,12 @@ class hmc7044(hmc7044_bf):
             raise Exception("clk_names is not the same size as out_freqs")
 
         # Setup clock chip internal constraints
-        self._setup(vcxo)
+        self.setup_constraints(vcxo)
         self._clk_names = clk_names
         # if type(self.vcxo) not in [int,float]:
         #     vcxo = self.vcxo['range']
 
-        self._saved_solution = None
+        self._last_config = None
 
         # Add requested clocks to output constraints
         for d_n, out_freq in enumerate(out_freqs):

--- a/adijif/clocks/ltc6952.py
+++ b/adijif/clocks/ltc6952.py
@@ -474,14 +474,14 @@ class ltc6952(ltc6952_bf):
             )
 
         if solution:
-            self.solution = solution
+            self._solution = solution
 
         out_dividers = [self._get_val(x) for x in self.config["out_dividers"]]
 
         # Handle different vcxo types
         if hasattr(self, "vcxo_arb") and self.vcxo_arb:
             # arb_source case
-            vcxo_cfg = self.vcxo_arb.get_config(self.solution)  # type: ignore
+            vcxo_cfg = self.vcxo_arb.get_config(self._solution)  # type: ignore
             vcxo_val = list(vcxo_cfg.values())[0]
         else:
             # int/float or range case
@@ -496,7 +496,7 @@ class ltc6952(ltc6952_bf):
         config: Dict = {
             "r2": self._get_val(self.config["r2"]),
             "n2": self._get_val(self.config["n2"]),
-            "VCO": clk,
+            "vco": clk,
             "vcxo": vcxo_val,
             "out_dividers": out_dividers,
             "output_clocks": [],
@@ -509,7 +509,7 @@ class ltc6952(ltc6952_bf):
 
         config["output_clocks"] = output_cfg
 
-        self._saved_solution = config
+        self._last_config = config
 
         return config
 
@@ -542,7 +542,7 @@ class ltc6952(ltc6952_bf):
         # ``system.add_objective`` if they want to bias toward smaller
         # dividers.
 
-    def _setup(self, vcxo: int) -> None:
+    def setup_constraints(self, vcxo: int) -> None:
         # Setup clock chip internal constraints
 
         # FIXME: ADD SPLIT m1 configuration support
@@ -555,7 +555,7 @@ class ltc6952(ltc6952_bf):
         self.config["out_dividers"] = []
         self._clk_names = []  # Reset
 
-    def _get_clock_constraint(
+    def request_clock_constraint(
         self, clk_name: List[str]
     ) -> Union[int, float, CpoExpr, GK_Intermediate]:
         """Get abstract clock output.
@@ -607,7 +607,7 @@ class ltc6952(ltc6952_bf):
             raise Exception("clk_names is not the same size as out_freqs")
 
         # Setup clock chip internal constraints
-        self._setup(vcxo)
+        self.setup_constraints(vcxo)
         self._clk_names = clk_names
 
         # Add requested clocks to output constraints

--- a/adijif/clocks/ltc6953.py
+++ b/adijif/clocks/ltc6953.py
@@ -391,7 +391,7 @@ class ltc6953(clock):
             )
 
         if solution:
-            self.solution = solution
+            self._solution = solution
 
         out_dividers = [self._get_val(x) for x in self.config["out_dividers"]]
 
@@ -403,7 +403,7 @@ class ltc6953(clock):
         # Handle different input_ref types
         if hasattr(self, "input_ref_arb") and self.input_ref_arb:
             # arb_source case
-            input_ref_cfg = self.input_ref_arb.get_config(self.solution)  # type: ignore
+            input_ref_cfg = self.input_ref_arb.get_config(self._solution)  # type: ignore
             config["input_ref"] = list(input_ref_cfg.values())[0]
         else:
             # int/float or range case
@@ -418,7 +418,7 @@ class ltc6953(clock):
 
         config["output_clocks"] = output_cfg
 
-        self._saved_solution = config
+        self._last_config = config
 
         return config
 
@@ -434,7 +434,7 @@ class ltc6953(clock):
         Raises:
             Exception: If no solution is saved
         """
-        if not self._saved_solution:
+        if not self._last_config:
             raise Exception("No solution to draw. Must call solve first.")
 
         system_draw = lo is not None
@@ -455,7 +455,7 @@ class ltc6953(clock):
             lo.add_node(ref_in)
         else:
             ref_name = None
-            for key in self._saved_solution.keys():
+            for key in self._last_config.keys():
                 if "input_ref" in key.lower():
                     ref_name = key
                     break
@@ -471,12 +471,12 @@ class ltc6953(clock):
                 ref_in = Node("REF_IN", ntype="input")
                 lo.add_node(ref_in)
 
-        input_ref = self._saved_solution["input_ref"]
+        input_ref = self._last_config["input_ref"]
         lo.add_connection({"from": ref_in, "to": ic_node, "rate": input_ref})
 
         # Add each output clock with its divider
         for i, (clk_name, clk_cfg) in enumerate(
-            self._saved_solution["output_clocks"].items()
+            self._last_config["output_clocks"].items()
         ):
             div_node = Node(f"D{i}", ntype="divider")
             div_node.value = str(int(clk_cfg["divider"]))
@@ -520,7 +520,7 @@ class ltc6953(clock):
             ]
         )
 
-    def _setup(self, input_ref: int) -> None:
+    def setup_constraints(self, input_ref: int) -> None:
         if isinstance(input_ref, (float, int)):
             assert self.input_freq_max >= input_ref >= 0, (
                 "Input frequency out of range"
@@ -532,7 +532,7 @@ class ltc6953(clock):
         # Add requested clocks to output constraints
         self.config["out_dividers"] = []
 
-    def _get_clock_constraint(
+    def request_clock_constraint(
         self, clk_name: List[str]
     ) -> Union[int, float, CpoExpr, GK_Intermediate]:
         """Get abstract clock output.
@@ -581,7 +581,7 @@ class ltc6953(clock):
         self._clk_names = clk_names
 
         # Setup clock chip internal constraints
-        self._setup(input_ref)
+        self.setup_constraints(input_ref)
 
         # Add requested clocks to output constraints
         for out_freq, clk_name in zip(out_freqs, clk_names):  # noqa: B905

--- a/adijif/common.py
+++ b/adijif/common.py
@@ -96,7 +96,7 @@ class core:
         Raises:
             Exception: If solver is not valid
         """
-        self._saved_solution = None
+        self._last_config = None
         self._objectives: List[Objective] = []
         self._disabled_objectives: set = set()
         self._solution = None

--- a/adijif/converters/ad9081.py
+++ b/adijif/converters/ad9081.py
@@ -121,7 +121,7 @@ class ad9081_core(converter, metaclass=ABCMeta):
             Dict: Dictionary of clocking rates and dividers for configuration
         """
         if solution:
-            self.solution = solution
+            self._solution = solution
         if self.clocking_option == "integrated_pll":
             pll_config: Dict = {
                 "m_vco": self._get_val(self.config["ad9081_m_vco"]),

--- a/adijif/converters/ad9084.py
+++ b/adijif/converters/ad9084.py
@@ -119,8 +119,8 @@ class ad9084_core(ad9084_draw, converter, metaclass=ABCMeta):
             Dict: Dictionary of clocking rates and dividers for configuration
         """
         if solution:
-            self.solution = solution
-            self._saved_solution = solution
+            self._solution = solution
+            self._last_config = solution
 
         if self.clocking_option == "integrated_pll":
             pll_config: Dict = {

--- a/adijif/converters/ad9084_draw.py
+++ b/adijif/converters/ad9084_draw.py
@@ -105,7 +105,7 @@ class ad9084_draw:
         Raises:
             Exception: If no solution is saved
         """
-        if not self._saved_solution:
+        if not self._last_config:
             raise Exception("No solution to draw. Must call solve first.")
 
         system_draw = lo is not None

--- a/adijif/converters/ad9144.py
+++ b/adijif/converters/ad9144.py
@@ -178,7 +178,7 @@ class ad9144(ad9144_draw, ad9144_bf):
 
         if self.solver == "CPLEX":
             if solution:
-                self.solution = solution
+                self._solution = solution
             config.update(
                 {
                     "BCount": self._get_val(self.config["BCount"]),

--- a/adijif/converters/ad9680.py
+++ b/adijif/converters/ad9680.py
@@ -157,7 +157,7 @@ class ad9680(ad9680_draw, ad9680_bf):
             Dict: Dictionary of clocking rates and dividers for configuration
         """
         if solution:
-            self._saved_solution = solution
+            self._last_config = solution
         return {
             "clocking_option": self.clocking_option,
             "decimation": self.decimation,

--- a/adijif/converters/ad9680_draw.py
+++ b/adijif/converters/ad9680_draw.py
@@ -88,7 +88,7 @@ class ad9680_draw:
         Raises:
             Exception: If no solution is saved
         """
-        if not self._saved_solution:
+        if not self._last_config:
             raise Exception("No solution to draw. Must call solve first.")
 
         system_draw = lo is not None

--- a/adijif/converters/adrv9009.py
+++ b/adijif/converters/adrv9009.py
@@ -108,7 +108,7 @@ class adrv9009_core(converter, metaclass=ABCMeta):
             Dict: Dictionary of clocking rates and dividers for configuration
         """
         if solution:
-            self.solution = solution
+            self._solution = solution
         return {}
 
 

--- a/adijif/fpgas/xilinx/__init__.py
+++ b/adijif/fpgas/xilinx/__init__.py
@@ -555,9 +555,9 @@ class xilinx(xilinx_bf, xilinx_draw):
         """
         out = []
         if solution:
-            self.solution = solution
+            self._solution = solution
 
-        self._saved_solution = solution  # needed for draw
+        self._last_config = solution  # needed for draw
 
         for config in self.configs:
             pll_config: Dict[str, Union[str, int, float]] = {}

--- a/adijif/fpgas/xilinx/pll.py
+++ b/adijif/fpgas/xilinx/pll.py
@@ -15,7 +15,7 @@ class XilinxPLL(core, gekko_translation):
     plls = None
     parent = None
     _model = None  # Hold internal model when used standalone
-    _solution = None  # Hold internal solution when used standalone
+    _local_solution = None  # Hold internal solution when used standalone
 
     def __init__(
         self,
@@ -43,7 +43,6 @@ class XilinxPLL(core, gekko_translation):
         self.parent = parent
         if parent:
             self._model = parent.model
-            self._solution = parent.solution
             self.solver = parent.solver
         self.add_plls()
         if self.solver == "gekko":
@@ -75,14 +74,19 @@ class XilinxPLL(core, gekko_translation):
         self._model = val
 
     @property
-    def solution(self) -> CpoSolveResult:
-        """Solution object from solver."""
-        if self.parent:
-            return self.parent.solution
-        return self._solution
+    def _solution(self) -> CpoSolveResult:
+        """Solution object from solver.
 
-    @solution.setter
-    def solution(self, val: CpoSolveResult) -> None:
+        Delegates to the parent's solution when used as a child PLL of
+        an FPGA / system object; otherwise returns the locally stored
+        solution from a standalone solve.
+        """
+        if self.parent:
+            return self.parent._solution
+        return self._local_solution
+
+    @_solution.setter
+    def _solution(self, val: CpoSolveResult) -> None:
         """Set solution object from solver.
 
         Args:
@@ -93,7 +97,7 @@ class XilinxPLL(core, gekko_translation):
         """
         if self.parent:
             raise Exception("Cannot set solution when parent model is used")
-        self._solution = val
+        self._local_solution = val
 
     @property
     def transceiver_type(self) -> str:
@@ -170,10 +174,10 @@ class XilinxPLL(core, gekko_translation):
     #     pass
 
     def _solve_cplex(self) -> CpoSolveResult:
-        self.solution = self.model.solve(LogVerbosity="Normal")
-        if self.solution.solve_status not in ["Feasible", "Optimal"]:
+        self._solution = self.model.solve(LogVerbosity="Normal")
+        if self._solution.solve_status not in ["Feasible", "Optimal"]:
             raise Exception("Solution Not Found")
-        return self.solution
+        return self._solution
 
     def solve(self) -> Union[None, CpoSolveResult]:
         """Local solve method for clock model.
@@ -225,10 +229,10 @@ class PLLCommon(gekko_translation):
         return self.parent.solver
 
     @property
-    def solution(self) -> CpoSolveResult:
+    def _solution(self) -> CpoSolveResult:
         """Solution object from solver.
 
         Returns:
             CpoSolveResult: Solution object from solver
         """
-        return self.parent.solution
+        return self.parent._solution

--- a/adijif/fpgas/xilinx/sevenseries.py
+++ b/adijif/fpgas/xilinx/sevenseries.py
@@ -76,13 +76,13 @@ class SevenSeries(XilinxPLL):
         """
         if self.force_cpll:
             ecpll = 1
-            eqpll = self.solution.get_kpis()[converter.name + "_use_qpll"]
+            eqpll = self._solution.get_kpis()[converter.name + "_use_qpll"]
         elif self.force_qpll:
-            ecpll = self.solution.get_kpis()[converter.name + "_use_cpll"]
+            ecpll = self._solution.get_kpis()[converter.name + "_use_cpll"]
             eqpll = 1
         else:
-            ecpll = self.solution.get_kpis()[converter.name + "_use_cpll"]
-            eqpll = self.solution.get_kpis()[converter.name + "_use_qpll"]
+            ecpll = self._solution.get_kpis()[converter.name + "_use_cpll"]
+            eqpll = self._solution.get_kpis()[converter.name + "_use_qpll"]
 
         assert ecpll != eqpll, "Both CPLL and QPLL enabled"
         pll = "CPLL" if ecpll else "QPLL"

--- a/adijif/fpgas/xilinx/ultrascaleplus.py
+++ b/adijif/fpgas/xilinx/ultrascaleplus.py
@@ -81,20 +81,20 @@ class UltraScalePlus(XilinxPLL, core, gekko_translation):
         if self.force_cpll or self.force_qpll or self.force_qpll1:
             if self.force_cpll:
                 ecpll = 1
-                eqpll = self.solution.get_kpis()[converter.name + "_use_qpll"]
-                eqpll1 = self.solution.get_kpis()[converter.name + "_use_qpll1"]
+                eqpll = self._solution.get_kpis()[converter.name + "_use_qpll"]
+                eqpll1 = self._solution.get_kpis()[converter.name + "_use_qpll1"]
             elif self.force_qpll:
-                ecpll = self.solution.get_kpis()[converter.name + "_use_cpll"]
+                ecpll = self._solution.get_kpis()[converter.name + "_use_cpll"]
                 eqpll = 1
-                eqpll1 = self.solution.get_kpis()[converter.name + "_use_qpll1"]
+                eqpll1 = self._solution.get_kpis()[converter.name + "_use_qpll1"]
             else:
-                ecpll = self.solution.get_kpis()[converter.name + "_use_cpll"]
-                eqpll = self.solution.get_kpis()[converter.name + "_use_qpll"]
+                ecpll = self._solution.get_kpis()[converter.name + "_use_cpll"]
+                eqpll = self._solution.get_kpis()[converter.name + "_use_qpll"]
                 eqpll1 = 1
         else:
-            ecpll = self.solution.get_kpis()[converter.name + "_use_cpll"]
-            eqpll = self.solution.get_kpis()[converter.name + "_use_qpll"]
-            eqpll1 = self.solution.get_kpis()[converter.name + "_use_qpll1"]
+            ecpll = self._solution.get_kpis()[converter.name + "_use_cpll"]
+            eqpll = self._solution.get_kpis()[converter.name + "_use_qpll"]
+            eqpll1 = self._solution.get_kpis()[converter.name + "_use_qpll1"]
         assert ecpll + eqpll + eqpll1 == 1, "Only one PLL can be enabled"
         if ecpll:
             pll = "CPLL"
@@ -292,10 +292,10 @@ class QPLL(SevenSeriesQPLL):
                 pll_config["sdm_width"] = self._get_val(
                     config[converter.name + f"_sdm_width_{pname}"]
                 )
-                pll_config["frac"] = self.solution.get_kpis()[
+                pll_config["frac"] = self._solution.get_kpis()[
                     converter.name + f"_frac_{pname}"
                 ]
-                pll_config["n_dot_frac"] = self.solution.get_kpis()[
+                pll_config["n_dot_frac"] = self._solution.get_kpis()[
                     converter.name + f"_n_dot_frac_{pname}"
                 ]
             else:
@@ -306,7 +306,7 @@ class QPLL(SevenSeriesQPLL):
         pll_config["n"] = pll_config["n_dot_frac"]
 
         # config['vco'] = self._get_val(config[converter.name + f"_vco_{pname}"])
-        pll_config["vco"] = self.solution.get_kpis()[
+        pll_config["vco"] = self._solution.get_kpis()[
             converter.name + f"_vco_{pname}"
         ]
 

--- a/adijif/fpgas/xilinx/versal.py
+++ b/adijif/fpgas/xilinx/versal.py
@@ -93,13 +93,13 @@ class Versal(XilinxPLL, core, gekko_translation):
         """
         if self.force_rpll:
             erpll = 1
-            elcpll = self.solution.get_kpis()[converter.name + "_use_lcpll"]
+            elcpll = self._solution.get_kpis()[converter.name + "_use_lcpll"]
         elif self.force_lcpll:
-            erpll = self.solution.get_kpis()[converter.name + "_use_rpll"]
+            erpll = self._solution.get_kpis()[converter.name + "_use_rpll"]
             elcpll = 1
         else:
-            erpll = self.solution.get_kpis()[converter.name + "_use_rpll"]
-            elcpll = self.solution.get_kpis()[converter.name + "_use_lcpll"]
+            erpll = self._solution.get_kpis()[converter.name + "_use_rpll"]
+            elcpll = self._solution.get_kpis()[converter.name + "_use_lcpll"]
 
         assert erpll != elcpll, "Both RPLL and LCPLL enabled"
         pll = "RPLL" if erpll else "LCPLL"
@@ -274,10 +274,10 @@ class RPLL(PLLCommon):
                 pll_config["sdm_width"] = self._get_val(
                     config[converter.name + f"_sdm_width_{pname}"]
                 )
-                pll_config["frac"] = self.solution.get_kpis()[
+                pll_config["frac"] = self._solution.get_kpis()[
                     converter.name + f"_frac_{pname}"
                 ]
-                pll_config["n_dot_frac"] = self.solution.get_kpis()[
+                pll_config["n_dot_frac"] = self._solution.get_kpis()[
                     converter.name + f"_n_dot_frac_{pname}"
                 ]
             else:
@@ -286,7 +286,7 @@ class RPLL(PLLCommon):
             pll_config["n_dot_frac"] = pll_config["n"]
 
         pll_config["n"] = pll_config["n_dot_frac"]
-        pll_config["vco"] = self.solution.get_kpis()[
+        pll_config["vco"] = self._solution.get_kpis()[
             converter.name + f"_vco_{pname}"
         ]
 
@@ -627,10 +627,10 @@ class LCPLL(PLLCommon):
                 pll_config["sdm_width"] = self._get_val(
                     config[converter.name + f"_sdm_width_{pname}"]
                 )
-                pll_config["frac"] = self.solution.get_kpis()[
+                pll_config["frac"] = self._solution.get_kpis()[
                     converter.name + f"_frac_{pname}"
                 ]
-                pll_config["n_dot_frac"] = self.solution.get_kpis()[
+                pll_config["n_dot_frac"] = self._solution.get_kpis()[
                     converter.name + f"_n_dot_frac_{pname}"
                 ]
             else:
@@ -639,7 +639,7 @@ class LCPLL(PLLCommon):
             pll_config["n_dot_frac"] = pll_config["n"]
 
         pll_config["n"] = pll_config["n_dot_frac"]
-        pll_config["vco"] = self.solution.get_kpis()[
+        pll_config["vco"] = self._solution.get_kpis()[
             converter.name + f"_vco_{pname}"
         ]
 

--- a/adijif/fpgas/xilinx/xilinx_draw.py
+++ b/adijif/fpgas/xilinx/xilinx_draw.py
@@ -291,7 +291,7 @@ class xilinx_draw:
             Exception: If no solution is saved
             Exception: If no converter is found
         """
-        if not self._saved_solution:
+        if not self._last_config:
             raise Exception("No solution to draw. Must call solve first.")
 
         system_draw = lo is not None

--- a/adijif/gekko_trans.py
+++ b/adijif/gekko_trans.py
@@ -105,7 +105,7 @@ class gekko_translation:
         elif self.solver == "CPLEX":
             if isinstance(value, (int, float)):
                 return value
-            return self.solution.get_value(value.get_name())
+            return self._solution.get_value(value.get_name())
         else:
             raise Exception(f"Unknown solver {self.solver}")
 

--- a/adijif/jesd.py
+++ b/adijif/jesd.py
@@ -75,7 +75,7 @@ class jesd(metaclass=ABCMeta):
             Dict: Dictionary of JESD parameters
         """
         if solution:  # type: ignore
-            self.solution = solution
+            self._solution = solution
         cfg = {p: getattr(self, p) for p in self._parameters_to_return}
         cfg["jesd_mode"] = self._check_valid_jesd_mode()
         return cfg

--- a/adijif/plls/adf4030.py
+++ b/adijif/plls/adf4030.py
@@ -98,7 +98,7 @@ class adf4030_drawer(object):
         Returns:
             Layout: Diagram layout object
         """
-        if not self._saved_solution:
+        if not self._last_config:
             raise Exception("No solution to draw. Must call solve first")
 
         system_draw = lo is not None
@@ -121,11 +121,11 @@ class adf4030_drawer(object):
 
         # Update node values
         node = self.ic_diagram_node.get_child("R")
-        node.value = str(self._saved_solution["r"])
+        node.value = str(self._last_config["r"])
         node = self.ic_diagram_node.get_child("N")
-        node.value = str(self._saved_solution["n"])
+        node.value = str(self._last_config["n"])
 
-        o_div_value = str(self._saved_solution["o"])
+        o_div_value = str(self._last_config["o"])
 
         o_divs = 0
         output_divs = Node("Output Dividers", ntype="divider_group")
@@ -151,10 +151,10 @@ class adf4030_drawer(object):
             )
             bsync_target_source = b_connection[0]["from"]
             # Connect BSYNC reference to output divider
-            first_key = list(self._saved_solution["output_clocks"].keys())[0]
+            first_key = list(self._last_config["output_clocks"].keys())[0]
             rate = (
-                self._saved_solution["vco"]
-                / self._saved_solution["output_clocks"][first_key]["divider"]
+                self._last_config["vco"]
+                / self._last_config["output_clocks"][first_key]["divider"]
             )
             o_div_node = Node(f"O{o_divs}", ntype="divider")
             o_divs += 1
@@ -171,7 +171,7 @@ class adf4030_drawer(object):
             lo.remove_node(bsync_target.name)
 
         # Add dummy nodes for each output clock since we don't know their actual connections in the system diagram
-        for key, val in self._saved_solution["output_clocks"].items():
+        for key, val in self._last_config["output_clocks"].items():
             o_div_n = Node(f"O{o_divs}", ntype="divider")
             o_divs += 1
             o_div_n.value = str(o_div_value)
@@ -316,7 +316,7 @@ class adf4030(pll, adf4030_drawer):
             )
 
         if solution:
-            self.solution = solution
+            self._solution = solution
 
         config: Dict = {
             "r": self._get_val(self.config["r"]),
@@ -324,7 +324,7 @@ class adf4030(pll, adf4030_drawer):
             "o": self._get_val(self.config["o"]),
         }
 
-        vco = self.solution.get_kpis()["vco_adf4030"]
+        vco = self._solution.get_kpis()["vco_adf4030"]
         config["vco"] = vco
 
         # Outputs
@@ -338,7 +338,7 @@ class adf4030(pll, adf4030_drawer):
 
         config["output_clocks"] = output_config
 
-        self._saved_solution = config
+        self._last_config = config
 
         return config
 
@@ -391,7 +391,7 @@ class adf4030(pll, adf4030_drawer):
             ]
         )
 
-    def _setup(self, input_ref: Union[int, clockc]) -> None:
+    def setup_constraints(self, input_ref: Union[int, clockc]) -> None:
         # For integer/float values, validate frequency range
         if isinstance(input_ref, (float, int)):
             assert self.input_freq_max >= input_ref >= self.input_freq_min, (
@@ -404,7 +404,7 @@ class adf4030(pll, adf4030_drawer):
 
         self._clk_names = []  # List of clock names to be generated
 
-    def _get_clock_constraint(
+    def request_clock_constraint(
         self, clk_name: str
     ) -> Union[int, float, CpoExpr, GK_Intermediate]:
         """Get abstract clock output.
@@ -490,7 +490,7 @@ class adf4030(pll, adf4030_drawer):
         assert len(out_freq) == 1, (
             "Only one output clock supported for ADF4030 since it only has one output divider"
         )
-        self._setup(ref_in)
+        self.setup_constraints(ref_in)
         self._clk_names = clk_names
 
         for freq in out_freq:

--- a/adijif/plls/adf4371.py
+++ b/adijif/plls/adf4371.py
@@ -74,7 +74,7 @@ class adf4371_drawer(object):
         Raises:
             Exception: If solve hasn't been called yet
         """
-        if not self._saved_solution:
+        if not self._last_config:
             raise Exception("No solution to draw. Must call solve first")
 
         system_draw = lo is not None
@@ -93,20 +93,20 @@ class adf4371_drawer(object):
 
         # Update node values from the saved solution.
         self.ic_diagram_node.get_child("D").value = str(
-            self._saved_solution["d"]
+            self._last_config["d"]
         )
         self.ic_diagram_node.get_child("R").value = str(
-            self._saved_solution["r"]
+            self._last_config["r"]
         )
         self.ic_diagram_node.get_child("N").value = str(
-            self._saved_solution["int"]
+            self._last_config["int"]
         )
 
         output_dividers = self.ic_diagram_node.get_child("Output Dividers")
         rf_div = output_dividers.get_child("RF_DIV")
-        rf_div.value = str(self._saved_solution["rf_div"])
+        rf_div.value = str(self._last_config["rf_div"])
 
-        for key, val in self._saved_solution.get("output_clocks", {}).items():
+        for key, val in self._last_config.get("output_clocks", {}).items():
             clk_node = Node(key, ntype="dummy")
             lo.add_node(clk_node)
             lo.add_connection(
@@ -311,7 +311,7 @@ class adf4371(pll, adf4371_drawer):
             )
 
         if solution:
-            self.solution = solution
+            self._solution = solution
 
         config: Dict = {
             "d": self._get_val(self.config["d"]),
@@ -334,7 +334,7 @@ class adf4371(pll, adf4371_drawer):
         else:
             config["prescaler"] = "4/5"
 
-        vco = self.solution.get_kpis()["vco"]
+        vco = self._solution.get_kpis()["vco"]
         config["rf_out_frequency"] = vco / config["rf_div"]
         config["rf_out_frequency"] = tround(config["rf_out_frequency"])
 
@@ -346,7 +346,7 @@ class adf4371(pll, adf4371_drawer):
             }
         config["output_clocks"] = output_clocks
 
-        self._saved_solution = config
+        self._last_config = config
 
         return config
 
@@ -525,7 +525,7 @@ class adf4371(pll, adf4371_drawer):
             ]
         )
 
-    def _setup(self, input_ref: int) -> None:
+    def setup_constraints(self, input_ref: int) -> None:
         if isinstance(input_ref, (float, int)):
             assert self.input_freq_max >= input_ref >= self.input_freq_min, (
                 "Input frequency out of range"
@@ -534,7 +534,7 @@ class adf4371(pll, adf4371_drawer):
         # Setup clock chip internal constraints
         self._setup_solver_constraints(input_ref)
 
-    def _get_clock_constraint(
+    def request_clock_constraint(
         self, clk_name: str
     ) -> Union[int, float, CpoExpr, GK_Intermediate]:
         """Get abstract clock output.
@@ -565,7 +565,7 @@ class adf4371(pll, adf4371_drawer):
             out_freq (int): list of required clocks to be output
 
         """
-        self._setup(ref_in)
+        self.setup_constraints(ref_in)
         self._clk_names = ["rf_out"]
 
         self.config["rf_div"] = self._convert_input(self.rf_div, "rf_div")

--- a/adijif/plls/adf4382.py
+++ b/adijif/plls/adf4382.py
@@ -123,7 +123,7 @@ class adf4382_drawer(object):
         Returns:
             Layout: Diagram layout object
         """
-        if not self._saved_solution:
+        if not self._last_config:
             raise Exception("No solution to draw. Must call solve first")
 
         system_draw = lo is not None
@@ -147,17 +147,17 @@ class adf4382_drawer(object):
 
         # Update node values
         node = self.ic_diagram_node.get_child("D")
-        node.value = str(self._saved_solution["d"])
+        node.value = str(self._last_config["d"])
         node = self.ic_diagram_node.get_child("R")
-        node.value = str(self._saved_solution["r"])
+        node.value = str(self._last_config["r"])
         node = self.ic_diagram_node.get_child("N")
-        node.value = str(self._saved_solution["n"])
+        node.value = str(self._last_config["n"])
 
         output_dividers = self.ic_diagram_node.get_child("Output Dividers")
         od_node = output_dividers.get_child("O")
-        od_node.value = str(self._saved_solution["o"])
+        od_node.value = str(self._last_config["o"])
 
-        for key, val in self._saved_solution.get("output_clocks", {}).items():
+        for key, val in self._last_config.get("output_clocks", {}).items():
             clk_node = Node(key, ntype="dummy")
             lo.add_node(clk_node)
             lo.add_connection(
@@ -432,16 +432,16 @@ class adf4382(pll, adf4382_drawer):
             )
 
         if solution:
-            self.solution = solution
+            self._solution = solution
 
         config: Dict = {
             "d": self._get_val(self.config["d"]),
-            # "n": self.solution.get_kpis()["n"],
+            # "n": self._solution.get_kpis()["n"],
             "o": self._get_val(self.config["o"]),
             "r": self._get_val(self.config["r"]),
         }
         if isinstance(self._n, list):
-            config["n"] = self.solution.get_kpis()["n"]
+            config["n"] = self._solution.get_kpis()["n"]
         else:
             config["n"] = self._n
 
@@ -466,7 +466,7 @@ class adf4382(pll, adf4382_drawer):
             config["n_int"] = self._get_val(self.config["n_int"])
             config["EFM3_MODE"] = self._get_val(self.config["EFM3_MODE"])
 
-        vco = self.solution.get_kpis()["vco"]
+        vco = self._solution.get_kpis()["vco"]
         config["rf_out_frequency"] = vco / config["o"]
         config["vco"] = vco
 
@@ -478,7 +478,7 @@ class adf4382(pll, adf4382_drawer):
             }
         config["output_clocks"] = output_config
 
-        self._saved_solution = config
+        self._last_config = config
 
         return config
 
@@ -730,7 +730,7 @@ class adf4382(pll, adf4382_drawer):
             1 / self.config["n"], sense="max", tier=1, name="adf4382.n_min"
         )
 
-    def _setup(self, input_ref: int) -> None:
+    def setup_constraints(self, input_ref: int) -> None:
         if isinstance(input_ref, (float, int)):
             assert self.input_freq_max >= input_ref >= self.input_freq_min, (
                 "Input frequency out of range"
@@ -739,7 +739,7 @@ class adf4382(pll, adf4382_drawer):
         # Setup clock chip internal constraints
         self._setup_solver_constraints(input_ref)
 
-    def _get_clock_constraint(
+    def request_clock_constraint(
         self, clk_name: str
     ) -> Union[int, float, CpoExpr, GK_Intermediate]:
         """Get abstract clock output.
@@ -772,7 +772,7 @@ class adf4382(pll, adf4382_drawer):
             out_freq (int): list of required clocks to be output
 
         """
-        self._setup(ref_in)
+        self.setup_constraints(ref_in)
         self._clk_names = ["rf_out"]
 
         self._add_equation([self.config["o"] * out_freq == self.config["vco"]])

--- a/adijif/plls/pll.py
+++ b/adijif/plls/pll.py
@@ -68,7 +68,7 @@ class pll(core, gekko_translation, metaclass=ABCMeta):
     def _solve_cplex(self) -> CpoSolveResult:
         apply_objectives(self.model, self.solver, self._objectives)
         self.model.export_model()
-        self.solution = self.model.solve(
+        self._solution = self.model.solve(
             # Workers=1,
             # agent="local",
             # SearchType="DepthFirst",
@@ -76,9 +76,9 @@ class pll(core, gekko_translation, metaclass=ABCMeta):
             # OptimalityTolerance=1e-12,
             # RelativeOptimalityTolerance=1e-12,
         )
-        if self.solution.solve_status not in ["Feasible", "Optimal"]:
+        if self._solution.solve_status not in ["Feasible", "Optimal"]:
             raise Exception("Solution Not Found")
-        return self.solution
+        return self._solution
 
     def solve(self) -> Union[None, CpoSolveResult]:
         """Local solve method for clock model.

--- a/adijif/sys/s_plls.py
+++ b/adijif/sys/s_plls.py
@@ -79,7 +79,7 @@ class SystemPLL:
     def _get_ref_clock(
         self, conv: convc, config: dict, clock_names: List[str]
     ) -> Tuple[dict, List[str]]:
-        config[f"{conv.name}_ref_clk"] = self.clock._get_clock_constraint(
+        config[f"{conv.name}_ref_clk"] = self.clock.request_clock_constraint(
             f"{conv.name}_ref_clk"
         )
         clock_names.append(f"{conv.name}_ref_clk")
@@ -102,7 +102,7 @@ class SystemPLL:
             Tuple of updated config dictionary and clock names list
         """
         config[f"{pll.name}_bsync_reference"] = (
-            self.clock._get_clock_constraint(f"{pll.name}_bsync_reference")
+            self.clock.request_clock_constraint(f"{pll.name}_bsync_reference")
         )
         clock_names.append(f"{pll.name}_bsync_reference")
         return config, clock_names
@@ -118,7 +118,7 @@ class SystemPLL:
             names = conv._nested
             for name in names:
                 config[f"{name}_fpga_ref_clk"] = (
-                    self.clock._get_clock_constraint(
+                    self.clock.request_clock_constraint(
                         f"{self.fpga.name}_{name}_ref_clk"
                     )
                 )
@@ -127,7 +127,7 @@ class SystemPLL:
 
                 if need_separate_link_clock:
                     config[f"{name}_fpga_device_clk"] = (
-                        self.clock._get_clock_constraint(
+                        self.clock.request_clock_constraint(
                             f"{self.fpga.name}_{name}_device_clk"
                         )
                     )
@@ -135,7 +135,7 @@ class SystemPLL:
 
         else:
             config[f"{conv.name}_fpga_ref_clk"] = (
-                self.clock._get_clock_constraint(
+                self.clock.request_clock_constraint(
                     f"{self.fpga.name}_{conv.name}_ref_clk"
                 )
             )
@@ -144,7 +144,7 @@ class SystemPLL:
 
             if need_separate_link_clock:
                 config[f"{conv.name}_fpga_device_clk"] = (
-                    self.clock._get_clock_constraint(
+                    self.clock.request_clock_constraint(
                         f"{self.fpga.name}_{conv.name}_device_clk"
                     )
                 )
@@ -159,7 +159,7 @@ class SystemPLL:
         if self._plls_sysref:
             for pll in self._plls_sysref:
                 if name in pll._connected_to_output:
-                    config[f"{name}_sysref"] = pll._get_clock_constraint(
+                    config[f"{name}_sysref"] = pll.request_clock_constraint(
                         f"{name}_sysref"
                     )
                     clock_names.append(f"{name}_sysref")
@@ -180,7 +180,7 @@ class SystemPLL:
                 )
                 if not found:
                     # Use clock chip for SYSREF
-                    config[f"{name}_sysref"] = self.clock._get_clock_constraint(
+                    config[f"{name}_sysref"] = self.clock.request_clock_constraint(
                         f"{name}_sysref"
                     )
                     clock_names.append(f"{name}_sysref")
@@ -191,7 +191,7 @@ class SystemPLL:
             if not found:
                 # Use clock chip for SYSREF
                 config[f"{conv.name}_sysref"] = (
-                    self.clock._get_clock_constraint(f"{conv.name}_sysref")
+                    self.clock.request_clock_constraint(f"{conv.name}_sysref")
                 )
                 clock_names.append(f"{conv.name}_sysref")
         return config, clock_names

--- a/adijif/system.py
+++ b/adijif/system.py
@@ -36,7 +36,7 @@ class system(SystemPLL, system_draw):
 
     Debug_Solver = False
     solver = "CPLEX"
-    solution = None
+    _solution = None
 
     _plls = []
     _initialized = False
@@ -243,7 +243,7 @@ class system(SystemPLL, system_draw):
         Returns:
             Dict: Dictionary containing all clocking configurations of all components
         """
-        cfg = {"clock": self.clock.get_config(self.solution), "converter": []}
+        cfg = {"clock": self.clock.get_config(self._solution), "converter": []}
 
         c = (
             self.converter
@@ -258,13 +258,13 @@ class system(SystemPLL, system_draw):
                         f"{self.fpga.name}_{name}_ref_clk"
                     ]["rate"]
                     cfg["fpga_" + name] = self.fpga.get_config(
-                        solution=self.solution,
+                        solution=self._solution,
                         converter=getattr(conv, name),
                         fpga_ref=clk_ref,
                     )
-                    cfg["converter"] = conv.get_config(self.solution)  # type: ignore
+                    cfg["converter"] = conv.get_config(self._solution)  # type: ignore
                     cfg["jesd_" + name] = getattr(conv, name).get_jesd_config(
-                        self.solution
+                        self._solution
                     )
                     if getattr(conv, name).datapath:
                         cfg["datapath_" + name] = getattr(
@@ -275,19 +275,19 @@ class system(SystemPLL, system_draw):
                     f"{self.fpga.name}_{conv.name}_ref_clk"
                 ]["rate"]
                 cfg["fpga_" + conv.name] = self.fpga.get_config(
-                    solution=self.solution, converter=conv, fpga_ref=clk_ref
+                    solution=self._solution, converter=conv, fpga_ref=clk_ref
                 )
-                cfg["converter_" + conv.name] = conv.get_config(self.solution)
-                cfg["jesd_" + conv.name] = conv.get_jesd_config(self.solution)
+                cfg["converter_" + conv.name] = conv.get_config(self._solution)
+                cfg["jesd_" + conv.name] = conv.get_jesd_config(self._solution)
 
         # Collect PLLs driving converter sampling clock configs
         for pll in self._plls:
-            cfg["clock_ext_pll_" + pll.name] = pll.get_config(self.solution)
+            cfg["clock_ext_pll_" + pll.name] = pll.get_config(self._solution)
 
         # Collect PLLs driving sysref clocks configurations.
         for pll in self._plls_sysref:
             cfg["clock_ext_pll_sysref_" + pll.name] = pll.get_config(
-                self.solution
+                self._solution
             )
         return cfg
 
@@ -357,9 +357,9 @@ class system(SystemPLL, system_draw):
         ll = "Normal" if self.Debug_Solver else "Quiet"
         wl = 0  # WarningLevel 0-off 3-all warnings
         # self.model.export_model()
-        self.solution = self.model.solve(LogVerbosity=ll, WarningLevel=wl)
-        # self.solution.print_solution()
-        if not self.solution.is_solution():
+        self._solution = self.model.solve(LogVerbosity=ll, WarningLevel=wl)
+        # self._solution.print_solution()
+        if not self._solution.is_solution():
             raise Exception("No solution found")
 
     def solve(
@@ -490,7 +490,7 @@ class system(SystemPLL, system_draw):
             )
 
             # Setup clock chip
-            self.clock._setup(self.vcxo)
+            self.clock.setup_constraints(self.vcxo)
 
             # Initialize loop variables for clock constraints
             self.fpga.configs = []  # reset
@@ -506,9 +506,9 @@ class system(SystemPLL, system_draw):
                     config, clock_names = self._get_ref_clock(
                         pll, config, clock_names
                     )
-                    pll._setup(config[pll.name + "_ref_clk"])
+                    pll.setup_constraints(config[pll.name + "_ref_clk"])
                 else:  # Assume its a int or float constant or arb_source
-                    pll._setup(pll._ref)
+                    pll.setup_constraints(pll._ref)
                 # Connect BSYNC reference if applicable
                 if hasattr(pll, "_bsync_reference") and pll._bsync_reference:
                     if isinstance(pll._bsync_reference, clockc):
@@ -577,7 +577,7 @@ class system(SystemPLL, system_draw):
                             config, clock_names = self._get_ref_clock(
                                 pll, config, clock_names
                             )
-                            pll._setup(config[pll.name + "_ref_clk"])
+                            pll.setup_constraints(config[pll.name + "_ref_clk"])
 
                         else:
                             assert isinstance(
@@ -585,11 +585,11 @@ class system(SystemPLL, system_draw):
                             ), (
                                 "PLL reference must be clock object, constant, range, or arb_source"
                             )
-                            pll._setup(pll._ref)
+                            pll.setup_constraints(pll._ref)
 
                         # Give PLL's output as converter's reference
                         config[conv.name + "_ref_clk_from_ext_pll"] = (
-                            pll._get_clock_constraint(
+                            pll.request_clock_constraint(
                                 conv.name + "_ref_clk_from_ext_pll"
                             )
                         )

--- a/examples/synchrona.py
+++ b/examples/synchrona.py
@@ -5,7 +5,7 @@ vcxo = adijif.range(100000000,150000000,25000000,"vcxo")
 
 clk = adijif.hmc7044(solver="gekko")
 
-clk.vxco_doubler = 2
+clk.vcxo_doubler = 2
 
 output_clocks = [1e9, 500e6, 7.8125e6]
 output_clocks = list(map(int, output_clocks))  # force to be ints

--- a/tests/test_drawing_coverage.py
+++ b/tests/test_drawing_coverage.py
@@ -61,7 +61,7 @@ def test_xilinx_draw_gtxe2_standalone():
     fpga.setup_by_dev_kit_name("zc706")
 
     # Mock solution and solver state needed for draw
-    fpga._saved_solution = True
+    fpga._last_config = True
     # _draw_phy expects FPGA_REF and LINK_OUT_REF in config["clocks"] if converter is None
     fpga.config = {
         "clocks": {
@@ -96,7 +96,7 @@ def test_xilinx_draw_gtye5_standalone():
     fpga = adijif.xilinx()
     fpga.setup_by_dev_kit_name("vck190")
 
-    fpga._saved_solution = True
+    fpga._last_config = True
     fpga.config = {
         "clocks": {
             "FPGA_REF": 125e6,
@@ -126,7 +126,7 @@ def test_ad9084_draw_standalone():
     """Verify AD9084 standalone drawing logic."""
     conv = adijif.ad9084_rx()
 
-    conv._saved_solution = True
+    conv._last_config = True
 
     # ad9084_draw.py L142 uses clocks[f"{name}_ref_clk"] where name is self.name
     # and it seems it expects "AD9084" for the standalone path if it's not 9088

--- a/tests/test_ltc_coverage.py
+++ b/tests/test_ltc_coverage.py
@@ -76,5 +76,5 @@ def test_ltc6952_solve_smoke():
     clk.solve()
     config = clk.get_config()
     assert config is not None
-    assert "VCO" in config
-    assert config["VCO"] >= 1e9
+    assert "vco" in config
+    assert config["vco"] >= 1e9

--- a/tests/test_xilinx_pll.py
+++ b/tests/test_xilinx_pll.py
@@ -31,7 +31,7 @@ def test_7s_pll(pll, out_clock):
     print(ss_plls.model.export_model())
 
     ss_plls.solve()
-    print(ss_plls.solution.print_solution())
+    print(ss_plls._solution.print_solution())
 
     cfg = ss_plls.get_config(config, cnv, in_clock)
     pprint(cfg)
@@ -81,7 +81,7 @@ def test_us_pll(pll, out_clock):
     print(us_plls.model.export_model())
 
     us_plls.solve()
-    print(us_plls.solution.print_solution())
+    print(us_plls._solution.print_solution())
 
     cfg = us_plls.get_config(config, cnv, in_clock)
     pprint(cfg)


### PR DESCRIPTION
## Summary
- Cleans up naming inconsistencies and public/private boundary violations across the clock subsystem (and extends the same renames to PLLs, FPGAs, and converters where the affected names are shared).
- Decouples `clock.solve()` from `get_config()`/`draw()` — calling `solve()` now best-effort caches the config so `draw()` works without an explicit intermediate `get_config()` call.
- Documents the canonical standalone vs system-mode call orders on the `clock` base class.

### Renames
| Old | New | Notes |
|---|---|---|
| `vxco_doubler` | `vcxo_doubler` | HMC7044 property typo |
| `"VCO"` config key | `"vco"` | LTC6952 was the only inconsistent one |
| `self.solution` | `self._solution` | 50+ sites across clocks, PLLs, FPGAs, converters |
| `_saved_solution` | `_last_config` | Clearer: it's the cached config dict, not the raw solver result |
| `_setup(...)` | `setup_constraints(...)` | Called from `system.py`; public-by-use |
| `_get_clock_constraint(...)` | `request_clock_constraint(...)` | Same — public-by-use |

### Other changes
- `AD9523._setup_solver_constraints` now uses `clock._parse_reference()` (was duplicating the inline VCXO parsing logic with a dead `vcxo_set` config key).
- `XilinxPLL` / `PLLCommon`: the `solution` `@property` that delegated child-PLL reads to the parent was renamed to `_solution`, with the local-storage attribute moved to `_local_solution`. Without this, transceiver `get_config` would have read `None` after the bulk rename.
- AD9545's diverging multi-reference API (`ref0..ref3`, per-input/per-output dividers) is intentionally out of scope; only the renamed methods are touched there.

## Test plan
- [x] Static grep audit: zero hits for `vxco_doubler`, `_saved_solution`, `_get_clock_constraint`, bare `self.solution`, `._setup(`, or `"VCO"` config key.
- [x] `pytest tests/test_clocks*.py tests/test_ltc_coverage.py tests/test_draw*.py` — 83 passed (matches pre-change baseline).
- [x] `pytest tests/test_system.py tests/test_daq2.py tests/test_fmcdaq3.py tests/test_ad9081.py tests/test_ad9084.py` — 91 passed, 2 skipped, 1 xfailed.
- [x] Full suite (excluding `test_mcp_server_coverage` / `tests/tools` env-dependent suites): 510 passed; the 2 `test_adf4382_frac_datasheet_*` failures are pre-existing (`mpmath` module missing in this env), verified unchanged by `git stash` against base.
- [x] REPL spot-check: `clk = adijif.hmc7044(); clk.vcxo_doubler = 2; clk.set_requested_clocks(...); clk.solve(); clk.draw()` works without an intermediate `get_config()`; `cfg["vco"]` present.