### PR TITLE
feat(utils): add find_extreme_rate for solver-directed lane/sample rate optimization

### DIFF
--- a/adijif/utils.py
+++ b/adijif/utils.py
@@ -9,6 +9,7 @@ import adijif.fpgas.xilinx.sevenseries as xp
 import adijif.fpgas.xilinx.ultrascaleplus as us
 from adijif.converters.converter import converter
 from adijif.fpgas.fpga import fpga
+from adijif.solvers import CpoModel, cplex_solver, integer_var  # type: ignore
 
 
 def get_jesd_mode_from_params(conv: converter, **kwargs: int) -> List[dict]:
@@ -193,3 +194,409 @@ def get_max_sample_rates(
             }
         )
     return results
+
+
+class _InfeasibleMode(Exception):
+    """Internal sentinel: this mode cannot be made feasible. Skip it."""
+
+
+def _fpga_max_lane_rate(fpga_obj: fpga) -> float:
+    """Return the max lane rate the FPGA's QPLL can produce.
+
+    Mirrors the per-family logic in ``get_max_sample_rates``:
+    7-Series uses QPLL VCO max directly; UltraScale+ doubles it.
+    """
+    trx_type = fpga_obj.transceiver_type
+    family_digit = int(trx_type[4])
+    if family_digit == 2:
+        trx = xp.SevenSeries(parent=fpga_obj, transceiver_type=trx_type)
+        return trx.plls["QPLL"].vco_max
+    if family_digit in (3, 4):
+        trx = us.UltraScalePlus(parent=fpga_obj, transceiver_type=trx_type)
+        return trx.plls["QPLL"].vco_max * 2
+    raise Exception(f"Unsupported FPGA transceiver type: {trx_type}")
+
+
+def _enumerate_modes(
+    conv: converter, mode: Optional[str], jesd_class: Optional[str]
+) -> List[tuple]:
+    """Build the list of (jesd_class, mode) pairs to try."""
+    if mode is not None:
+        smode = str(mode)
+        if jesd_class is not None:
+            if smode not in conv.quick_configuration_modes[jesd_class]:
+                raise ValueError(
+                    f"Mode {smode!r} not found in {jesd_class} for {conv.name}"
+                )
+            return [(jesd_class, smode)]
+        # Search for which JESD class contains this mode
+        matches = [
+            jc
+            for jc in conv.quick_configuration_modes
+            if smode in conv.quick_configuration_modes[jc]
+        ]
+        if not matches:
+            raise ValueError(
+                f"Mode {smode!r} not found in any JESD class for {conv.name}"
+            )
+        if len(matches) > 1:
+            raise ValueError(
+                f"Mode {smode!r} is ambiguous across {matches}; "
+                "pass jesd_class explicitly."
+            )
+        return [(matches[0], smode)]
+    return [
+        (jc, m)
+        for jc in conv.quick_configuration_modes
+        for m in conv.quick_configuration_modes[jc]
+    ]
+
+
+def _solve_one_mode(
+    conv_template: converter,
+    jesd_class: str,
+    mode: str,
+    target: str,
+    sense: str,
+    fpga_max_lane_rate: Optional[float],
+    fpga_max_lanes: Optional[int],
+) -> dict:
+    """Solve for the extreme rate within a single JESD mode.
+
+    Returns the result dict. Raises ``_InfeasibleMode`` if the mode cannot
+    satisfy the requested constraints (lane count, empty bound range, or no
+    solver solution).
+    """
+    conv = copy.deepcopy(conv_template)
+    try:
+        conv.set_quick_configuration_mode(mode, jesd_class)
+    except Exception as e:
+        raise _InfeasibleMode() from e
+
+    if fpga_max_lanes is not None and conv.L > fpga_max_lanes:
+        raise _InfeasibleMode()
+
+    bc_min = conv.bit_clock_min_available[jesd_class]
+    bc_max = conv.bit_clock_max_available[jesd_class]
+    if fpga_max_lane_rate is not None:
+        bc_max = min(bc_max, fpga_max_lane_rate)
+
+    # sample_clock = bit_clock * L * encoding_n / (encoding_d * M * Np)
+    factor = (conv.L * conv.encoding_n) / (conv.encoding_d * conv.M * conv.Np)
+    sc_min = bc_min * factor
+    sc_max = bc_max * factor
+
+    dev_sc_min = getattr(conv, "sample_clock_min", None)
+    if dev_sc_min is not None:
+        sc_min = max(sc_min, dev_sc_min)
+    dev_sc_max = getattr(conv, "sample_clock_max", None)
+    if dev_sc_max is not None:
+        sc_max = min(sc_max, dev_sc_max)
+
+    if sc_min > sc_max:
+        raise _InfeasibleMode()
+
+    model = CpoModel()
+    sc_var = integer_var(int(sc_min), int(sc_max), name="sample_clock")
+    conv._sample_clock = sc_var
+
+    expr = conv.bit_clock if target == "lane" else conv.sample_clock
+    if sense == "max":
+        model.maximize(expr)
+    else:
+        model.minimize(expr)
+
+    solution = model.solve(LogVerbosity="Quiet", WarningLevel=0)
+    if not solution.is_solution():
+        raise _InfeasibleMode()
+
+    sc_value = solution.get_value(sc_var)
+    bc_value = (
+        (conv.M / conv.L)
+        * conv.Np
+        * (conv.encoding_d / conv.encoding_n)
+        * sc_value
+    )
+    obj_value = bc_value if target == "lane" else float(sc_value)
+
+    return {
+        "sample_clock": float(sc_value),
+        "bit_clock": float(bc_value),
+        "mode": mode,
+        "jesd_class": jesd_class,
+        "M": conv.M,
+        "L": conv.L,
+        "Np": conv.Np,
+        "F": conv.F,
+        "S": conv.S,
+        "K": conv.K,
+        "clock_config": None,
+        "fpga_config": None,
+        "objective_value": float(obj_value),
+    }
+
+
+def _solve_one_mode_with_clock(
+    conv_template: converter,
+    clock_template: object,
+    fpga_template: fpga,
+    vcxo: float,
+    jesd_class: str,
+    mode: str,
+    target: str,
+    sense: str,
+) -> dict:
+    """Solve for the extreme rate within a single mode using a full clock chain.
+
+    Uses ``adijif.system`` to wire the clock chip, converter, and FPGA. The
+    converter's ``_sample_clock`` is replaced with an integer variable so the
+    solver chooses it under the user objective; range-validation hooks that
+    can't tolerate a solver expression are bypassed (variable bounds enforce
+    the same limits).
+    """
+    import adijif  # local: utils sits below system in the dependency graph
+
+    if conv_template.L > fpga_template.max_serdes_lanes:
+        raise _InfeasibleMode()
+
+    conv_local = copy.deepcopy(conv_template)
+    clock_local = copy.deepcopy(clock_template)
+    fpga_local = copy.deepcopy(fpga_template)
+
+    try:
+        conv_local.set_quick_configuration_mode(mode, jesd_class)
+    except Exception as e:
+        raise _InfeasibleMode() from e
+
+    if conv_local.L > fpga_local.max_serdes_lanes:
+        raise _InfeasibleMode()
+
+    sys_obj = adijif.system(
+        type(conv_local).__name__,
+        type(clock_local).__name__,
+        type(fpga_local).__name__,
+        vcxo,
+        solver="CPLEX",
+    )
+    # Override the system's freshly-constructed components with the user's
+    # deep-copies, rebinding each to the system's shared solver model.
+    sys_obj.converter = conv_local
+    sys_obj.converter.model = sys_obj.model
+    sys_obj.clock = clock_local
+    sys_obj.clock.model = sys_obj.model
+    sys_obj.fpga = fpga_local
+    sys_obj.fpga.model = sys_obj.model
+
+    bc_min = conv_local.bit_clock_min_available[jesd_class]
+    bc_max = conv_local.bit_clock_max_available[jesd_class]
+    fpga_cap = _fpga_max_lane_rate(fpga_local)
+    bc_max = min(bc_max, fpga_cap)
+
+    factor = (conv_local.L * conv_local.encoding_n) / (
+        conv_local.encoding_d * conv_local.M * conv_local.Np
+    )
+    sc_min = bc_min * factor
+    sc_max = bc_max * factor
+    dev_sc_min = getattr(conv_local, "sample_clock_min", None)
+    if dev_sc_min is not None:
+        sc_min = max(sc_min, dev_sc_min)
+    dev_sc_max = getattr(conv_local, "sample_clock_max", None)
+    if dev_sc_max is not None:
+        sc_max = min(sc_max, dev_sc_max)
+    if sc_min > sc_max:
+        raise _InfeasibleMode()
+
+    sc_var = integer_var(int(sc_min), int(sc_max), name="sample_clock")
+    sys_obj.converter._sample_clock = sc_var
+
+    # Skip scalar-range validation hooks that can't handle a CpoExpr. The
+    # integer_var bounds enforce the same limits at solve time.
+    sys_obj.converter._skip_clock_validation = True
+    sys_obj.converter._check_jesd_config = lambda: None
+    sys_obj.converter._check_valid_internal_configuration = lambda: None
+
+    expr_target = (
+        sys_obj.converter.bit_clock
+        if target == "lane"
+        else sys_obj.converter.sample_clock
+    )
+    sys_obj.add_objective(
+        expr_target,
+        sense=sense,
+        tier=0,
+        name=f"find_extreme_rate.{target}_{sense}",
+    )
+
+    try:
+        sys_obj.initialize()
+        sys_obj._solve_cplex()
+    except Exception as e:
+        raise _InfeasibleMode() from e
+
+    sc_value = sys_obj._solution.get_value(sc_var)
+    # Rebind to a scalar so component get_config() calls (which compare
+    # bit_clock to PLL outputs as plain numbers) work normally.
+    sys_obj.converter._sample_clock = float(sc_value)
+    full_config = sys_obj._get_configs()
+
+    bc_value = (
+        (conv_local.M / conv_local.L)
+        * conv_local.Np
+        * (conv_local.encoding_d / conv_local.encoding_n)
+        * sc_value
+    )
+    obj_value = bc_value if target == "lane" else float(sc_value)
+
+    return {
+        "sample_clock": float(sc_value),
+        "bit_clock": float(bc_value),
+        "mode": mode,
+        "jesd_class": jesd_class,
+        "M": conv_local.M,
+        "L": conv_local.L,
+        "Np": conv_local.Np,
+        "F": conv_local.F,
+        "S": conv_local.S,
+        "K": conv_local.K,
+        "clock_config": full_config.get("clock"),
+        "fpga_config": {
+            k: v for k, v in full_config.items() if k.startswith("fpga_")
+        },
+        "objective_value": float(obj_value),
+    }
+
+
+def find_extreme_rate(
+    conv: converter,
+    *,
+    target: str = "lane",
+    sense: str = "max",
+    fpga: Optional[fpga] = None,
+    clock: Optional[object] = None,
+    vcxo: Optional[float] = None,
+    mode: Optional[str] = None,
+    jesd_class: Optional[str] = None,
+    solver: str = "CPLEX",
+) -> dict:
+    """Find the max or min lane rate or sample rate for a converter.
+
+    Two modes:
+
+    - **Constraint-only** (default): builds a small CPLEX model per JESD
+      mode, bounds ``sample_clock`` by the JESD class and (if ``fpga`` is
+      given) the FPGA's QPLL VCO cap, and optimizes the chosen target.
+    - **Full clock chain** (when ``clock`` is supplied): also wires the
+      clock chip through ``adijif.system`` so the solution must be
+      reachable by the clock chip's dividers. Requires ``fpga`` and
+      ``vcxo``.
+
+    When ``mode`` is omitted, every mode in
+    ``conv.quick_configuration_modes`` is tried and the best result is
+    returned. The input ``conv`` (and ``clock``, ``fpga``) is not
+    mutated; each attempt runs on a deep copy.
+
+    Args:
+        conv: Converter object to evaluate. Nested converters (MxFE /
+            transceivers) are not supported -- pass the rx or tx side
+            directly.
+        target: ``"lane"`` to optimize ``bit_clock``, ``"sample"`` for
+            ``sample_clock``.
+        sense: ``"max"`` (default) or ``"min"``.
+        fpga: Optional FPGA object. When supplied, its lane-count and
+            QPLL-derived max lane rate bound the search. Required when
+            ``clock`` is supplied.
+        clock: Optional clock chip. When supplied, the solver also
+            satisfies the clock-chain dividers, and ``fpga`` and ``vcxo``
+            are required.
+        vcxo: VCXO frequency in Hz. Required when ``clock`` is supplied.
+        mode: Optional JESD quick-configuration mode key. If omitted, all
+            modes are enumerated.
+        jesd_class: ``"jesd204b"`` or ``"jesd204c"``. Required only when
+            ``mode`` is set and ambiguous across classes.
+        solver: Currently only ``"CPLEX"`` is supported.
+
+    Returns:
+        dict: Resulting configuration. Keys: ``sample_clock``, ``bit_clock``,
+        ``mode``, ``jesd_class``, ``M``, ``L``, ``Np``, ``F``, ``S``, ``K``,
+        ``clock_config``, ``fpga_config``, ``objective_value``.
+        ``clock_config`` and ``fpga_config`` are populated only when the
+        respective component is supplied.
+
+    Raises:
+        ValueError: Invalid ``target``, ``sense``, or mode arguments, or
+            ``clock`` supplied without ``fpga``/``vcxo``.
+        NotImplementedError: ``solver != "CPLEX"`` or CPLEX is not installed.
+        Exception: No feasible mode found, or the converter is nested.
+    """
+    if target not in ("lane", "sample"):
+        raise ValueError(f"target must be 'lane' or 'sample', got {target!r}")
+    if sense not in ("max", "min"):
+        raise ValueError(f"sense must be 'max' or 'min', got {sense!r}")
+    if solver != "CPLEX":
+        raise NotImplementedError(
+            "find_extreme_rate currently only supports solver='CPLEX'"
+        )
+    if not cplex_solver:
+        raise NotImplementedError(
+            "find_extreme_rate requires CPLEX/docplex. "
+            "Install with: pip install 'pyadi-jif[cplex]'"
+        )
+    if clock is not None:
+        if fpga is None:
+            raise ValueError(
+                "find_extreme_rate requires fpga when clock is supplied "
+                "(no-FPGA clock-chain solving is not supported)."
+            )
+        if vcxo is None:
+            raise ValueError("vcxo is required when clock is supplied")
+    elif vcxo is not None:
+        raise ValueError("vcxo is only meaningful when clock is supplied")
+    if getattr(conv, "_nested", False):
+        raise Exception(
+            f"{conv.name} is a nested device; pass the rx or tx side "
+            "(e.g. ad9081_rx) directly."
+        )
+
+    modes_to_try = _enumerate_modes(conv, mode, jesd_class)
+
+    fpga_max_lane_rate = (
+        _fpga_max_lane_rate(fpga)
+        if (fpga is not None and clock is None)
+        else None
+    )
+    fpga_max_lanes = (
+        fpga.max_serdes_lanes if (fpga is not None and clock is None) else None
+    )
+
+    best: Optional[dict] = None
+    for jc, m in modes_to_try:
+        try:
+            if clock is not None:
+                result = _solve_one_mode_with_clock(
+                    conv, clock, fpga, vcxo, jc, m, target, sense
+                )
+            else:
+                result = _solve_one_mode(
+                    conv,
+                    jc,
+                    m,
+                    target,
+                    sense,
+                    fpga_max_lane_rate,
+                    fpga_max_lanes,
+                )
+        except _InfeasibleMode:
+            continue
+        if best is None:
+            best = result
+            continue
+        if sense == "max":
+            if result["objective_value"] > best["objective_value"]:
+                best = result
+        else:
+            if result["objective_value"] < best["objective_value"]:
+                best = result
+
+    if best is None:
+        raise Exception(f"No feasible JESD configuration found for {conv.name}")
+    return best

--- a/doc/source/finding_extreme_rates.md
+++ b/doc/source/finding_extreme_rates.md
@@ -1,0 +1,217 @@
+# Finding Extreme Lane and Sample Rates
+
+`adijif.utils.find_extreme_rate(...)` answers "what is the fastest (or
+slowest) this converter can run?" by replacing the converter's scalar
+`sample_clock` with a solver variable and asking CPLEX to push it to the
+boundary. Unlike `adijif.utils.get_max_sample_rates`, which iterates
+modes outside the solver, `find_extreme_rate` routes through the same
+objective framework used by [Constraints and Optimization](optimization.md),
+so its results respect every constraint the solver knows about — including,
+optionally, a full clock-chain through a real clock chip.
+
+The function has two modes:
+
+- **Constraint-only**: no `clock` argument. Builds a minimal model
+  bounded by the JESD-class limits and (optionally) an FPGA's QPLL VCO
+  cap. Fast.
+- **Full clock-chain**: pass `clock`, `fpga`, and `vcxo`. The solver
+  additionally requires the result to be reachable by the clock chip's
+  dividers.
+
+When `mode` is omitted, every entry in `conv.quick_configuration_modes`
+is enumerated and the best result is returned.
+
+## Prerequisites
+
+- pyadi-jif installed with the CPLEX extra (`pip install 'pyadi-jif[cplex]'`).
+  `find_extreme_rate` is CPLEX-only.
+- Familiarity with [Usage Flows](flow.md).
+
+## Step 1: Maximize lane rate without any FPGA
+
+The simplest call takes only a converter and asks for the largest lane
+rate achievable across every JESD mode it supports:
+
+```{exec_code}
+:caption_output: Max lane rate, AD9081_RX
+
+import adijif
+
+conv = adijif.ad9081_rx()
+result = adijif.utils.find_extreme_rate(
+    conv, target="lane", sense="max"
+)
+print(f"bit_clock    = {result['bit_clock']:.4e}")
+print(f"sample_clock = {result['sample_clock']:.4e}")
+print(f"mode         = {result['mode']} ({result['jesd_class']})")
+print(f"M={result['M']}, L={result['L']}, Np={result['Np']}")
+```
+
+The result is whichever mode achieves the highest `bit_clock` within the
+JESD204C class limits.
+
+The input `conv` is not mutated — the function deep-copies it for each
+attempt — so it is safe to call against an object you intend to use
+afterward.
+
+## Step 2: Apply an FPGA lane-rate cap
+
+Pass an `fpga` to bound the search by the FPGA's QPLL VCO ceiling (and
+its `max_serdes_lanes`):
+
+```{exec_code}
+:caption_output: Max lane rate, AD9081_RX + ZC706
+
+import adijif
+
+conv = adijif.ad9081_rx()
+fpga = adijif.xilinx()
+fpga.setup_by_dev_kit_name("zc706")
+fpga.sys_clk_select = "XCVR_QPLL0"
+
+result = adijif.utils.find_extreme_rate(
+    conv, target="lane", sense="max", fpga=fpga
+)
+print(f"bit_clock    = {result['bit_clock']:.4e}")
+print(f"sample_clock = {result['sample_clock']:.4e}")
+print(f"mode         = {result['mode']} ({result['jesd_class']})")
+```
+
+With ZC706 in the loop the cap drops from the JESD204C maximum to the
+QPLL-derived bit-rate limit (10.3125 GHz for 7-Series GTX).
+
+## Step 3: Pin a JESD mode
+
+Pass `mode=` (and `jesd_class=` if the mode key is ambiguous across
+JESD204B and JESD204C) to skip enumeration and solve for one mode only.
+This is the fast path when you already know which mode you want and just
+need the maximum achievable rate within it:
+
+```{exec_code}
+:caption_output: Max lane rate in a specific mode
+
+import adijif
+
+conv = adijif.ad9081_rx()
+fpga = adijif.xilinx()
+fpga.setup_by_dev_kit_name("zc706")
+fpga.sys_clk_select = "XCVR_QPLL0"
+
+result = adijif.utils.find_extreme_rate(
+    conv,
+    target="lane",
+    sense="max",
+    mode="19.0",
+    jesd_class="jesd204b",
+    fpga=fpga,
+)
+print(f"bit_clock    = {result['bit_clock']:.4e}")
+print(f"sample_clock = {result['sample_clock']:.4e}")
+```
+
+## Step 4: Minimize instead
+
+Set `sense="min"` to find the slowest valid rate, or `target="sample"`
+to optimize the sample rate directly instead of the lane rate:
+
+```{exec_code}
+:caption_output: Minimum sample rate
+
+import adijif
+
+conv = adijif.ad9081_rx()
+result = adijif.utils.find_extreme_rate(
+    conv, target="sample", sense="min",
+    mode="19.0", jesd_class="jesd204b",
+)
+print(f"sample_clock = {result['sample_clock']:.4e}")
+print(f"bit_clock    = {result['bit_clock']:.4e}")
+```
+
+The minimum sample rate is whatever brings `bit_clock` down to the
+JESD204B class minimum (1.5 GHz here) or the device's
+`sample_clock_min`, whichever binds first.
+
+## Step 5: Solve with a full clock chain
+
+Adding a `clock` chip (plus `vcxo`) takes the analysis from "what's
+theoretically achievable" to "what's actually reachable end-to-end". The
+solver now also has to satisfy the clock chip's dividers, so a mode that
+needs an awkward fractional reference clock can become infeasible. When
+`clock` is supplied, `fpga` and `vcxo` are required:
+
+```{exec_code}
+:caption_output: Max lane rate, AD9680 + HMC7044 + ZC706
+
+import adijif
+
+conv = adijif.ad9680()
+clock = adijif.hmc7044()
+fpga = adijif.xilinx()
+fpga.setup_by_dev_kit_name("zc706")
+
+result = adijif.utils.find_extreme_rate(
+    conv,
+    target="lane",
+    sense="max",
+    mode="64",
+    jesd_class="jesd204b",
+    clock=clock,
+    fpga=fpga,
+    vcxo=125e6,
+)
+print(f"bit_clock     = {result['bit_clock']:.4e}")
+print(f"sample_clock  = {result['sample_clock']:.4e}")
+print(f"clock_config keys: {list(result['clock_config'].keys())}")
+print(f"fpga_config keys:  {list(result['fpga_config'].keys())}")
+```
+
+In clock-chain mode the result dict includes `clock_config` (HMC7044
+dividers and output rates) and `fpga_config` (FPGA transceiver PLL
+selection) — everything you need to reproduce the solution in a full
+`adijif.system` solve.
+
+## Result shape
+
+Every call returns the same dict shape:
+
+| key                | meaning                                                       |
+| ------------------ | ------------------------------------------------------------- |
+| `sample_clock`     | Sample rate (Hz) of the winning configuration                 |
+| `bit_clock`        | Lane rate (Hz)                                                |
+| `mode`             | JESD quick-configuration mode key                             |
+| `jesd_class`       | `"jesd204b"` or `"jesd204c"`                                  |
+| `M`, `L`, `Np`, `F`, `S`, `K` | Resolved JESD parameters                           |
+| `clock_config`     | Clock chip config (full chain mode only; otherwise `None`)    |
+| `fpga_config`      | FPGA transceiver config (full chain mode only)                |
+| `objective_value`  | Numerical value the solver optimized — `bit_clock` when `target="lane"`, `sample_clock` when `target="sample"` |
+
+## Choosing the right mode
+
+| Goal                                                | Args                                |
+| --------------------------------------------------- | ----------------------------------- |
+| Quick JESD-class ceiling check                      | `target`, `sense`                   |
+| Add an FPGA lane-rate cap                           | `+ fpga=`                           |
+| Pin a specific mode                                 | `+ mode=, jesd_class=`              |
+| Require the clock chip to actually produce the ref  | `+ clock=, fpga=, vcxo=`            |
+
+## Relationship to `get_max_sample_rates`
+
+`adijif.utils.get_max_sample_rates` returns one entry per `M`
+(channel count) and uses a closed-form check rather than the solver, so
+it is faster for "give me the per-channel-count summary" workflows. Use
+`find_extreme_rate` when you want a single global winner, a `min`
+sense, or a clock-chain-aware result. The two agree on the constraint-only
+path for the configurations they both cover.
+
+## What's next
+
+- The {py:class}`adijif.optimization.Objective` framework
+  (see [Constraints and Optimization](optimization.md)) is what
+  `find_extreme_rate` ultimately calls into; everything you can express
+  by hand with `sys.add_objective` is available there.
+- Nested converters (full MxFE / transceiver devices) are rejected by
+  `find_extreme_rate`; pass the rx or tx side directly (e.g.
+  `adijif.ad9081_rx()`).
+- The gekko solver backend is not supported — the function requires
+  `solver="CPLEX"` and the `[cplex]` extra.

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -119,6 +119,7 @@ tools.md
 mcp_server.md
 flow.md
 optimization.md
+finding_extreme_rates.md
 converters.md
 clocking/index
 fpgas/index

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -248,6 +248,248 @@ def test_generate_max_rates_fpga_utility():
         assert result in ref
 
 
+def test_find_extreme_rate_single_mode_max_lane_no_fpga():
+    """Single mode, max lane rate, no FPGA: should equal JESD-class max."""
+    conv = jif.ad9081_rx()
+    result = jif.utils.find_extreme_rate(
+        conv, target="lane", sense="max", mode="19.0", jesd_class="jesd204b"
+    )
+    assert result["bit_clock"] == 15.5e9
+    assert result["jesd_class"] == "jesd204b"
+    assert result["mode"] == "19.0"
+    # Input converter must not be mutated
+    assert conv._sample_clock == 122.88e6
+
+
+def test_find_extreme_rate_single_mode_min_sample_no_fpga():
+    """Single mode, min sample rate: bounded by JESD-class bit_clock_min."""
+    conv = jif.ad9081_rx()
+    result = jif.utils.find_extreme_rate(
+        conv, target="sample", sense="min", mode="19.0", jesd_class="jesd204b"
+    )
+    # bit_clock_min[jesd204b] = 1.5e9; factor = L*en/(ed*M*Np) = 8*8/(10*2*16) = 0.2
+    # sc_min = 1.5e9 * 0.2 = 3e8
+    assert result["sample_clock"] == 3e8
+    assert result["bit_clock"] == 1.5e9
+
+
+def test_find_extreme_rate_with_fpga_matches_get_max_sample_rates():
+    """With FPGA, single mode matches the reference brute-force result."""
+    conv = jif.ad9081_rx()
+    fpga = jif.xilinx()
+    fpga.setup_by_dev_kit_name("zc706")
+    fpga.sys_clk_select = "XCVR_QPLL0"
+
+    # Mode 19.01 (M=1, L=8) bounded by converter sample_clock_max = 4e9
+    result_19_01 = jif.utils.find_extreme_rate(
+        conv,
+        target="lane",
+        sense="max",
+        mode="19.01",
+        jesd_class="jesd204b",
+        fpga=fpga,
+    )
+    assert result_19_01["bit_clock"] == 10e9
+    assert result_19_01["sample_clock"] == 4e9
+    assert result_19_01["M"] == 1
+    assert result_19_01["L"] == 8
+
+    # Mode 19.0 (M=2, L=8) bounded by FPGA QPLL VCO cap
+    result_19_0 = jif.utils.find_extreme_rate(
+        conv,
+        target="lane",
+        sense="max",
+        mode="19.0",
+        jesd_class="jesd204b",
+        fpga=fpga,
+    )
+    assert result_19_0["bit_clock"] == 10.3125e9
+    assert result_19_0["sample_clock"] == 2.0625e9
+    assert result_19_0["M"] == 2
+
+
+def test_find_extreme_rate_enumerate_modes_no_fpga():
+    """Mode=None enumerates all modes and picks the best."""
+    conv = jif.ad9081_rx()
+    result = jif.utils.find_extreme_rate(conv, target="lane", sense="max")
+    # Max possible: jesd204c bit_clock_max = 24.75e9
+    assert result["bit_clock"] == 24.75e9
+    assert result["jesd_class"] == "jesd204c"
+
+
+def test_find_extreme_rate_enumerate_modes_with_fpga():
+    """Enumeration with FPGA cap; max sample rate respects converter cap."""
+    conv = jif.ad9081_rx()
+    fpga = jif.xilinx()
+    fpga.setup_by_dev_kit_name("zc706")
+    fpga.sys_clk_select = "XCVR_QPLL0"
+
+    result = jif.utils.find_extreme_rate(
+        conv, target="sample", sense="max", fpga=fpga
+    )
+    # AD9081_RX sample_clock_max = 4e9; achievable in mode 19.01
+    assert result["sample_clock"] == 4e9
+
+
+def test_find_extreme_rate_does_not_mutate_input():
+    """Repeated calls leave the input converter's state untouched."""
+    conv = jif.ad9081_rx()
+    conv.sample_clock = 1.5e9
+    original_sc = conv._sample_clock
+    original_jesd = conv.jesd_class
+    jif.utils.find_extreme_rate(conv, target="lane", sense="max")
+    assert conv._sample_clock == original_sc
+    assert conv.jesd_class == original_jesd
+
+
+def test_find_extreme_rate_jesd_class_auto_search():
+    """Mode key that lives in only one JESD class is auto-detected."""
+    conv = jif.ad9680()
+    # AD9680 only supports jesd204b
+    result = jif.utils.find_extreme_rate(
+        conv, mode="64", target="lane", sense="max"
+    )
+    assert result["jesd_class"] == "jesd204b"
+
+
+def test_find_extreme_rate_ambiguous_mode_requires_jesd_class():
+    """Mode present in multiple classes errors when jesd_class is omitted."""
+    conv = jif.ad9081_rx()
+    with pytest.raises(ValueError, match="ambiguous"):
+        jif.utils.find_extreme_rate(conv, mode="19.0")
+
+
+def test_find_extreme_rate_invalid_target():
+    with pytest.raises(ValueError, match="target"):
+        jif.utils.find_extreme_rate(jif.ad9081_rx(), target="invalid")
+
+
+def test_find_extreme_rate_invalid_sense():
+    with pytest.raises(ValueError, match="sense"):
+        jif.utils.find_extreme_rate(jif.ad9081_rx(), sense="invalid")
+
+
+def test_find_extreme_rate_unknown_mode():
+    with pytest.raises(ValueError, match="not found"):
+        jif.utils.find_extreme_rate(
+            jif.ad9081_rx(), mode="999", jesd_class="jesd204b"
+        )
+
+
+def test_find_extreme_rate_nested_converter_rejected():
+    """Nested MxFE devices must be split into rx/tx before calling."""
+    with pytest.raises(Exception, match="nested"):
+        jif.utils.find_extreme_rate(jif.ad9081())
+
+
+def test_find_extreme_rate_clock_requires_fpga():
+    """Clock supplied without an FPGA is a hard error."""
+    with pytest.raises(ValueError, match="requires fpga"):
+        jif.utils.find_extreme_rate(
+            jif.ad9680(), clock=jif.hmc7044(), vcxo=125e6
+        )
+
+
+def test_find_extreme_rate_clock_requires_vcxo():
+    """Clock supplied without a VCXO is a hard error."""
+    fpga = jif.xilinx()
+    fpga.setup_by_dev_kit_name("zc706")
+    with pytest.raises(ValueError, match="vcxo is required"):
+        jif.utils.find_extreme_rate(
+            jif.ad9680(), clock=jif.hmc7044(), fpga=fpga
+        )
+
+
+def test_find_extreme_rate_vcxo_without_clock_rejected():
+    """vcxo passed without clock is rejected."""
+    fpga = jif.xilinx()
+    fpga.setup_by_dev_kit_name("zc706")
+    with pytest.raises(ValueError, match="vcxo is only meaningful"):
+        jif.utils.find_extreme_rate(jif.ad9680(), vcxo=125e6, fpga=fpga)
+
+
+def test_find_extreme_rate_with_clock_and_fpga_single_mode():
+    """Full clock chain: AD9680 + HMC7044 + ZC706 caps at the FPGA QPLL VCO."""
+    conv = jif.ad9680()
+    clock = jif.hmc7044()
+    fpga = jif.xilinx()
+    fpga.setup_by_dev_kit_name("zc706")
+
+    result = jif.utils.find_extreme_rate(
+        conv,
+        target="lane",
+        sense="max",
+        mode="64",
+        jesd_class="jesd204b",
+        clock=clock,
+        fpga=fpga,
+        vcxo=125e6,
+    )
+    # ZC706 GTX QPLL VCO max = 10.3125 GHz, applied as the bit-rate cap
+    assert result["bit_clock"] == 10.3125e9
+    assert result["sample_clock"] == 1.03125e9
+    assert result["mode"] == "64"
+    assert result["clock_config"] is not None
+    assert result["fpga_config"] is not None
+    assert "output_clocks" in result["clock_config"]
+    # Inputs unchanged
+    assert conv._sample_clock == 1e9  # AD9680 default
+    assert clock._objectives == [] or all(
+        not isinstance(o.expr, type(None)) for o in clock._objectives
+    )
+
+
+def test_find_extreme_rate_with_clock_min_sense():
+    """Min sense bounded by JESD-class bit_clock_min."""
+    conv = jif.ad9680()
+    clock = jif.hmc7044()
+    fpga = jif.xilinx()
+    fpga.setup_by_dev_kit_name("zc706")
+
+    result = jif.utils.find_extreme_rate(
+        conv,
+        target="lane",
+        sense="min",
+        mode="64",
+        jesd_class="jesd204b",
+        clock=clock,
+        fpga=fpga,
+        vcxo=125e6,
+    )
+    # AD9680 bit_clock_min[jesd204b] = 3.125e9
+    assert result["bit_clock"] == 3.125e9
+
+
+def test_find_extreme_rate_with_clock_enumerate_modes():
+    """Mode=None with clock+fpga enumerates and picks the winner."""
+    clock = jif.hmc7044()
+    fpga = jif.xilinx()
+    fpga.setup_by_dev_kit_name("zc706")
+    result = jif.utils.find_extreme_rate(
+        jif.ad9680(),
+        target="sample",
+        sense="max",
+        clock=clock,
+        fpga=fpga,
+        vcxo=125e6,
+    )
+    # AD9680 sample_clock_max = 1.25 GSPS, reachable via at least one mode
+    assert result["sample_clock"] == 1.25e9
+    assert result["clock_config"] is not None
+
+
+def test_find_extreme_rate_ad9680_ultrascaleplus():
+    """AD9680 with UltraScale+ FPGA enumeration returns a feasible result."""
+    conv = jif.ad9680()
+    fpga = jif.xilinx()
+    fpga.setup_by_dev_kit_name("vcu118")
+    result = jif.utils.find_extreme_rate(
+        conv, target="sample", sense="max", fpga=fpga
+    )
+    # AD9680 sample_clock_max = 1.25 GSPS
+    assert result["sample_clock"] == 1.25e9
+
+
 def test_generate_max_rates_utility():
     conv = jif.ad9081_rx()
     # conv.decimation = 1


### PR DESCRIPTION
## Summary

- Adds `adijif.utils.find_extreme_rate(conv, *, target, sense, fpga=None, clock=None, vcxo=None, mode=None, jesd_class=None)` — finds the max/min lane rate (`bit_clock`) or sample rate (`sample_clock`) for a converter via a CPLEX objective.
- Two modes: **constraint-only** (no `clock`, optional `fpga`) builds a minimal `CpoModel`; **full clock-chain** (`clock` + `fpga` + `vcxo`) wires through `adijif.system`. When `mode` is omitted, every `quick_configuration_mode` is enumerated.
- The input `conv`/`clock`/`fpga` are not mutated — every attempt runs on a deep copy.

## Why this exists

The current `get_max_sample_rates` is a post-solve brute force that never exercises the constraint solver, so it can't account for clock-chain feasibility or any constraint that isn't hard-coded into its enumeration loop. `find_extreme_rate` replaces the scalar `conv._sample_clock` with an `integer_var` bounded by the JESD-class limits (plus any FPGA / per-device caps), then routes through CPLEX `maximize`/`minimize` so future constraints can compose naturally.

## Notes / design choices

- Three scalar-only validation hooks on the converter (`_skip_clock_validation`, `_check_jesd_config`, `_check_valid_internal_configuration`) are bypassed in the clock+FPGA path because they can't tolerate a `CpoExpr`. The `integer_var` bounds enforce the same ranges at solve time.
- After solving, `_sample_clock` is rebound to the scalar solver value so `_get_configs()` (which contains FPGA PLL equality asserts comparing scalars to `converter.bit_clock`) works normally.
- The `clock`-without-`fpga` flow is rejected with a clear `ValueError` — `system.enable_fpga_clocks = False` is effectively a no-op in `system.initialize`'s wiring loop, so silently including FPGA constraints would be more confusing than erroring.

## Test plan

- [x] `nox -rs tests -- tests/test_utils.py -v` — 32/32 pass (15 new)
- [x] Regression slice across `test_system`, `test_optimization`, `test_more_coverage`, `test_utils` — 81 passed, 1 pre-existing skip
- [x] `ruff check` and `ruff format --check` clean on the two changed files
- [x] Cross-check vs `get_max_sample_rates` for AD9081_RX + ZC706: mode 19.01 → `bit_clock=10 GHz` / `sample_clock=4 GSPS`, mode 19.0 → `bit_clock=10.3125 GHz` / `sample_clock=2.0625 GSPS` — matches the existing reference dataset
- [x] End-to-end clock+FPGA: AD9680 + HMC7044 + ZC706 + vcxo=125 MHz, mode 64, max lane → `bit_clock=10.3125 GHz`, full `clock_config` and `fpga_config` populated