### PR TITLE
docs(clocks): add docstrings for renamed setup_constraints and bf helpers

### DIFF
--- a/adijif/clocks/ad9523.py
+++ b/adijif/clocks/ad9523.py
@@ -245,10 +245,22 @@ class ad9523_1(ad9523_1_bf):
         )
 
     def setup_constraints(self, vcxo: int) -> None:
-        # Setup clock chip internal constraints
+        """Wire solver variables and PLL constraints for the chip.
 
+        Public entry point used by both standalone mode (called from
+        ``set_requested_clocks``) and system mode (called from
+        ``adijif.system.initialize``). Must run before any
+        ``request_clock_constraint`` call or ``solve``.
+
+        Args:
+            vcxo (int): VCXO frequency in hertz, range expression, or
+                arb_source callable.
+
+        Raises:
+            Exception: VCXO doubler is enabled but ``vcxo`` is not a
+                plain ``int``.
+        """
         # FIXME: ADD SPLIT m1 configuration support
-
         if self.use_vcxo_double and not isinstance(vcxo, int):
             raise Exception("VCXO doubler not supported in this mode TBD")
         if self.use_vcxo_double:

--- a/adijif/clocks/ad9528.py
+++ b/adijif/clocks/ad9528.py
@@ -379,11 +379,18 @@ class ad9528(ad9528_bf):
         )
 
     def setup_constraints(self, vcxo: int) -> None:
-        # Setup clock chip internal constraints
+        """Wire solver variables and PLL constraints for the chip.
 
+        Public entry point used by both standalone mode (called from
+        ``set_requested_clocks``) and system mode (called from
+        ``adijif.system.initialize``). Must run before any
+        ``request_clock_constraint`` call or ``solve``.
+
+        Args:
+            vcxo (int): VCXO frequency in hertz, range expression, or
+                arb_source callable.
+        """
         # FIXME: ADD SPLIT m1 configuration support
-
-        # Setup clock chip internal constraints
         if self.use_vcxo_double:
             vcxo *= 2
         self._setup_solver_constraints(vcxo)

--- a/adijif/clocks/ad9545.py
+++ b/adijif/clocks/ad9545.py
@@ -545,8 +545,24 @@ class ad9545(clock):
                     name=f"ad9545.r{i}_min",
                 )
 
-    def setup_constraints(self, input_refs: List[int], out_freqs: List[int]) -> None:
-        # Setup clock chip internal constraints
+    def setup_constraints(
+        self, input_refs: List[int], out_freqs: List[int]
+    ) -> None:
+        """Wire solver variables and PLL constraints for the chip.
+
+        AD9545 takes lists of multiple references and target outputs
+        rather than a single VCXO, reflecting its 4-input / 10-output
+        topology. Must run before ``solve``.
+
+        Args:
+            input_refs (List[int]): Length-4 list of input reference
+                rates in hertz; 0 marks an unused reference slot.
+            out_freqs (List[int]): Length-10 list of requested output
+                rates in hertz; 0 marks an unused output.
+
+        Raises:
+            Exception: gekko solver is selected (AD9545 is CPLEX-only).
+        """
         if self.solver == "gekko":
             raise Exception("Gekko solver not supported for AD9545")
 

--- a/adijif/clocks/hmc7044.py
+++ b/adijif/clocks/hmc7044.py
@@ -451,11 +451,18 @@ class hmc7044(hmc7044_bf):
         )
 
     def setup_constraints(self, vcxo: int) -> None:
-        # Setup clock chip internal constraints
+        """Wire solver variables and PLL constraints for the chip.
 
+        Public entry point used by both standalone mode (called from
+        ``set_requested_clocks``) and system mode (called from
+        ``adijif.system.initialize``). Must run before any
+        ``request_clock_constraint`` call or ``solve``.
+
+        Args:
+            vcxo (int): VCXO frequency in hertz, range expression, or
+                arb_source callable.
+        """
         # FIXME: ADD SPLIT m1 configuration support
-
-        # Handle vcxo of different types
         vcxo = self._parse_reference(vcxo)
         self._setup_solver_constraints(vcxo)
 

--- a/adijif/clocks/ltc6952.py
+++ b/adijif/clocks/ltc6952.py
@@ -543,11 +543,18 @@ class ltc6952(ltc6952_bf):
         # dividers.
 
     def setup_constraints(self, vcxo: int) -> None:
-        # Setup clock chip internal constraints
+        """Wire solver variables and PLL constraints for the chip.
 
+        Public entry point used by both standalone mode (called from
+        ``set_requested_clocks``) and system mode (called from
+        ``adijif.system.initialize``). Must run before any
+        ``request_clock_constraint`` call or ``solve``.
+
+        Args:
+            vcxo (int): VCXO frequency in hertz, range expression, or
+                arb_source callable.
+        """
         # FIXME: ADD SPLIT m1 configuration support
-
-        # Setup clock chip internal constraints
         vcxo = self._parse_reference(vcxo)
         self._setup_solver_constraints(vcxo)
 

--- a/adijif/clocks/ltc6953.py
+++ b/adijif/clocks/ltc6953.py
@@ -521,6 +521,17 @@ class ltc6953(clock):
         )
 
     def setup_constraints(self, input_ref: int) -> None:
+        """Wire solver variables and divider constraints for the chip.
+
+        Public entry point used by both standalone mode (called from
+        ``set_requested_clocks``) and system mode (called from
+        ``adijif.system.initialize``). Must run before any
+        ``request_clock_constraint`` call or ``solve``.
+
+        Args:
+            input_ref (int): Input reference frequency in hertz, range
+                expression, or arb_source callable.
+        """
         if isinstance(input_ref, (float, int)):
             assert self.input_freq_max >= input_ref >= 0, (
                 "Input frequency out of range"

--- a/adijif/converters/ad9144_bf.py
+++ b/adijif/converters/ad9144_bf.py
@@ -1,3 +1,5 @@
+"""Brute-force AD9144 clock helpers for cross-checking solver output."""
+
 from typing import NoReturn
 
 import numpy as np
@@ -39,6 +41,17 @@ class ad9144_bf(dac):
         return lmfc / 2048, lmfc / 2
 
     def sysref_met(self, sysref_clock, sample_clock) -> None:
+        """Validate that SYSREF is a valid multiple of LMFC.
+
+        Args:
+            sysref_clock: Candidate SYSREF clock rate in hertz.
+            sample_clock: Sample clock rate in hertz (unused; kept for
+                signature parity with sibling brute-force classes).
+
+        Raises:
+            Exception: SYSREF is not a multiple of LMFC, or the ratio
+                LMFC/SYSREF is less than ``2 * input_clock_divider``.
+        """
         if sysref_clock % self.multiframe_clock != 0:
             raise Exception("SYSREF not a multiple of LMFC")
         if (

--- a/adijif/converters/ad9680_bf.py
+++ b/adijif/converters/ad9680_bf.py
@@ -1,3 +1,5 @@
+"""Brute-force AD9680 clock helpers for cross-checking solver output."""
+
 import numpy as np
 
 from adijif.converters.adc import adc
@@ -36,6 +38,17 @@ class ad9680_bf(adc):
         return lmfc / 2048, lmfc / 2
 
     def sysref_met(self, sysref_clock, sample_clock) -> None:
+        """Validate that SYSREF is a valid multiple of LMFC.
+
+        Args:
+            sysref_clock: Candidate SYSREF clock rate in hertz.
+            sample_clock: Sample clock rate in hertz (unused; kept for
+                signature parity with sibling brute-force classes).
+
+        Raises:
+            Exception: SYSREF is not a multiple of LMFC, or the ratio
+                LMFC/SYSREF is less than ``2 * input_clock_divider``.
+        """
         if sysref_clock % self.multiframe_clock != 0:
             raise Exception("SYSREF not a multiple of LMFC")
         if (

--- a/adijif/converters/adrv9009_bf.py
+++ b/adijif/converters/adrv9009_bf.py
@@ -1,3 +1,5 @@
+"""Brute-force ADRV9009 clock helpers for cross-checking solver output."""
+
 import numpy as np
 
 from adijif.converters.converter import converter
@@ -36,6 +38,17 @@ class adrv9009_bf(converter):
         return lmfc / 2048, lmfc / 2
 
     def sysref_met(self, sysref_clock, sample_clock) -> None:
+        """Validate that SYSREF is a valid multiple of LMFC.
+
+        Args:
+            sysref_clock: Candidate SYSREF clock rate in hertz.
+            sample_clock: Sample clock rate in hertz (unused; kept for
+                signature parity with sibling brute-force classes).
+
+        Raises:
+            Exception: SYSREF is not a multiple of LMFC, or the ratio
+                LMFC/SYSREF is less than ``2 * input_clock_divider``.
+        """
         if sysref_clock % self.multiframe_clock != 0:
             raise Exception("SYSREF not a multiple of LMFC")
         if (

--- a/adijif/fpgas/xilinx/__init__.py
+++ b/adijif/fpgas/xilinx/__init__.py
@@ -874,10 +874,12 @@ class xilinx(xilinx_bf, xilinx_draw):
 
         Args:
             converter (conv): Converter object(s) connected to FPGA
-            fpga_ref (int,GKVariable, GK_Intermediate, GK_Operators, CpoIntVar):
-                Reference clock for FPGA
-            link_out_ref (None, int,GKVariable, GK_Intermediate, GK_Operators,
-                CpoIntVar): Link layer output reference clock
+            fpga_ref: Reference clock for FPGA. ``int`` or one of
+                ``GKVariable``, ``GK_Intermediate``, ``GK_Operators``,
+                ``CpoIntVar`` for a solver expression.
+            link_out_ref: Link layer output reference clock. Same type
+                set as ``fpga_ref``, or ``None`` to omit the separate
+                link clock.
 
         Returns:
             Dict: Dictionary of clocking rates and dividers for configuration

--- a/adijif/plls/adf4030.py
+++ b/adijif/plls/adf4030.py
@@ -392,14 +392,24 @@ class adf4030(pll, adf4030_drawer):
         )
 
     def setup_constraints(self, input_ref: Union[int, clockc]) -> None:
-        # For integer/float values, validate frequency range
+        """Wire solver variables and PLL constraints for the part.
+
+        Public entry point used by system mode (called from
+        ``adijif.system.initialize``) and by standalone callers before
+        ``solve``.
+
+        Args:
+            input_ref (Union[int, clockc]): Reference frequency in
+                hertz or a clock-object placeholder whose value is
+                resolved by the solver.
+        """
         if isinstance(input_ref, (float, int)):
             assert self.input_freq_max >= input_ref >= self.input_freq_min, (
                 "Input frequency out of range"
             )
 
-        # Setup clock chip internal constraints (this converts input_ref to solver var
-        # and adds constraints for range/arb_source types)
+        # Converts input_ref to solver var and adds constraints for
+        # range/arb_source types.
         self._setup_solver_constraints(input_ref)
 
         self._clk_names = []  # List of clock names to be generated
@@ -443,7 +453,9 @@ class adf4030(pll, adf4030_drawer):
         PLL.
 
         Args:
-            clk (Union[clockc, int, float]): Clock object or frequency in hertz to be added as BSYNC reference
+            bsync_ref (Union[int, float, CpoExpr, GK_Intermediate]):
+                BSYNC reference rate in hertz, or a solver expression
+                resolving to one.
         """
         self._add_equation(self.config["vco"] / self.config["o"] == bsync_ref)
         if isinstance(bsync_ref, (float, int)):

--- a/adijif/plls/adf4371.py
+++ b/adijif/plls/adf4371.py
@@ -526,6 +526,16 @@ class adf4371(pll, adf4371_drawer):
         )
 
     def setup_constraints(self, input_ref: int) -> None:
+        """Wire solver variables and PLL constraints for the part.
+
+        Public entry point used by system mode (called from
+        ``adijif.system.initialize``) and by standalone callers before
+        ``solve``.
+
+        Args:
+            input_ref (int): Reference frequency in hertz, range
+                expression, or arb_source callable.
+        """
         if isinstance(input_ref, (float, int)):
             assert self.input_freq_max >= input_ref >= self.input_freq_min, (
                 "Input frequency out of range"

--- a/adijif/plls/adf4382.py
+++ b/adijif/plls/adf4382.py
@@ -731,6 +731,16 @@ class adf4382(pll, adf4382_drawer):
         )
 
     def setup_constraints(self, input_ref: int) -> None:
+        """Wire solver variables and PLL constraints for the part.
+
+        Public entry point used by system mode (called from
+        ``adijif.system.initialize``) and by standalone callers before
+        ``solve``.
+
+        Args:
+            input_ref (int): Reference frequency in hertz, range
+                expression, or arb_source callable.
+        """
         if isinstance(input_ref, (float, int)):
             assert self.input_freq_max >= input_ref >= self.input_freq_min, (
                 "Input frequency out of range"


### PR DESCRIPTION
## Summary
- Restores docstring coverage on the `setup_constraints` methods (formerly `_setup`) across every clock chip and PLL. They lost coverage in #241 when promoted to public-by-name — `D102` (missing docstring in public method) is permitted on underscored methods but applies once the underscore is gone.
- Adds module docstrings and `sysref_met` docstrings on the brute-force helpers (`ad9144_bf`, `ad9680_bf`, `adrv9009_bf`).
- Fixes two pre-existing `D417` arg-description mismatches: `_setup_quad_tile` (xilinx) and `_setup_bsync_reference` (adf4030 — arg was named `bsync_ref` but docstring documented `clk`).

## Test plan
- [x] `ruff check adijif tests noxfile.py` — clean (was 17 errors).
- [x] Full pytest suite — 510 passed; the 2 `test_adf4382_frac_datasheet_*` failures are pre-existing `mpmath`-missing env issues, identical to the #241 baseline.