### PR TITLE
Fix shared device state and model correctness issues

### DIFF
--- a/adijif/clocks/hmc7044.py
+++ b/adijif/clocks/hmc7044.py
@@ -488,7 +488,7 @@ class hmc7044(hmc7044_bf):
         if self.solver == "gekko":
             __d = self._d if isinstance(self._d, list) else [self._d]
 
-            if __d.sort() != self.d_available.sort():
+            if sorted(__d) != sorted(self.d_available):
                 raise Exception(
                     "For solver gekko d is not configurable for HMC7044"
                 )
@@ -539,7 +539,7 @@ class hmc7044(hmc7044_bf):
         for d_n, out_freq in enumerate(out_freqs):
             if self.solver == "gekko":
                 __d = self._d if isinstance(self._d, list) else [self._d]
-                if __d.sort() != self.d_available.sort():
+                if sorted(__d) != sorted(self.d_available):
                     raise Exception(
                         "For solver gekko d is not configurable for HMC7044"
                     )

--- a/adijif/clocks/ltc6952.py
+++ b/adijif/clocks/ltc6952.py
@@ -580,7 +580,7 @@ class ltc6952(ltc6952_bf):
         if self.solver == "gekko":
             __d = self._d if isinstance(self._d, list) else [self._d]
 
-            if __d.sort() != self.d_available.sort():
+            if sorted(__d) != sorted(self.d_available):
                 raise Exception(
                     "For solver gekko d is not configurable for LTC6952"
                 )
@@ -621,7 +621,7 @@ class ltc6952(ltc6952_bf):
         for out_freq, clk_name in zip(out_freqs, clk_names):  # noqa: B905
             if self.solver == "gekko":
                 __d = self._d if isinstance(self._d, list) else [self._d]
-                if __d.sort() != self.d_available.sort():
+                if sorted(__d) != sorted(self.d_available):
                     raise Exception(
                         "For solver gekko d is not configurable for LTC6952"
                     )

--- a/adijif/converters/ad9081.py
+++ b/adijif/converters/ad9081.py
@@ -369,6 +369,7 @@ class ad9081_rx(ad9081_rx_draw, adc, ad9081_core):
             *args (Any): Pass through arguments
             **kwargs (Any): Pass through keyword arguments
         """
+        self.datapath = ad9081_dp_rx()
         self.set_quick_configuration_mode("3.01", "jesd204b")
         self.datapath.cddc_decimations = [2] * 4
         self.datapath.fddc_decimations = [4] * 8
@@ -491,6 +492,7 @@ class ad9081_tx(ad9081_tx_draw, dac, ad9081_core):
             *args (Any): Pass through arguments
             **kwargs (Any): Pass through keyword arguments
         """
+        self.datapath = ad9081_dp_tx()
         self.set_quick_configuration_mode("0", "jesd204c")
         self.datapath.cduc_interpolation = 6
         self.datapath.fduc_interpolation = 4

--- a/adijif/converters/ad9081_dp.py
+++ b/adijif/converters/ad9081_dp.py
@@ -21,6 +21,18 @@ class ad9081_dp_rx:
 
     def __init__(self) -> None:
         """Initialize the AD9081 RX datapath."""
+        for name in (
+            "cddc_enabled",
+            "cddc_decimations",
+            "cddc_nco_frequencies",
+            "cddc_nco_phases",
+            "fddc_enabled",
+            "fddc_decimations",
+            "fddc_nco_frequencies",
+            "fddc_nco_phases",
+            "fddc_source",
+        ):
+            object.__setattr__(self, name, list(getattr(type(self), name)))
         self._freeze()
 
     def __setattr__(self, key: str, value: any) -> None:
@@ -144,6 +156,18 @@ class ad9081_dp_tx:
 
     def __init__(self) -> None:
         """Initialize the AD9081 TX datapath."""
+        for name in (
+            "cduc_enabled",
+            "cduc_nco_frequencies",
+            "cduc_nco_phases",
+            "fduc_enabled",
+            "fduc_nco_frequencies",
+            "fduc_nco_phases",
+        ):
+            object.__setattr__(self, name, list(getattr(type(self), name)))
+        object.__setattr__(
+            self, "cduc_sources", [list(source) for source in self.cduc_sources]
+        )
         self._freeze()
 
     def __setattr__(self, key: str, value: any) -> None:

--- a/adijif/converters/ad9084.py
+++ b/adijif/converters/ad9084.py
@@ -326,6 +326,9 @@ class ad9084_rx(adc, ad9084_core):
             *args (Any): Pass through arguments
             **kwargs (Any): Pass through keyword arguments
         """
+        self.datapath = (
+            ad9084_dp_rx() if "AD9084" in self.name else ad9088_dp_rx()
+        )
         self.sample_clock = int(2.5e9) if "AD9084" in self.name else int(1e9)
         N = 1 if "9084" in self.name else 2
         self.datapath.cddc_decimations = [4] * 4 * N
@@ -460,11 +463,8 @@ class ad9084_tx(dac, ad9084_core):
             model (CpoModel): Solver model
             solver (str): Solver name (CPLEX)
         """
-        if solver:
-            self.solver = solver
-        if model:
-            self.model = model
-        self.datapath = ad9084_dp_tx()  # fresh per-instance datapath
+        super().__init__(model=model, solver=solver)
+        self.datapath = ad9084_dp_tx()
         self.sample_clock = int(8e9)
         self.set_quick_configuration_mode("2", "jesd204c")
 

--- a/adijif/converters/ad9084_dp.py
+++ b/adijif/converters/ad9084_dp.py
@@ -18,6 +18,21 @@ class ad9084_dp_rx:
 
     fddc_source = [1, 1, 2, 2, 3, 3, 4, 4]
 
+    def __init__(self) -> None:
+        """Initialize mutable datapath settings for this instance."""
+        for name in (
+            "cddc_enabled",
+            "cddc_decimations",
+            "cddc_nco_frequencies",
+            "cddc_nco_phases",
+            "fddc_enabled",
+            "fddc_decimations",
+            "fddc_nco_frequencies",
+            "fddc_nco_phases",
+            "fddc_source",
+        ):
+            setattr(self, name, list(getattr(type(self), name)))
+
     def get_config(self) -> dict:
         """Get the datapath configuration for the AD9084 RX.
 
@@ -93,6 +108,20 @@ class ad9084_dp_tx:
     cduc_sources = [[1], [1], [3], [3]]
     # fduc_source[i] maps FDUC i (0-indexed) to its parent CDUC (1-indexed)
     fduc_source = [1, 1, 2, 2, 3, 3, 4, 4]
+
+    def __init__(self) -> None:
+        """Initialize mutable datapath settings for this instance."""
+        for name in (
+            "cduc_enabled",
+            "cduc_nco_frequencies",
+            "cduc_nco_phases",
+            "fduc_enabled",
+            "fduc_nco_frequencies",
+            "fduc_nco_phases",
+            "fduc_source",
+        ):
+            setattr(self, name, list(getattr(type(self), name)))
+        self.cduc_sources = [list(source) for source in type(self).cduc_sources]
 
     @property
     def interpolation_overall(self) -> int:

--- a/adijif/converters/ad9088_dp.py
+++ b/adijif/converters/ad9088_dp.py
@@ -18,6 +18,21 @@ class ad9088_dp_rx:
 
     fddc_source = [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8]
 
+    def __init__(self) -> None:
+        """Initialize mutable datapath settings for this instance."""
+        for name in (
+            "cddc_enabled",
+            "cddc_decimations",
+            "cddc_nco_frequencies",
+            "cddc_nco_phases",
+            "fddc_enabled",
+            "fddc_decimations",
+            "fddc_nco_frequencies",
+            "fddc_nco_phases",
+            "fddc_source",
+        ):
+            setattr(self, name, list(getattr(type(self), name)))
+
     def get_config(self) -> dict:
         """Get the datapath configuration for the AD9088 RX.
 

--- a/adijif/draw.py
+++ b/adijif/draw.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import os
+import subprocess  # noqa: S404
 from importlib.util import find_spec
 from typing import Union
 
@@ -536,12 +536,18 @@ class Layout:
             with open(self.output_filename, "w") as f:
                 f.write(diag)
 
-            cmd = (
-                f"d2 --theme=0 --dark-theme=200 -l {self.layout_engine} "
-                + f"{self.output_filename} "
+            subprocess.run(  # noqa: S603
+                [  # noqa: S607
+                    "d2",
+                    "--theme=0",
+                    "--dark-theme=200",
+                    "-l",
+                    self.layout_engine,
+                    self.output_filename,
+                    self.output_image_filename,
+                ],
+                check=True,
             )
-            cmd += f"{self.output_image_filename}"
-            os.system(cmd)  # noqa: S605
             return self.output_image_filename
         else:
             if self._write_out_d2_file:

--- a/adijif/fpgas/xilinx/__init__.py
+++ b/adijif/fpgas/xilinx/__init__.py
@@ -1,6 +1,6 @@
 """Xilinx FPGA clocking model."""
 
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from docplex.cp.modeler import if_then
 
@@ -29,6 +29,18 @@ class xilinx(xilinx_bf, xilinx_draw):
     """
 
     name = "Xilinx-FPGA"
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize solver state and per-instance FPGA build state."""
+        super().__init__(*args, **kwargs)
+        self._clock_names = []
+        self._used_progdiv = {}
+        self._device_clock_source = list(type(self)._device_clock_source)
+        self._out_clk_select = list(type(self)._out_clk_select)
+        self.configs = []
+        self._transceiver_models = {}
+        self._use_gearbox = {}
+        self._sps = {}
 
     """Force generation of separate device clock from the clock chip. In many
     cases, the ref clock and device clock can be the same."""
@@ -1023,7 +1035,7 @@ class xilinx(xilinx_bf, xilinx_draw):
         self._use_gearbox[converter.name] = (
             data_path_width != tpl_data_path_width
         )
-        if self._use_gearbox:
+        if self._use_gearbox[converter.name]:
             device_clock_rate = (
                 link_layer_input_rate * data_path_width / tpl_data_path_width
             )

--- a/adijif/fpgas/xilinx/ultrascaleplus.py
+++ b/adijif/fpgas/xilinx/ultrascaleplus.py
@@ -168,7 +168,7 @@ class QPLL(SevenSeriesQPLL):
     _QPLL_CLKOUTRATE_GTH = [1, 2]
 
     @property
-    def QPLL_CLKOUTRATE(self) -> int:
+    def QPLL_CLKOUTRATE(self) -> Union[int, List[int]]:
         """Get the QPLL_CLKOUTRATE value."""
         if "GTH" in self.parent.transceiver_type:
             return self._QPLL_CLKOUTRATE_GTH
@@ -189,9 +189,12 @@ class QPLL(SevenSeriesQPLL):
         )
         if "GTH" in self.parent.transceiver_type:
             self._QPLL_CLKOUTRATE_GTH = val
-        raise ValueError(
-            f"QPLL_CLKOUTRATE not available for {self.parent.transceiver_type}"
-        )
+        elif "GTY" in self.parent.transceiver_type:
+            self._QPLL_CLKOUTRATE_GTY = val
+        else:
+            raise ValueError(
+                f"QPLL_CLKOUTRATE not available for {self.parent.transceiver_type}"
+            )
 
     SDMDATA_min_max = [0, 2**24 - 1]
     _SDMDATA_min = 0

--- a/tests/test_device_state_cleanup.py
+++ b/tests/test_device_state_cleanup.py
@@ -1,0 +1,104 @@
+"""Regression tests for device-instance state and focused model defects."""
+
+from types import SimpleNamespace
+
+import pytest
+
+import adijif
+from adijif.fpgas.xilinx.ultrascaleplus import QPLL
+
+
+@pytest.mark.parametrize(
+    "device_type, mutable_attribute",
+    [
+        (adijif.ad9081_rx, "cddc_decimations"),
+        (adijif.ad9081_tx, "fduc_enabled"),
+        (adijif.ad9084_rx, "cddc_decimations"),
+        (adijif.ad9088_rx, "cddc_decimations"),
+        (adijif.ad9084_tx, "fduc_enabled"),
+        (adijif.ad9088_tx, "fduc_enabled"),
+    ],
+)
+def test_converter_datapath_is_per_instance(device_type, mutable_attribute):
+    """Mutating one converter datapath must not affect another instance."""
+    first = device_type(solver="gekko")
+    second = device_type(solver="gekko")
+
+    assert first.datapath is not second.datapath
+    first_values = getattr(first.datapath, mutable_attribute)
+    second_values = getattr(second.datapath, mutable_attribute)
+    assert first_values is not second_values
+
+    original = list(second_values)
+    first_values[0] = not first_values[0] if isinstance(first_values[0], bool) else 99
+    assert getattr(second.datapath, mutable_attribute) == original
+
+
+def test_ad9084_tx_runs_common_initialization():
+    """AD9084 TX must initialize the state guaranteed by core."""
+    device = adijif.ad9084_tx(solver="gekko")
+
+    assert device.model is not None
+    assert device.configs == []
+    assert device._objectives == []
+    assert device._disabled_objectives == set()
+    assert device._last_config is None
+
+
+def test_xilinx_runtime_state_is_per_instance():
+    """FPGA constraint-build collections must not leak between instances."""
+    first = adijif.xilinx(solver="gekko")
+    second = adijif.xilinx(solver="gekko")
+
+    for attribute in (
+        "_clock_names",
+        "_used_progdiv",
+        "_device_clock_source",
+        "_out_clk_select",
+        "configs",
+        "_transceiver_models",
+        "_use_gearbox",
+        "_sps",
+    ):
+        assert getattr(first, attribute) is not getattr(second, attribute)
+
+    first._clock_names.append("first_only")
+    first._use_gearbox["converter"] = True
+    assert second._clock_names == []
+    assert second._use_gearbox == {}
+
+
+@pytest.mark.parametrize(
+    "clock_type, message",
+    [
+        (adijif.hmc7044, "HMC7044"),
+        (adijif.ltc6952, "LTC6952"),
+    ],
+)
+def test_gekko_restricted_output_dividers_are_detected(clock_type, message):
+    """Restricted divider lists must not bypass the documented GEKKO guard."""
+    clock = clock_type(solver="gekko")
+    clock.d = [1]
+
+    with pytest.raises(Exception, match=message):
+        clock.set_requested_clocks(100_000_000, [10_000_000], ["out"])
+
+
+@pytest.mark.parametrize("transceiver_type", ["GTHE4", "GTYE4"])
+def test_ultrascale_qpll_clkout_rate_can_be_set(transceiver_type):
+    """Valid GTH and GTY clock-output-rate selections must be retained."""
+    qpll = object.__new__(QPLL)
+    qpll.parent = SimpleNamespace(transceiver_type=transceiver_type)
+
+    qpll.QPLL_CLKOUTRATE = 1
+
+    assert qpll.QPLL_CLKOUTRATE == 1
+
+
+def test_ultrascale_qpll_clkout_rate_rejects_unavailable_value():
+    """GTHE4 supports rate selections one and two only."""
+    qpll = object.__new__(QPLL)
+    qpll.parent = SimpleNamespace(transceiver_type="GTHE4")
+
+    with pytest.raises(Exception, match="QPLL_CLKOUTRATE"):
+        qpll.QPLL_CLKOUTRATE = 4


### PR DESCRIPTION
## Summary

- make AD9081, AD9084, and AD9088 datapath runtime collections instance-local
- initialize Xilinx FPGA constraint-build state per instance
- restore common initialization for AD9084 TX
- fix Xilinx gearbox selection and UltraScale+ QPLL clock-output-rate assignment
- fix ineffective GEKKO divider-domain checks for HMC7044 and LTC6952
- add focused regression coverage for instance isolation and corrected model behavior

## Motivation

Several device classes stored mutable datapath or FPGA build state at class scope. Constructing or modifying one device could therefore affect another instance. The focused tests added here reproduced nine failures before the fixes.

This also addresses concrete correctness issues found during the audit: the gearbox branch checked the dictionary rather than the current converter value, the UltraScale+ QPLL setter always raised after valid assignments, and the GEKKO divider guards compared the `None` return values from `list.sort()`.

## Verification

```text
uvx ruff check <changed Python files>
All checks passed!

pytest -q tests/test_device_state_cleanup.py tests/test_ad9084.py tests/test_converter.py tests/test_clocks.py tests/test_xilinx_coverage.py --ignore=tests/tools/e2e
85 passed, 9 warnings in 1.57s
```

The warnings are existing environment/library warnings from pytest configuration, GEKKO with NumPy 2.x, and partially constructed `system` teardown in failure-path tests.