### PR TITLE
Preserve legacy Xilinx transceiver attribute

### DIFF
--- a/adijif/fpgas/xilinx/bf.py
+++ b/adijif/fpgas/xilinx/bf.py
@@ -97,7 +97,10 @@ class xilinx_bf(fpga):
                             "type": "QPLL",
                         }
 
-                    if self.transceiver_type != "GTY4":
+                    transceiver_type = self.transceiver_type or getattr(
+                        self, "transciever_type", ""
+                    )
+                    if transceiver_type != "GTY4":
                         continue
 
                     if fpga_ref_clock / m / d == bit_clock / 2 / n:


### PR DESCRIPTION
## Summary

- restore compatibility with existing brute-force subclasses that define the historical `transciever_type` spelling
- prefer the canonical `transceiver_type` attribute while using the legacy spelling as a fallback
- fix the post-merge default-branch test failure introduced by #251

## Verification

```text
pytest -q tests/test_xilinx_bf.py tests/test_xilinx_coverage.py tests/test_fpga.py tests/test_xilinx_pll.py
33 passed, 1 warning

ruff check adijif/fpgas/xilinx/bf.py
All checks passed!

git diff --check
passed
```