### PR TITLE
Correct abstract device operation interfaces

### DIFF
--- a/adijif/clocks/clock.py
+++ b/adijif/clocks/clock.py
@@ -69,7 +69,6 @@ class clock(core, gekko_translation, metaclass=ABCMeta):
 
         return vcxo
 
-    @property
     @abstractmethod
     def find_dividers(self) -> Dict:
         """Find all possible divider settings that validate config.
@@ -79,7 +78,6 @@ class clock(core, gekko_translation, metaclass=ABCMeta):
         """
         raise NotImplementedError  # pragma: no cover
 
-    @property
     @abstractmethod
     def list_available_references(self) -> List[int]:
         """Determine all references that can be generated.

--- a/adijif/fpgas/fpga.py
+++ b/adijif/fpgas/fpga.py
@@ -17,9 +17,8 @@ class fpga(core, gekko_translation, metaclass=ABCMeta):
     """
     requires_separate_link_layer_out_clock: bool = False
 
-    @property
     @abstractmethod
-    def determine_cpll(self) -> None:
+    def determine_cpll(self, bit_clock: int, fpga_ref_clock: int) -> Dict:
         """Try to use CPLL for clocking.
 
         This method is only used in brute-force classes
@@ -29,9 +28,8 @@ class fpga(core, gekko_translation, metaclass=ABCMeta):
         """
         raise NotImplementedError  # pragma: no cover
 
-    @property
     @abstractmethod
-    def determine_qpll(self) -> None:
+    def determine_qpll(self, bit_clock: int, fpga_ref_clock: int) -> Dict:
         """Try to use QPLL for clocking.
 
         This method is only used in brute-force classes
@@ -41,7 +39,6 @@ class fpga(core, gekko_translation, metaclass=ABCMeta):
         """
         raise NotImplementedError  # pragma: no cover
 
-    @property
     @abstractmethod
     def get_config(  # type: ignore
         self,

--- a/tests/test_abstract_device_interfaces.py
+++ b/tests/test_abstract_device_interfaces.py
@@ -1,0 +1,20 @@
+"""Tests for callable abstract device interfaces."""
+
+import inspect
+
+from adijif.clocks.clock import clock
+from adijif.fpgas.fpga import fpga
+
+
+def test_clock_abstract_operations_are_methods():
+    """Clock discovery operations accept inputs and must remain callable."""
+    assert inspect.isfunction(inspect.getattr_static(clock, "find_dividers"))
+    assert inspect.isfunction(
+        inspect.getattr_static(clock, "list_available_references")
+    )
+
+
+def test_fpga_abstract_operations_are_methods():
+    """FPGA discovery and extraction operations must remain callable."""
+    for operation in ("determine_cpll", "determine_qpll", "get_config"):
+        assert inspect.isfunction(inspect.getattr_static(fpga, operation))


### PR DESCRIPTION
## Summary

- declare clock divider/reference discovery operations as abstract methods rather than properties
- declare FPGA CPLL/QPLL discovery and configuration extraction as abstract methods rather than properties
- align the FPGA discovery signatures with their concrete implementations
- add regression coverage that checks these operations remain callable descriptors

## Motivation

These interfaces represent actions, accept arguments in their concrete implementations, and are called as methods throughout the system. Decorating them as properties made the abstract contract misleading and incompatible with the actual API.

## Verification

```text
pytest -q tests/test_abstract_device_interfaces.py tests/test_clocks.py tests/test_bf.py tests/test_fpga.py tests/test_xilinx_bf.py tests/test_xilinx_coverage.py tests/test_xilinx_pll.py
72 passed, 4 skipped, 9 warnings

ruff check <changed files>
All checks passed!

ty check <project CI arguments>
All checks passed!

git diff --check
passed
```