### PR TITLE
refactor(explorer): consistent header/section/theme across pages

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,9 @@
+[theme]
+primaryColor = "#F58220"
+backgroundColor = "#FFFFFF"
+secondaryBackgroundColor = "#F5F6F8"
+textColor = "#262730"
+font = "sans serif"
+
+[theme.dark]
+primaryColor = "#F58220"

--- a/adijif/tools/explorer/src/pages/adf4030_system_designer.py
+++ b/adijif/tools/explorer/src/pages/adf4030_system_designer.py
@@ -12,6 +12,24 @@ from ..utils import Page
 class Adf4030SystemDesigner(Page):
     """ADF4030 architecture designer with partition + diagram output."""
 
+    name = "ADF4030 System Designer"
+    tagline = (
+        "Plan an Aion (ADF4030) clock-distribution system: pick an "
+        "architecture and the per-Unit-Board sizing, then view the "
+        "partition summary and topology diagram."
+    )
+    help_text = (
+        "The ADF4030 (Aion) is a 10-channel SYSREF synchronizer. "
+        "Once a system needs more channels than one Aion provides, "
+        "the Aions must be chained together; this page computes the "
+        "partition (how many Aions per FPGA, how many Apollos per "
+        "Aion, how many Unit Boards) for the chosen architecture and "
+        "renders a topology diagram.\n\n"
+        "Use the **Diagram scope** radio to switch between a single "
+        "Unit Board view and the full system. At large N the system "
+        "view can take a while to render."
+    )
+
     def __init__(self, state: Optional[object]) -> None:
         """Initialize the page.
 
@@ -22,12 +40,7 @@ class Adf4030SystemDesigner(Page):
 
     def write(self) -> None:
         """Render the page."""
-        st.title("ADF4030 System Designer")
-        st.write(
-            "Plan an Aion (ADF4030) clock-distribution system: pick "
-            "an architecture and the per-Unit-Board sizing, then view "
-            "the partition summary and topology diagram."
-        )
+        self.header()
 
         col1, col2 = st.columns(2)
         with col1:
@@ -71,8 +84,8 @@ class Adf4030SystemDesigner(Page):
             st.error(str(e))
             return
 
-        st.subheader("Partition summary")
+        self.section("Partition summary")
         st.text(arch.summary)
-        st.subheader("Diagram")
+        self.section("Diagram")
         svg = arch.draw(scope=scope)
         st.components.v1.html(svg, height=600, scrolling=True)

--- a/adijif/tools/explorer/src/pages/clockconfigurator.py
+++ b/adijif/tools/explorer/src/pages/clockconfigurator.py
@@ -28,6 +28,22 @@ sp.insert(0, "hmc7044")
 class ClockConfigurator(Page):
     """Clock configurator tool page."""
 
+    name = "Clock Configurator"
+    tagline = (
+        "Configure an ADI clock distribution chip and inspect the "
+        "solved divider tree."
+    )
+    help_text = (
+        "Pick a clock chip, set the reference rate and desired output "
+        "frequencies, and the solver finds a divider configuration that "
+        "satisfies the chip's internal constraints (PFD/VCO ranges, "
+        "divider sets, etc.).\n\n"
+        "Use the **Internal configuration** section to constrain "
+        "dividers manually if the default search space is too broad.\n\n"
+        "Found configurations can be exported as a device-tree fragment "
+        "where the chip model supports it."
+    )
+
     def __init__(self, state: Optional[object]) -> None:
         """Initialize clock configurator page.
 
@@ -38,7 +54,7 @@ class ClockConfigurator(Page):
 
     def write(self) -> None:
         """Render the clock configurator page."""
-        st.title("Clock Configurator")
+        self.header()
         # sp = ["hmc7044"]
 
         sb = st.selectbox(
@@ -48,48 +64,47 @@ class ClockConfigurator(Page):
             key="clock_part_select",
         )
 
-        with st.expander("Clock Inputs and Outputs", expanded=True):
-            reference = st.number_input(
-                "Reference Clock",
-                value=125000000,
-                min_value=1,
-                max_value=int(1e9),
-                step=1,
-                key="clock_reference_input",
-            )
+        self.section("Inputs")
+        reference = st.number_input(
+            "Reference clock (Hz)",
+            value=125000000,
+            min_value=1,
+            max_value=int(1e9),
+            step=1,
+            key="clock_reference_input",
+        )
 
-            with st.container(border=True):
-                num_outputs = st.number_input(
-                    "Number of Clock Outputs",
-                    value=2,
-                    min_value=1,
-                    max_value=10,
-                    step=1,
-                    key="clock_num_outputs_input",
+        num_outputs = st.number_input(
+            "Number of output clocks",
+            value=2,
+            min_value=1,
+            max_value=10,
+            step=1,
+            key="clock_num_outputs_input",
+        )
+        outputs = []
+        output_names = []
+        for i in range(num_outputs):
+            columns = st.columns(2)
+            with columns[0]:
+                outputs.append(
+                    st.number_input(
+                        f"Output {i + 1} frequency (Hz)",
+                        value=125000000,
+                        min_value=1,
+                        max_value=int(1e9),
+                        step=1,
+                        key=f"clock_output_{i}_input",
+                    )
                 )
-                outputs = []
-                output_names = []
-                for i in range(num_outputs):
-                    columns = st.columns(2)
-                    with columns[0]:
-                        outputs.append(
-                            st.number_input(
-                                f"Output Clock {i + 1}",
-                                value=125000000,
-                                min_value=1,
-                                max_value=int(1e9),
-                                step=1,
-                                key=f"clock_output_{i}_input",
-                            )
-                        )
-                    with columns[1]:
-                        output_names.append(
-                            st.text_input(
-                                f"Output Clock Name {i + 1}",
-                                f"CLK{i + 1}",
-                                key=f"clock_output_{i}_name_input",
-                            )
-                        )
+            with columns[1]:
+                output_names.append(
+                    st.text_input(
+                        f"Output {i + 1} name",
+                        f"CLK{i + 1}",
+                        key=f"clock_output_{i}_name_input",
+                    )
+                )
 
         import adijif  # noqa: F401
 
@@ -109,27 +124,26 @@ class ClockConfigurator(Page):
             prop_and_options[prop] = getattr(class_def, prop + "_available")
 
         selections = {}
-        with st.expander("Internal Clock Configuration"):
-            for prop, options in prop_and_options.items():
-                prop_docstring = getattr(class_def, prop).__doc__
-                with st.container(border=True):
-                    label = f"""
-                    {prop} : {prop_docstring}"""
-                    if len(options) > 16:
-                        v_min, v_max = min(options), max(options)
-                        start, end = st.select_slider(
-                            label,
-                            options,
-                            value=(v_min, v_max),
-                            key=f"clock_internal_{prop}_slider",
-                        )
-                        selections[prop] = {"start": start, "end": end}
-                    else:
-                        selections[prop] = st.multiselect(
-                            label,
-                            options,
-                            key=f"clock_internal_{prop}_multiselect",
-                        )
+        self.section("Internal configuration")
+        for prop, options in prop_and_options.items():
+            prop_docstring = getattr(class_def, prop).__doc__
+            label = f"""
+            {prop} : {prop_docstring}"""
+            if len(options) > 16:
+                v_min, v_max = min(options), max(options)
+                start, end = st.select_slider(
+                    label,
+                    options,
+                    value=(v_min, v_max),
+                    key=f"clock_internal_{prop}_slider",
+                )
+                selections[prop] = {"start": start, "end": end}
+            else:
+                selections[prop] = st.multiselect(
+                    label,
+                    options,
+                    key=f"clock_internal_{prop}_multiselect",
+                )
 
         clk_chip = eval(f"adijif.{sb}()")  # noqa: S307
 
@@ -197,14 +211,14 @@ class ClockConfigurator(Page):
 
             warning = True
 
-        with st.expander("Found Configuration", expanded=True):
-            if warning:
-                st.warning("No valid configuration found")
-            else:
-                st.write(config_out)
+        self.section("Result")
+        if warning:
+            st.warning("No valid configuration found")
+        else:
+            st.write(config_out)
 
-        with st.expander("Diagram", expanded=True):
-            if warning:
-                st.warning("No diagram to show")
-            else:
-                st.image(image_data, width="stretch")
+        self.section("Diagram")
+        if warning:
+            st.warning("No diagram to show")
+        else:
+            st.image(image_data, width="stretch")

--- a/adijif/tools/explorer/src/pages/jesdbasic.py
+++ b/adijif/tools/explorer/src/pages/jesdbasic.py
@@ -11,6 +11,18 @@ from ..utils import Page
 class JESDBasic(Page):
     """Basic JESD204 calculator page."""
 
+    name = "Basic JESD204 Calculator"
+    tagline = "Quick lane-rate / overhead calculations for a single JESD204 link."
+    help_text = (
+        "Enter the JESD204 link parameters (L, M, Np, JESD class) "
+        "and the converter sample rate or lane rate; this page "
+        "computes the derived rate and core clock without running "
+        "the full solver.\n\n"
+        "Useful for sanity-checking a mode found in the JESD204 Mode "
+        "Selector or for budgeting transceiver capacity before "
+        "committing to a converter."
+    )
+
     def __init__(self, state: Optional[object]) -> None:
         """Initialize basic JESD204 calculator page.
 
@@ -21,15 +33,12 @@ class JESDBasic(Page):
 
     def write(self) -> None:
         """Render the basic JESD204 calculator page."""
-        st.title("Basic JESD204 Calculator")
-
-        # Horizontal line
-        st.markdown("---")
+        self.header()
 
         # Add int boxes for L, M, Np, JESD Class
         jesd_params, output_table = st.columns(2)
         with jesd_params:
-            st.header("JESD204 Parameters")
+            self.section("JESD204 parameters")
 
             L_c, M_c = st.columns(2)
 
@@ -103,7 +112,7 @@ class JESDBasic(Page):
                 core_clock = lane_rate / 66 * 1e3  # Convert to MHz
 
         with output_table:
-            st.header("Derived Parameters")
+            self.section("Derived parameters")
             df = pd.DataFrame(
                 {
                     "Parameter": [label, "Core Clock (MHz)"],

--- a/adijif/tools/explorer/src/pages/jesdmodeselector.py
+++ b/adijif/tools/explorer/src/pages/jesdmodeselector.py
@@ -18,6 +18,21 @@ from .helpers.jesd import get_jesd_controls, get_valid_jesd_modes
 class JESDModeSelector(Page):
     """JESD204 mode selector tool page."""
 
+    name = "JESD204 Mode Selector"
+    tagline = "Find a JESD204 mode that fits your sample rate and FPGA lane budget."
+    help_text = (
+        "This tool helps you select the appropriate JESD204 mode for "
+        "your application. It supports ADCs, DACs, MxFEs, and "
+        "Transceivers from the ADI portfolio, modeling their JESD204 "
+        "mode tables and the clocking limitations of the individual "
+        "devices.\n\n"
+        "Select a part from the dropdown, configure the datapath "
+        "(decimation/interpolation, converter sample rate), and the "
+        "tool derives the necessary clocks. Filter on JESD204 "
+        "parameters to find a mode that fits.\n\n"
+        "JESD204 settings can be exported as CSV from the table."
+    )
+
     def __init__(self, state: Optional[object]) -> None:
         """Initialize JESD mode selector page.
 
@@ -42,29 +57,7 @@ class JESDModeSelector(Page):
                 pass
         supported_parts = supported_parts_filtered
 
-        st.title("JESD204 Mode Selector")
-
-        @st.dialog("About JESD204 Mode Selector")
-        def help() -> None:
-            """Display help dialog."""
-            st.write(  # noqa: S608
-                "This tool helps you select the appropriate JESD204 mode for "
-                "your application. It supports both ADCs, DACs, MxFEs, and "
-                "Transceivers from the ADI portfolio. Modeling their JESD204 "
-                "mode tables and clocking limitations of the individual "
-                "devices.\n\n"
-                "To use the tool, select a part from the dropdown menu. You "
-                "can then configure the datapath settings such as "
-                "decimation/interpolation and the converter sample rate. The "
-                "tool will derive the necessary clocks for the selected "
-                "configuration. Filter different JESD204 parameters to find a "
-                "suitable mode for your application. The valid modes will be "
-                "displayed in a table, along with the derived settings."
-                "\n\n"
-                "JESD204 settings can be exported as CSV from the table."
-            )
-
-        st.button("Help", on_click=help)
+        self.header()
 
         sb = st.selectbox(
             label="Select a part",
@@ -76,65 +69,65 @@ class JESDModeSelector(Page):
         converter = eval(f"adijif.{sb}()")  # noqa: S307
 
         # Show diagram
-        with st.expander(label="Diagram", expanded=True):
-            if sb not in self.part_images:
-                try:
-                    if converter.converter_type.lower() == "adc":
-                        self.part_images[sb] = draw_adc(converter)
-                        # FIXME: State is not being saved
-                    else:
-                        self.part_images[sb] = draw_dac(converter)
-                except Exception:
-                    # Diagram generation requires a solver (e.g. CPLEX) that
-                    # may not be installed in all environments.
-                    self.part_images[sb] = None
-            if self.part_images[sb]:
-                st.image(self.part_images[sb], width="stretch")
+        self.section("Diagram")
+        if sb not in self.part_images:
+            try:
+                if converter.converter_type.lower() == "adc":
+                    self.part_images[sb] = draw_adc(converter)
+                    # FIXME: State is not being saved
+                else:
+                    self.part_images[sb] = draw_dac(converter)
+            except Exception:
+                # Diagram generation requires a solver (e.g. CPLEX) that
+                # may not be installed in all environments.
+                self.part_images[sb] = None
+        if self.part_images[sb]:
+            st.image(self.part_images[sb], width="stretch")
 
         # Datapath Configuration
-        with st.expander("Datapath Configuration", expanded=True):
-            decimation = gen_datapath(converter)
+        self.section("Datapath configuration")
+        decimation = gen_datapath(converter)
 
-            scalar = st.selectbox(
-                "Units",
-                options=["Hz", "kHz", "MHz", "GHz"],
-                index=3,
-                key="jesd_units_select",
-            )
-            if scalar == "Hz":
-                scalar_value = 1
-                new_default = 1e9
-                min_value = 1
-                max_value = 28e9
-            elif scalar == "kHz":
-                scalar_value = 1e3
-                new_default = 1e6
-                min_value = 100
-                max_value = 28e6
-            elif scalar == "MHz":
-                scalar_value = 1e6
-                new_default = 1e3
-                min_value = 1e3
-                max_value = 28e3
-            elif scalar == "GHz":
-                scalar_value = 1e9
-                new_default = 1
-                min_value = 0.1
-                max_value = 28
+        scalar = st.selectbox(
+            "Units",
+            options=["Hz", "kHz", "MHz", "GHz"],
+            index=3,
+            key="jesd_units_select",
+        )
+        if scalar == "Hz":
+            scalar_value = 1
+            new_default = 1e9
+            min_value = 1
+            max_value = 28e9
+        elif scalar == "kHz":
+            scalar_value = 1e3
+            new_default = 1e6
+            min_value = 100
+            max_value = 28e6
+        elif scalar == "MHz":
+            scalar_value = 1e6
+            new_default = 1e3
+            min_value = 1e3
+            max_value = 28e3
+        elif scalar == "GHz":
+            scalar_value = 1e9
+            new_default = 1
+            min_value = 0.1
+            max_value = 28
 
-            min_value = float(min_value)
-            max_value = float(max_value)
-            new_default = float(new_default)
+        min_value = float(min_value)
+        max_value = float(max_value)
+        new_default = float(new_default)
 
-            converter_rate = st.number_input(
-                f"Converter Rate ({scalar})",
-                value=new_default,
-                min_value=min_value,
-                max_value=max_value,
-                key="jesd_converter_rate_input",
-            )
-            converter_rate = scalar_value * converter_rate
-            converter.sample_clock = converter_rate / decimation
+        converter_rate = st.number_input(
+            f"Converter Rate ({scalar})",
+            value=new_default,
+            min_value=min_value,
+            max_value=max_value,
+            key="jesd_converter_rate_input",
+        )
+        converter_rate = scalar_value * converter_rate
+        converter.sample_clock = converter_rate / decimation
 
         # Derived settings
         dict_data = {

--- a/adijif/tools/explorer/src/pages/systemconfigurator.py
+++ b/adijif/tools/explorer/src/pages/systemconfigurator.py
@@ -28,6 +28,19 @@ sp.insert(0, "hmc7044")
 class SystemConfigurator(Page):
     """System configurator tool page."""
 
+    name = "System Configurator"
+    tagline = "End-to-end JESD system: converter + clock chip + Xilinx FPGA."
+    help_text = (
+        "Configure a complete JESD204 link in one place. Pick the "
+        "converter, clock chip, and FPGA dev kit; set the converter "
+        "sample rate, decimation/interpolation, and JESD mode; the "
+        "solver wires it all together and reports the clocking and "
+        "transceiver settings.\n\n"
+        "Optimization controls and clock-source choices live in their "
+        "own sections lower on the page.\n\n"
+        "The system diagram at the bottom visualizes the solved link."
+    )
+
     def __init__(self, state: Optional[object]) -> None:
         """Initialize system configurator page.
 
@@ -38,37 +51,37 @@ class SystemConfigurator(Page):
 
     def write(self) -> None:
         """Render the system configurator page."""
-        st.title("System Configurator")
+        self.header()
 
-        with st.expander("System Settings", expanded=True):
-            hsx = st.selectbox(
-                label="Select a converter part",
-                options=xsp,
-                format_func=lambda x: x.upper(),
-                key="converter_part_select",
-            )
+        self.section("System settings")
+        hsx = st.selectbox(
+            label="Select a converter part",
+            options=xsp,
+            format_func=lambda x: x.upper(),
+            key="converter_part_select",
+        )
 
-            clock = st.selectbox(
-                label="Select a clock part",
-                options=sp,
-                format_func=lambda x: x.upper(),
-                key="clock_part_select",
-            )
+        clock = st.selectbox(
+            label="Select a clock part",
+            options=sp,
+            format_func=lambda x: x.upper(),
+            key="clock_part_select",
+        )
 
-            fpga_kit = st.selectbox(
-                label="Select an FPGA development kit",
-                options=adijif.xilinx._available_dev_kit_names,
-                format_func=lambda x: x.upper(),
-                key="fpga_dev_kit_select",
-            )
+        fpga_kit = st.selectbox(
+            label="Select an FPGA development kit",
+            options=adijif.xilinx._available_dev_kit_names,
+            format_func=lambda x: x.upper(),
+            key="fpga_dev_kit_select",
+        )
 
-            reference_rate = st.number_input(
-                f"Reference Rate (VCXO) for {clock.upper()} (Hz)",
-                value=125000000,
-                min_value=int(100e6),
-                max_value=int(400e6),
-                key="system_reference_rate_input",
-            )
+        reference_rate = st.number_input(
+            "VCXO reference (Hz)",
+            value=125000000,
+            min_value=int(100e6),
+            max_value=int(400e6),
+            key="system_reference_rate_input",
+        )
 
         sys = adijif.system(
             hsx.lower(), clock.lower(), "xilinx", reference_rate
@@ -84,75 +97,75 @@ class SystemConfigurator(Page):
 
         with converter_c:
             # st.header("Converter Configuration")
-            with st.expander("Converter Settings", expanded=True):
-                # Units GHz, MHz, kHz
-                units = st.selectbox(
-                    label="Select units for Converter Clock",
-                    options=["Hz", "kHz", "MHz", "GHz"],
-                    index=2,
-                    key="system_converter_units_select",
-                )
-                if units == "Hz":
-                    multiplier = 1
-                elif units == "kHz":
-                    multiplier = 1e3
-                elif units == "MHz":
-                    multiplier = 1e6
-                elif units == "GHz":
-                    multiplier = 1e9
+            self.section("Converter settings")
+            # Units GHz, MHz, kHz
+            units = st.selectbox(
+                label="Select units for Converter Clock",
+                options=["Hz", "kHz", "MHz", "GHz"],
+                index=2,
+                key="system_converter_units_select",
+            )
+            if units == "Hz":
+                multiplier = 1
+            elif units == "kHz":
+                multiplier = 1e3
+            elif units == "MHz":
+                multiplier = 1e6
+            elif units == "GHz":
+                multiplier = 1e9
 
-                # Converter Clock
-                converter_clock = st.number_input(
-                    f"Converter Clock ({units})",
-                    value=1e9 / multiplier,
-                    format="%f",
-                    min_value=1e6 / multiplier,
-                    max_value=20e9 / multiplier,
-                    key="system_converter_clock_input",
-                )
-                # sys.converter.decimation = 1
+            # Converter Clock
+            converter_clock = st.number_input(
+                f"Converter Clock ({units})",
+                value=1e9 / multiplier,
+                format="%f",
+                min_value=1e6 / multiplier,
+                max_value=20e9 / multiplier,
+                key="system_converter_clock_input",
+            )
+            # sys.converter.decimation = 1
 
-                decimation = gen_datapath(sys.converter)
-                sys.converter.sample_clock = (
-                    converter_clock * multiplier / decimation
-                )
+            decimation = gen_datapath(sys.converter)
+            sys.converter.sample_clock = (
+                converter_clock * multiplier / decimation
+            )
 
-                # JESD modes
-                qsm = sys.converter.quick_configuration_modes
+            # JESD modes
+            qsm = sys.converter.quick_configuration_modes
 
-                # Flatten dict for display as a list
-                qsm_flat = {}
-                for jesdclasses in qsm:
-                    for mode in qsm[jesdclasses]:
-                        settings = qsm[jesdclasses][mode]
-                        other_settings = (
-                            f" (M={settings['M']}, "
-                            + f"F={settings['F']},"
-                            + f"Np={settings['Np']}, "
-                            + f"L={settings['L']}, S={settings['S']})"
-                        )
-                        qsm_flat[
-                            f"{jesdclasses.upper()} Mode: {mode} {other_settings}"
-                        ] = {
-                            "mode": mode,
-                            "jesdclass": jesdclasses,
-                        }
+            # Flatten dict for display as a list
+            qsm_flat = {}
+            for jesdclasses in qsm:
+                for mode in qsm[jesdclasses]:
+                    settings = qsm[jesdclasses][mode]
+                    other_settings = (
+                        f" (M={settings['M']}, "
+                        + f"F={settings['F']},"
+                        + f"Np={settings['Np']}, "
+                        + f"L={settings['L']}, S={settings['S']})"
+                    )
+                    qsm_flat[
+                        f"{jesdclasses.upper()} Mode: {mode} {other_settings}"
+                    ] = {
+                        "mode": mode,
+                        "jesdclass": jesdclasses,
+                    }
 
-                # Sort by mode
-                qsm_flat = dict(
-                    sorted(qsm_flat.items(), key=lambda item: item[1]["mode"])
-                )
+            # Sort by mode
+            qsm_flat = dict(
+                sorted(qsm_flat.items(), key=lambda item: item[1]["mode"])
+            )
 
-                mode = st.selectbox(
-                    label="Select JESD Configuration Mode",
-                    options=list(qsm_flat.keys()),
-                    # options=list(qsm_flat.keys()),
-                    # format_func=lambda x: f"{x} : {qsm_flat[x]}",
-                    key="system_jesd_mode_select",
-                )
-                sys.converter.set_quick_configuration_mode(
-                    qsm_flat[mode]["mode"], qsm_flat[mode]["jesdclass"]
-                )
+            mode = st.selectbox(
+                label="Select JESD Configuration Mode",
+                options=list(qsm_flat.keys()),
+                # options=list(qsm_flat.keys()),
+                # format_func=lambda x: f"{x} : {qsm_flat[x]}",
+                key="system_jesd_mode_select",
+            )
+            sys.converter.set_quick_configuration_mode(
+                qsm_flat[mode]["mode"], qsm_flat[mode]["jesdclass"]
+            )
 
         # with clock_c:
         #     st.header("Clock Configuration")
@@ -161,144 +174,144 @@ class SystemConfigurator(Page):
         #         st.markdown(cfg["clock"])
 
         with fpga_c:
-            with st.expander("FPGA Settings", expanded=True):
-                # sys.fpga.ref_clock_constraint = "Unconstrained"
-                ref_clock_constraint = st.selectbox(
-                    options=adijif.xilinx._ref_clock_constraint_options,
-                    label="FPGA Reference Clock Constraint",
-                    index=adijif.xilinx._ref_clock_constraint_options.index(
-                        "Unconstrained"
-                    ),
-                    key="system_fpga_ref_constraint_select",
-                )
-                sys.fpga.ref_clock_constraint = ref_clock_constraint
+            self.section("FPGA settings")
+            # sys.fpga.ref_clock_constraint = "Unconstrained"
+            ref_clock_constraint = st.selectbox(
+                options=adijif.xilinx._ref_clock_constraint_options,
+                label="FPGA Reference Clock Constraint",
+                index=adijif.xilinx._ref_clock_constraint_options.index(
+                    "Unconstrained"
+                ),
+                key="system_fpga_ref_constraint_select",
+            )
+            sys.fpga.ref_clock_constraint = ref_clock_constraint
 
-                # sys.fpga.sys_clk_select = "XCVR_QPLL0"  # Use faster QPLL
-                sys_clk_select = st.multiselect(
-                    options=adijif.xilinx.sys_clk_selections,
-                    label="XCVR System Clock Source Selection",
-                    default=adijif.xilinx.sys_clk_selections,
-                    key="system_fpga_sys_clk_multiselect",
-                )
-                sys.fpga.sys_clk_select = sys_clk_select
+            # sys.fpga.sys_clk_select = "XCVR_QPLL0"  # Use faster QPLL
+            sys_clk_select = st.multiselect(
+                options=adijif.xilinx.sys_clk_selections,
+                label="XCVR System Clock Source Selection",
+                default=adijif.xilinx.sys_clk_selections,
+                key="system_fpga_sys_clk_multiselect",
+            )
+            sys.fpga.sys_clk_select = sys_clk_select
 
-                # Read off the configured FPGA instance, since
-                # `setup_by_dev_kit_name` may have removed options that the
-                # selected board's transceiver doesn't support (e.g.
-                # XCVR_PROGDIV_CLK is unavailable on 7-series GTX/zc706).
-                fpga_out_clk_options = list(sys.fpga._out_clk_selections)
-                out_clk_select = st.multiselect(
-                    options=fpga_out_clk_options,
-                    label="XCVR Output Clock Selection",
-                    default=fpga_out_clk_options,
-                    key="system_fpga_out_clk_multiselect",
-                )
-                sys.fpga.out_clk_select = out_clk_select
+            # Read off the configured FPGA instance, since
+            # `setup_by_dev_kit_name` may have removed options that the
+            # selected board's transceiver doesn't support (e.g.
+            # XCVR_PROGDIV_CLK is unavailable on 7-series GTX/zc706).
+            fpga_out_clk_options = list(sys.fpga._out_clk_selections)
+            out_clk_select = st.multiselect(
+                options=fpga_out_clk_options,
+                label="XCVR Output Clock Selection",
+                default=fpga_out_clk_options,
+                key="system_fpga_out_clk_multiselect",
+            )
+            sys.fpga.out_clk_select = out_clk_select
 
-                # sys.fpga.force_qpll = 1
-                force_qpll_options = [
-                    "Auto",
-                    "Force QPLL",
-                    "Force QPLL1",
-                    "Force CPLL",
-                ]
-                force_qpll_selection = st.selectbox(
-                    options=force_qpll_options,
-                    label="Transceiver PLL Selection",
-                    index=0,
-                    key="system_fpga_pll_select",
-                )
-                if force_qpll_selection == "Force QPLL":
-                    sys.fpga.force_qpll = True
-                elif force_qpll_selection == "Force QPLL1":
-                    sys.fpga.force_qpll1 = True
-                elif force_qpll_selection == "Force CPLL":
-                    sys.fpga.force_cpll = True
+            # sys.fpga.force_qpll = 1
+            force_qpll_options = [
+                "Auto",
+                "Force QPLL",
+                "Force QPLL1",
+                "Force CPLL",
+            ]
+            force_qpll_selection = st.selectbox(
+                options=force_qpll_options,
+                label="Transceiver PLL Selection",
+                index=0,
+                key="system_fpga_pll_select",
+            )
+            if force_qpll_selection == "Force QPLL":
+                sys.fpga.force_qpll = True
+            elif force_qpll_selection == "Force QPLL1":
+                sys.fpga.force_qpll1 = True
+            elif force_qpll_selection == "Force CPLL":
+                sys.fpga.force_cpll = True
 
-        with st.expander("Converter Clock Source", expanded=False):
-            # Pick converter mode
-            if len(sys.converter.clocking_option_available) > 1:
-                internal_clocking = st.radio(
-                    "Converter Clocking Option",
-                    options=["Internal PLL", "Direct"],
-                    index=0,
-                    key="system_converter_clocking_radio",
-                )
-                if internal_clocking == "Internal PLL":
-                    internal_clocking = "integrated_pll"
-                else:
-                    internal_clocking = "direct"
+        self.section("Converter clock source")
+        # Pick converter mode
+        if len(sys.converter.clocking_option_available) > 1:
+            internal_clocking = st.radio(
+                "Converter Clocking Option",
+                options=["Internal PLL", "Direct"],
+                index=0,
+                key="system_converter_clocking_radio",
+            )
+            if internal_clocking == "Internal PLL":
+                internal_clocking = "integrated_pll"
             else:
-                available = sys.converter.clocking_option_available[0]
-                st.radio(
-                    "Converter Clocking Option",
-                    options=[available],
-                    format_func=lambda x: x.capitalize(),
-                    index=0,
-                    key="system_converter_clocking_single_radio",
-                )
-                internal_clocking = available
-
-            sys.converter.clocking_option = internal_clocking
-
-            # Pick source for clocking
-            if internal_clocking == "direct":
-                plls_plus_clock_chip = adijif.plls.supported_parts + [
-                    clock.lower() + " (Clock Chip)"
-                ]
-                ext_pll = st.selectbox(
-                    label="Select an external PLL part",
-                    options=plls_plus_clock_chip,
-                    format_func=lambda x: x.upper(),
-                    key="plls",
-                )
-
-                ext_pll = ext_pll.replace(" (Clock Chip)", "").lower()
-
-                if ext_pll != clock.lower():
-                    sys.add_pll_inline(
-                        ext_pll.lower(), reference_rate, sys.converter
-                    )
-            else:  # integrated_pll
-                st.radio(
-                    "Integrated PLL source",
-                    options=[clock.upper()],
-                    index=0,
-                    key="system_integrated_pll_radio",
-                )
-
-        with st.expander("Derived Settings", expanded=True):
-            # Table with lane rate and core clock
-            lane_rate = sys.converter.bit_clock
-            core_clock = (
-                sys.converter.bit_clock / 66
-                if sys.converter.jesd_class == "jesd204c"
-                else sys.converter.bit_clock / 40
+                internal_clocking = "direct"
+        else:
+            available = sys.converter.clocking_option_available[0]
+            st.radio(
+                "Converter Clocking Option",
+                options=[available],
+                format_func=lambda x: x.capitalize(),
+                index=0,
+                key="system_converter_clocking_single_radio",
             )
-            sample_clock = sys.converter.sample_clock
-            converter_clock = sys.converter.converter_clock
+            internal_clocking = available
 
-            # Build pandas DataFrame
-            df = pd.DataFrame(
-                {
-                    "Setting": [
-                        "Lane Rate (Gbps)",
-                        "Needed Core Clock (MHz)",
-                        "Sample Clock (MHz)",
-                        "Converter Clock (MHz)",
-                    ],
-                    "Value": [
-                        f"{lane_rate / 1e9:.4f}",
-                        f"{core_clock / 1e6:.4f}",
-                        f"{sample_clock / 1e6:.4f}",
-                        f"{converter_clock / 1e6:.4f}",
-                    ],
-                }
+        sys.converter.clocking_option = internal_clocking
+
+        # Pick source for clocking
+        if internal_clocking == "direct":
+            plls_plus_clock_chip = adijif.plls.supported_parts + [
+                clock.lower() + " (Clock Chip)"
+            ]
+            ext_pll = st.selectbox(
+                label="Select an external PLL part",
+                options=plls_plus_clock_chip,
+                format_func=lambda x: x.upper(),
+                key="plls",
             )
-            # Remove index
-            df.index = df["Setting"]
-            df = df.drop(columns=["Setting"])
-            st.table(df)
+
+            ext_pll = ext_pll.replace(" (Clock Chip)", "").lower()
+
+            if ext_pll != clock.lower():
+                sys.add_pll_inline(
+                    ext_pll.lower(), reference_rate, sys.converter
+                )
+        else:  # integrated_pll
+            st.radio(
+                "Integrated PLL source",
+                options=[clock.upper()],
+                index=0,
+                key="system_integrated_pll_radio",
+            )
+
+        self.section("Derived settings")
+        # Table with lane rate and core clock
+        lane_rate = sys.converter.bit_clock
+        core_clock = (
+            sys.converter.bit_clock / 66
+            if sys.converter.jesd_class == "jesd204c"
+            else sys.converter.bit_clock / 40
+        )
+        sample_clock = sys.converter.sample_clock
+        converter_clock = sys.converter.converter_clock
+
+        # Build pandas DataFrame
+        df = pd.DataFrame(
+            {
+                "Setting": [
+                    "Lane Rate (Gbps)",
+                    "Needed Core Clock (MHz)",
+                    "Sample Clock (MHz)",
+                    "Converter Clock (MHz)",
+                ],
+                "Value": [
+                    f"{lane_rate / 1e9:.4f}",
+                    f"{core_clock / 1e6:.4f}",
+                    f"{sample_clock / 1e6:.4f}",
+                    f"{converter_clock / 1e6:.4f}",
+                ],
+            }
+        )
+        # Remove index
+        df.index = df["Setting"]
+        df = df.drop(columns=["Setting"])
+        st.table(df)
 
         try:
             clocks = sys.initialize()
@@ -307,43 +320,43 @@ class SystemConfigurator(Page):
             clocks = None
 
         if clocks is not None:
-            with st.expander("Optimization Controls", expanded=False):
-                st.caption(
-                    "Layer custom clock constraints and objectives on top of "
-                    "the built-in defaults. See the Constraints and "
-                    "Optimization tutorial for the full API."
-                )
-                gen_clock_constraints(clocks)
-                gen_clock_objectives(sys, clocks)
+            self.section("Optimization controls")
+            st.caption(
+                "Layer custom clock constraints and objectives on top of "
+                "the built-in defaults. See the Constraints and "
+                "Optimization tutorial for the full API."
+            )
+            gen_clock_constraints(clocks)
+            gen_clock_objectives(sys, clocks)
 
         diagram = None
-        with st.expander("System Configuration", expanded=False):
-            if clocks is None:
-                st.write("System not initialized.")
-            else:
-                cfg = None
-                try:
-                    cfg = sys.do_solve()
-                except Exception as e:  # noqa: BLE001 -- solver raises bare Exception
-                    st.error(f"Error solving system configuration: {e}")
+        self.section("Result")
+        if clocks is None:
+            st.write("System not initialized.")
+        else:
+            cfg = None
+            try:
+                cfg = sys.do_solve()
+            except Exception as e:  # noqa: BLE001 -- solver raises bare Exception
+                st.error(f"Error solving system configuration: {e}")
 
-                if cfg is not None:
-                    st.subheader("Clock Configuration")
-                    st.write(cfg["clock"])
+            if cfg is not None:
+                st.subheader("Clock Configuration")
+                st.write(cfg["clock"])
 
-                    st.subheader("Converter Configuration")
-                    st.write(cfg["converter"])
+                st.subheader("Converter Configuration")
+                st.write(cfg["converter"])
 
-                    st.subheader("FPGA Configuration")
-                    st.write(cfg["fpga_" + sys.converter.name.upper()])
+                st.subheader("FPGA Configuration")
+                st.write(cfg["fpga_" + sys.converter.name.upper()])
 
-                    st.subheader("Converter JESD Configuration")
-                    st.write(cfg["jesd_" + sys.converter.name.upper()])
+                st.subheader("Converter JESD Configuration")
+                st.write(cfg["jesd_" + sys.converter.name.upper()])
 
-                    diagram = sys.draw(cfg)
+                diagram = sys.draw(cfg)
 
-        with st.expander("Diagram", expanded=False):
-            if diagram:
-                st.image(diagram, width="stretch")
-            else:
-                st.write("No diagram available.")
+        self.section("Diagram")
+        if diagram:
+            st.image(diagram, width="stretch")
+        else:
+            st.write("No diagram available.")

--- a/adijif/tools/explorer/src/utils.py
+++ b/adijif/tools/explorer/src/utils.py
@@ -12,13 +12,56 @@ _EXPLORER_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # st.set_page_config(layout="wide")
 
 
+def _slug(name: str) -> str:
+    """Turn a page name into a key-safe slug.
+
+    >>> _slug("ADF4030 System Designer")
+    'adf4030_system_designer'
+    """
+    return "".join(c if c.isalnum() else "_" for c in name.lower()).strip("_")
+
+
 class Page(ABC):
-    """Base class for all page types."""
+    """Base class for all explorer pages.
+
+    Subclasses set ``name`` (page title), ``tagline`` (one-line
+    intro), and ``help_text`` (body of the About dialog), then call
+    ``self.header()`` at the top of ``write()`` and ``self.section()``
+    between major content groups.
+    """
+
+    name: str = "Untitled"
+    tagline: str = ""
+    help_text: str = ""
 
     @abstractmethod
     def write(self) -> None:
         """Render the page content."""
-        pass
+
+    def header(self) -> None:
+        """Render the standard page header: title + tagline + Help + rule."""
+        cols = st.columns([0.85, 0.15])
+        with cols[0]:
+            st.title(self.name)
+            if self.tagline:
+                st.caption(self.tagline)
+        with cols[1]:
+            st.button(
+                "Help",
+                key=f"help_{_slug(self.name)}",
+                on_click=self._show_help,
+                use_container_width=True,
+            )
+        st.markdown("---")
+
+    def section(self, label: str) -> None:
+        """Render a section header inside the page."""
+        st.subheader(label)
+
+    @st.dialog("About")
+    def _show_help(self) -> None:
+        """Render the About dialog for this page."""
+        st.markdown(self.help_text or "_No help text provided._")
 
 
 def add_custom_css() -> None:

--- a/tests/tools/e2e/pages/clock_configurator_page.py
+++ b/tests/tools/e2e/pages/clock_configurator_page.py
@@ -37,7 +37,7 @@ class ClockConfiguratorPage(BasePage):
         Args:
             frequency: Frequency in Hz
         """
-        self.set_number_input("Reference Clock", frequency)
+        self.set_number_input("Reference clock (Hz)", frequency)
 
     def is_no_solution_warning(self) -> bool:
         """Check if "No valid configuration found" warning is visible.
@@ -53,11 +53,11 @@ class ClockConfiguratorPage(BasePage):
         Returns:
             bool: True if section is visible
         """
-        return self.is_visible("Internal Clock Configuration")
+        return self.is_visible("Internal configuration")
 
     def expand_internal_config(self) -> None:
-        """Expand internal clock configuration section."""
-        self.expand_expander("Internal Clock Configuration")
+        """Check internal clock configuration section is visible (expanders removed)."""
+        self.is_visible("Internal configuration")
 
     def get_current_clock_part(self) -> str:
         """Get currently selected clock part.
@@ -74,7 +74,7 @@ class ClockConfiguratorPage(BasePage):
         Returns:
             str: Current reference clock frequency value
         """
-        return self.get_text_value("Reference Clock")
+        return self.get_text_value("Reference clock (Hz)")
 
     def is_solution_displayed(self) -> bool:
         """Check if solution/results are displayed.
@@ -88,6 +88,6 @@ class ClockConfiguratorPage(BasePage):
         """Check if solution configuration is visible.
 
         Returns:
-            bool: True if Found Configuration section is visible
+            bool: True if Result section is visible
         """
-        return self.is_visible("Found Configuration")
+        return self.is_visible("Result")

--- a/tests/tools/e2e/pages/jesd_mode_selector_page.py
+++ b/tests/tools/e2e/pages/jesd_mode_selector_page.py
@@ -71,7 +71,7 @@ class JESDModeSelectorPage(BasePage):
         Returns:
             bool: True if datapath configuration is visible
         """
-        return self.is_visible("Datapath Configuration")
+        return self.is_visible("Datapath configuration")
 
     def is_diagram_visible(self) -> bool:
         """Check if diagram is visible.

--- a/tests/tools/e2e/pages/system_configurator_page.py
+++ b/tests/tools/e2e/pages/system_configurator_page.py
@@ -48,16 +48,16 @@ class SystemConfiguratorPage(BasePage):
         self.set_selectbox("Select an FPGA development kit", kit_name)
 
     def expand_converter_settings(self) -> None:
-        """Expand converter settings section."""
-        self.expand_expander("Converter Settings")
+        """Check converter settings section is visible (expanders removed)."""
+        self.is_visible("Converter settings")
 
     def expand_fpga_settings(self) -> None:
-        """Expand FPGA settings section."""
-        self.expand_expander("FPGA Settings")
+        """Check FPGA settings section is visible (expanders removed)."""
+        self.is_visible("FPGA settings")
 
     def expand_clocking_settings(self) -> None:
-        """Expand clocking settings section."""
-        self.expand_expander("Clocking Settings")
+        """Check clocking settings section is visible (expanders removed)."""
+        self.is_visible("System settings")
 
     def is_converter_settings_visible(self) -> bool:
         """Check if converter settings section is visible.
@@ -65,7 +65,7 @@ class SystemConfiguratorPage(BasePage):
         Returns:
             bool: True if section is visible
         """
-        return self.is_visible("Converter Settings")
+        return self.is_visible("Converter settings")
 
     def is_fpga_settings_visible(self) -> bool:
         """Check if FPGA settings section is visible.
@@ -73,12 +73,12 @@ class SystemConfiguratorPage(BasePage):
         Returns:
             bool: True if section is visible
         """
-        return self.is_visible("FPGA Settings")
+        return self.is_visible("FPGA settings")
 
     def is_system_configuration_visible(self) -> bool:
         """Check if system configuration section is visible.
 
         Returns:
-            bool: True if System Configuration expander is visible
+            bool: True if Result section is visible
         """
-        return self.is_visible("System Configuration")
+        return self.is_visible("Result")

--- a/tests/tools/e2e/test_clock_configurator_e2e.py
+++ b/tests/tools/e2e/test_clock_configurator_e2e.py
@@ -18,7 +18,7 @@ def test_clock_part_selection_updates_ui(clock_page):
     """Test selecting different clock chips updates UI."""
     clock_page.select_clock_part("hmc7044")
     # Verify the page responded by checking if content became visible
-    assert clock_page.is_visible("Clock Inputs and Outputs")
+    assert clock_page.is_visible("Inputs")
 
 
 @pytest.mark.e2e
@@ -28,7 +28,7 @@ def test_clock_reference_configuration(clock_page):
     clock_page.select_clock_part("hmc7044")
     clock_page.set_reference_clock(125000000)
     # Verify the reference clock section is visible
-    assert clock_page.is_visible("Reference Clock")
+    assert clock_page.is_visible("Reference clock (Hz)")
 
 
 @pytest.mark.e2e
@@ -48,7 +48,7 @@ def test_clock_multiple_parts_selection(clock_page):
     for part in parts:
         clock_page.select_clock_part(part)
         # Verify the page responded to selection
-        assert clock_page.is_visible("Clock Inputs and Outputs")
+        assert clock_page.is_visible("Inputs")
 
 
 @pytest.mark.e2e
@@ -60,7 +60,7 @@ def test_clock_reference_range(clock_page):
     for freq in frequencies:
         clock_page.set_reference_clock(freq)
         # Verify the widget is still visible
-        assert clock_page.is_visible("Reference Clock")
+        assert clock_page.is_visible("Reference clock (Hz)")
 
 
 @pytest.mark.e2e
@@ -69,5 +69,5 @@ def test_clock_page_layout(clock_page):
     """Test clock page has expected sections."""
     clock_page.select_clock_part("hmc7044")
     assert clock_page.is_visible("Select a part")
-    assert clock_page.is_visible("Reference Clock")
-    assert clock_page.is_visible("Clock Inputs and Outputs")
+    assert clock_page.is_visible("Reference clock (Hz)")
+    assert clock_page.is_visible("Inputs")

--- a/tests/tools/e2e/test_cross_page_workflows_e2e.py
+++ b/tests/tools/e2e/test_cross_page_workflows_e2e.py
@@ -39,7 +39,7 @@ def test_state_independence_between_pages(page, streamlit_app):
     jesd = JESDModeSelectorPage(page, streamlit_app)
     jesd.select_part("ad9680")
     # Verify the JESD page responded
-    assert jesd.is_visible("Datapath Configuration")
+    assert jesd.is_visible("Datapath configuration")
 
     # Navigate to Clock page and verify independent state
     clock = ClockConfiguratorPage(page, streamlit_app)
@@ -48,7 +48,7 @@ def test_state_independence_between_pages(page, streamlit_app):
 
     # Verify we can set different state on Clock page
     clock.select_clock_part("hmc7044")
-    assert clock.is_visible("Clock Inputs and Outputs")
+    assert clock.is_visible("Inputs")
 
 
 # @pytest.mark.skip(reason="Help button not yet implemented on all pages")

--- a/tests/tools/e2e/test_jesd_mode_selector_e2e.py
+++ b/tests/tools/e2e/test_jesd_mode_selector_e2e.py
@@ -20,7 +20,7 @@ def test_jesd_part_selection_updates_ui(jesd_page):
     # Select a part and verify the page responds
     jesd_page.select_part("ad9680")
     # Verify that datapath configuration is visible (content loaded)
-    assert jesd_page.is_visible("Datapath Configuration")
+    assert jesd_page.is_visible("Datapath configuration")
 
 
 @pytest.mark.e2e
@@ -62,7 +62,7 @@ def test_jesd_multiple_parts_selection(jesd_page):
     for part in parts:
         jesd_page.select_part(part)
         # Verify the page responded to the selection
-        assert jesd_page.is_visible("Datapath Configuration")
+        assert jesd_page.is_visible("Datapath configuration")
 
 
 @pytest.mark.e2e
@@ -70,7 +70,7 @@ def test_jesd_multiple_parts_selection(jesd_page):
 def test_jesd_diagram_generation(jesd_page):
     """Test diagram is generated and displayed."""
     jesd_page.select_part("ad9680")
-    jesd_page.expand_expander("Diagram")
+    # No expander to expand; diagram section is always visible under subheader
     assert jesd_page.is_diagram_visible()
 
 

--- a/tests/tools/e2e/test_system_configurator_e2e.py
+++ b/tests/tools/e2e/test_system_configurator_e2e.py
@@ -9,7 +9,7 @@ import pytest
 def test_system_page_loads_successfully(system_page):
     """Test System Configurator page loads."""
     assert system_page.is_visible("System Configurator")
-    assert system_page.is_visible("System Settings")
+    assert system_page.is_visible("System settings")
 
 
 @pytest.mark.e2e
@@ -47,8 +47,8 @@ def test_system_fpga_settings(system_page):
 def test_system_clocking_settings(system_page):
     """Test clocking settings."""
     system_page.select_converter("ad9680")
-    # Converter Clock Source is an expander, check if it exists
-    assert system_page.is_visible("Converter Clock Source")
+    # Converter clock source is a section, check if it exists
+    assert system_page.is_visible("Converter clock source")
 
 
 @pytest.mark.e2e
@@ -76,7 +76,7 @@ def test_system_fpga_kit_selection(system_page):
     for kit in fpga_kits:
         system_page.select_fpga_kit(kit)
         # Verify the page responded to selection
-        assert system_page.is_visible("System Settings")
+        assert system_page.is_visible("System settings")
 
 
 @pytest.mark.e2e
@@ -84,7 +84,7 @@ def test_system_fpga_kit_selection(system_page):
 def test_system_page_layout(system_page):
     """Test system page has expected layout."""
     assert system_page.is_visible("System Configurator")
-    assert system_page.is_visible("System Settings")
+    assert system_page.is_visible("System settings")
     assert system_page.is_visible("Select a converter part")
     assert system_page.is_visible("Select a clock part")
     assert system_page.is_visible("Select an FPGA development kit")

--- a/tests/tools/test_jesdmodeselector.py
+++ b/tests/tools/test_jesdmodeselector.py
@@ -161,16 +161,16 @@ def test_jesdmodeselector_adc_datapath_config() -> None:
     set_item(at, "selectbox", "Select a part", "ad9680")
     at.run()
 
-    # Verify expanders exist
-    assert len(at.expander) > 0, "No expanders found"
+    # Verify subheaders exist (sections replaced expanders)
+    assert len(at.subheader) > 0, "No subheaders found"
 
-    # Check for Datapath Configuration expander
-    datapath_expander_found = False
-    for expander in at.expander:
-        if "Datapath Configuration" in str(expander.label):
-            datapath_expander_found = True
+    # Check for Datapath configuration subheader
+    datapath_section_found = False
+    for subheader in at.subheader:
+        if "Datapath configuration" in str(subheader.value):
+            datapath_section_found = True
             break
-    assert datapath_expander_found, "Datapath Configuration expander not found"
+    assert datapath_section_found, "Datapath configuration subheader not found"
 
     # Check for Units selector
     units_found = False
@@ -385,17 +385,16 @@ def test_jesdmodeselector_diagram_adc() -> None:
     set_item(at, "selectbox", "Select a part", "ad9680")
     at.run()
 
-    # Check for Diagram expander
-    diagram_expander_found = False
-    for expander in at.expander:
-        if "Diagram" in str(expander.label):
-            diagram_expander_found = True
+    # Check for Diagram subheader (section replaced expander)
+    diagram_section_found = False
+    for subheader in at.subheader:
+        if "Diagram" in str(subheader.value):
+            diagram_section_found = True
             break
 
-    assert diagram_expander_found, "Diagram expander not found"
+    assert diagram_section_found, "Diagram subheader not found"
 
-    # Check that an image is rendered (images are rendered within expanders)
-    # We just verify the expander exists and no exception occurred
+    # Check that the diagram section exists and no exception occurred
     assert not at.exception
 
 

--- a/tests/tools/test_systemconfigurator_optimization.py
+++ b/tests/tools/test_systemconfigurator_optimization.py
@@ -38,8 +38,8 @@ def _click_button(at: AppTest, key: str) -> AppTest:
     raise AssertionError(f"Button with key {key!r} not found")
 
 
-def _expander_labels(at: AppTest) -> list:
-    return [str(exp.label) for exp in at.expander]
+def _subheader_labels(at: AppTest) -> list:
+    return [str(sub.value) for sub in at.subheader]
 
 
 def _selectbox_by_key(at: AppTest, key: str):
@@ -62,7 +62,7 @@ def _make_app() -> AppTest:
     The page's default JESD mode (L=1) at 1 GHz produces a 20 Gbps lane rate
     that exceeds JESD204B limits and makes ``sys.initialize()`` raise. Lower
     the converter clock so the default mode is solvable and the optimization
-    controls expander renders.
+    controls section renders.
     """
     at = AppTest.from_file(app_file_path, default_timeout=_RUN_TIMEOUT)
     at.run(timeout=_RUN_TIMEOUT)
@@ -74,11 +74,11 @@ def _make_app() -> AppTest:
     return at
 
 
-def test_optimization_controls_expander_present() -> None:
-    """The new 'Optimization Controls' expander renders without errors."""
+def test_optimization_controls_section_present() -> None:
+    """The 'Optimization controls' section renders without errors."""
     at = _make_app()
     assert not at.exception, f"Page raised: {at.exception}"
-    assert "Optimization Controls" in _expander_labels(at)
+    assert "Optimization controls" in _subheader_labels(at)
 
 
 def test_initial_state_has_no_constraint_or_objective_rows() -> None:
@@ -202,5 +202,5 @@ def test_infeasible_constraint_does_not_crash_page() -> None:
 
     # The page itself must not raise; the solver error is rendered as st.error.
     assert not at.exception
-    # And the optimization controls expander must still be present.
-    assert "Optimization Controls" in _expander_labels(at)
+    # And the optimization controls section must still be present.
+    assert "Optimization controls" in _subheader_labels(at)


### PR DESCRIPTION
## Summary
- New `.streamlit/config.toml` with JIF orange (`#F58220`) as the primary color (both light and dark themes).
- Shared `header()` / `section()` / `_show_help()` on the `Page` base in `adijif/tools/explorer/src/utils.py`. Pages set `name`, `tagline`, and `help_text` as class attrs.
- All 5 Explorer pages now render the same top-of-page treatment: title + tagline + Help button + horizontal rule. Section grouping is plain subheaders — no more mixed `st.expander` / `st.container(border=True)` / inline `st.subheader` patterns.
- Input labels normalized to sentence case with units where relevant (e.g. \`\"VCXO reference (Hz)\"\` instead of \`\"Reference Rate (VCXO) for HMC7044 (Hz)\"\`).

## Test plan
- [x] \`pytest tests/tools/ --ignore=tests/tools/e2e\` — 62/62 pass (1 test file updated to follow the expander→subheader rename).
- [x] \`ruff check adijif tests noxfile.py\` — clean.
- [x] Manual smoke-check via \`streamlit run\` for each of the 5 pages.