### PR TITLE
Fix Xilinx brute-force PLL error handling

### DIFF
--- a/adijif/fpgas/xilinx/__init__.py
+++ b/adijif/fpgas/xilinx/__init__.py
@@ -12,7 +12,7 @@ from ...solvers import (
     GK_Operators,
     GKVariable,
 )
-from .bf import xilinx_bf
+from .bf import CPLLConfigurationError, xilinx_bf
 from .sevenseries import SevenSeries as SSTransceiver
 from .ultrascaleplus import UltraScalePlus as USPTransceiver
 from .versal import Versal as VersalTransceiver
@@ -518,7 +518,7 @@ class xilinx(xilinx_bf, xilinx_draw):
         """
         try:
             info = self.determine_cpll(bit_clock, fpga_ref_clock)
-        except:  # noqa: B001
+        except CPLLConfigurationError:
             info = self.determine_qpll(bit_clock, fpga_ref_clock)
         return info
 
@@ -1106,70 +1106,6 @@ class xilinx(xilinx_bf, xilinx_draw):
                     "Invalid device clock and reference clock \n"
                     + f"relation {self.device_clock_and_ref_clock_relation}"
                 )
-
-        return config
-
-        # Add optimization to favor a single reference clock vs unique ref+device clocks
-        config[converter.name + "single_clk"] = self._convert_input(
-            [0, 1], converter.name + "single_clk"
-        )
-        if self.force_separate_device_clock:
-            sdc = [1]
-        else:
-            sdc = [0, 1]
-        config[converter.name + "two_clks"] = self._convert_input(
-            sdc, converter.name + "two_clks"
-        )
-        self._add_equation(
-            [
-                config[converter.name + "single_clk"]
-                + config[converter.name + "two_clks"]
-                == 1,
-            ]
-        )
-        # Favor single clock, this equation will be minimized
-        v = (
-            config[converter.name + "single_clk"]
-            + 1000 * config[converter.name + "two_clks"]
-        )
-        self._add_objective(v)
-
-        # Add constraints to meet sample clock
-        if self.requires_core_clock_from_device_clock:
-            if converter.jesd_class == "jesd204b":
-                core_clock = converter.bit_clock / 40
-            else:
-                core_clock = converter.bit_clock / 66
-
-            self._add_equation([core_clock == link_out_ref])
-
-        else:
-            possible_divs = []
-            for samples_per_clock in [1, 2, 4, 8, 16]:
-                if (
-                    converter.sample_clock / samples_per_clock
-                    <= self.target_Fmax
-                ):
-                    possible_divs.append(samples_per_clock)
-
-            if len(possible_divs) == 0:
-                raise Exception("Link layer output clock rate too high")
-
-            config[converter.name + "_link_out_div"] = self._convert_input(
-                possible_divs, converter.name + "_samples_per_clock"
-            )
-
-            self._add_equation(
-                [
-                    (
-                        config[converter.name + "single_clk"] * fpga_ref
-                        + config[converter.name + "two_clks"]
-                        * link_out_ref
-                        * config[converter.name + "_link_out_div"]
-                    )
-                    == converter.sample_clock
-                ]
-            )
 
         return config
 

--- a/adijif/fpgas/xilinx/bf.py
+++ b/adijif/fpgas/xilinx/bf.py
@@ -2,8 +2,13 @@
 from adijif.fpgas.fpga import fpga
 
 
+class CPLLConfigurationError(Exception):
+    """Raised when no CPLL configuration satisfies the requested clocks."""
+
+
 class xilinx_bf(fpga):
     max_serdes_lanes = 16
+    transceiver_type = ""
 
     def get_config(self, converter, fpga_ref, solution=None):
         return {}
@@ -53,7 +58,7 @@ class xilinx_bf(fpga):
                                 "type": "CPLL",
                             }
 
-        raise Exception("No valid CPLL configuration found")
+        raise CPLLConfigurationError("No valid CPLL configuration found")
 
     def determine_qpll(self, bit_clock, fpga_ref_clock):
         """
@@ -92,7 +97,7 @@ class xilinx_bf(fpga):
                             "type": "QPLL",
                         }
 
-                    if self.transciever_type != "GTY4":
+                    if self.transceiver_type != "GTY4":
                         continue
 
                     if fpga_ref_clock / m / d == bit_clock / 2 / n:

--- a/tests/test_xilinx_coverage.py
+++ b/tests/test_xilinx_coverage.py
@@ -3,6 +3,7 @@
 import pytest
 
 import adijif
+from adijif.fpgas.xilinx.bf import CPLLConfigurationError
 
 
 def test_xilinx_setup_by_dev_kit_vck190():
@@ -63,3 +64,42 @@ def test_xilinx_str_representation():
     """Verify __str__ representation."""
     fpga = adijif.xilinx()
     assert "adijif.fpgas.xilinx.xilinx" in str(fpga)
+
+
+def test_determine_pll_falls_back_only_for_infeasible_cpll(monkeypatch):
+    """Programming errors in CPLL discovery must not be hidden by QPLL fallback."""
+    fpga = adijif.xilinx()
+    qpll_config = {"type": "QPLL"}
+
+    monkeypatch.setattr(
+        fpga,
+        "determine_cpll",
+        lambda *_: (_ for _ in ()).throw(CPLLConfigurationError()),
+    )
+    monkeypatch.setattr(fpga, "determine_qpll", lambda *_: qpll_config)
+    assert fpga.determine_pll(1, 1) == qpll_config
+
+    monkeypatch.setattr(
+        fpga,
+        "determine_cpll",
+        lambda *_: (_ for _ in ()).throw(RuntimeError("implementation defect")),
+    )
+    with pytest.raises(RuntimeError, match="implementation defect"):
+        fpga.determine_pll(1, 1)
+
+
+def test_gty4_qpll_full_rate_path():
+    """GTY4 brute-force discovery must use the full-rate QPLL path."""
+    fpga = adijif.xilinx()
+    fpga.transceiver_type = "GTY4"
+    fpga.ref_clock_min = 60_000_000
+    fpga.ref_clock_max = 820_000_000
+    fpga.vco0_min = 8_000_000_000
+    fpga.vco0_max = 9_800_000_000
+    fpga.vco1_min = 9_800_000_000
+    fpga.vco1_max = 13_000_000_000
+    fpga.N = [16, 20, 32, 40, 64, 66, 80, 100]
+
+    config = fpga.determine_qpll(16_000_000_000, 80_000_000)
+
+    assert config["qty4_full_rate"] == 1


### PR DESCRIPTION
## Summary

- use a dedicated CPLL infeasibility exception so QPLL fallback does not hide implementation defects
- correct the GTY4 transceiver attribute typo in brute-force QPLL discovery
- remove an unreachable duplicate constraint block after an unconditional return
- add regression tests for narrow fallback behavior and the GTY4 full-rate QPLL path

## Verification

```text
pytest -q tests/test_xilinx_coverage.py tests/test_fpga.py tests/test_xilinx_pll.py
28 passed, 1 warning

ruff check adijif/fpgas/xilinx tests/test_xilinx_coverage.py
All checks passed!

ty check <project CI arguments>
All checks passed!

git diff --check
passed
```