### PR TITLE
Replace dynamic device construction with registry

### DIFF
--- a/adijif/clocks/clock.py
+++ b/adijif/clocks/clock.py
@@ -1,7 +1,7 @@
 """Clock parent metaclass to maintain consistency for all clock chip."""
 
 from abc import ABCMeta, abstractmethod
-from typing import Dict, List, Union
+from typing import Any, Dict, List, Union
 
 from docplex.cp.solution import CpoSolveResult  # type: ignore
 
@@ -70,7 +70,7 @@ class clock(core, gekko_translation, metaclass=ABCMeta):
         return vcxo
 
     @abstractmethod
-    def find_dividers(self) -> Dict:
+    def find_dividers(self, *args: Any, **kwargs: Any) -> Dict:
         """Find all possible divider settings that validate config.
 
         Raises:
@@ -79,7 +79,9 @@ class clock(core, gekko_translation, metaclass=ABCMeta):
         raise NotImplementedError  # pragma: no cover
 
     @abstractmethod
-    def list_available_references(self) -> List[int]:
+    def list_available_references(
+        self, *args: Any, **kwargs: Any
+    ) -> List[int]:
         """Determine all references that can be generated.
 
         Based on config list possible references that can be generated

--- a/adijif/registry.py
+++ b/adijif/registry.py
@@ -1,0 +1,122 @@
+"""Validated registry for constructing supported device models."""
+
+from typing import Dict, Literal, Type, Union, overload
+
+from adijif.clocks.ad9523 import ad9523_1
+from adijif.clocks.ad9528 import ad9528
+from adijif.clocks.ad9545 import ad9545
+from adijif.clocks.clock import clock
+from adijif.clocks.hmc7044 import hmc7044
+from adijif.clocks.ltc6952 import ltc6952
+from adijif.clocks.ltc6953 import ltc6953
+from adijif.converters.ad9081 import (
+    ad9081,
+    ad9081_rx,
+    ad9081_tx,
+    ad9082,
+    ad9082_rx,
+    ad9082_tx,
+)
+from adijif.converters.ad9084 import (
+    ad9084,
+    ad9084_rx,
+    ad9084_tx,
+    ad9088_rx,
+    ad9088_tx,
+)
+from adijif.converters.ad9144 import ad9144
+from adijif.converters.ad9152 import ad9152
+from adijif.converters.ad9680 import ad9680
+from adijif.converters.adrv9009 import adrv9009, adrv9009_rx, adrv9009_tx
+from adijif.converters.converter import converter
+from adijif.fpgas.fpga import fpga
+from adijif.fpgas.xilinx import xilinx
+from adijif.fpgas.xilinx.bf import xilinx_bf
+from adijif.plls.adf4030 import adf4030
+from adijif.plls.adf4371 import adf4371
+from adijif.plls.adf4382 import adf4382
+from adijif.plls.pll import pll
+
+ComponentType = Union[Type[converter], Type[clock], Type[fpga], Type[pll]]
+
+COMPONENT_REGISTRY: Dict[str, Dict[str, ComponentType]] = {
+    "converter": {
+        cls.__name__.lower(): cls
+        for cls in (
+            ad9081,
+            ad9081_rx,
+            ad9081_tx,
+            ad9082,
+            ad9082_rx,
+            ad9082_tx,
+            ad9084,
+            ad9084_rx,
+            ad9084_tx,
+            ad9088_rx,
+            ad9088_tx,
+            ad9144,
+            ad9152,
+            ad9680,
+            adrv9009,
+            adrv9009_rx,
+            adrv9009_tx,
+        )
+    },
+    "clock": {
+        cls.__name__.lower(): cls
+        for cls in (ad9523_1, ad9528, ad9545, hmc7044, ltc6952, ltc6953)
+    },
+    "fpga": {cls.__name__.lower(): cls for cls in (xilinx, xilinx_bf)},
+    "pll": {cls.__name__.lower(): cls for cls in (adf4030, adf4371, adf4382)},
+}
+
+_COMPONENT_BASES = {
+    "converter": converter,
+    "clock": clock,
+    "fpga": fpga,
+    "pll": pll,
+}
+
+
+@overload
+def get_component_class(kind: Literal["converter"], name: str) -> Type[converter]: ...
+
+
+@overload
+def get_component_class(kind: Literal["clock"], name: str) -> Type[clock]: ...
+
+
+@overload
+def get_component_class(kind: Literal["fpga"], name: str) -> Type[fpga]: ...
+
+
+@overload
+def get_component_class(kind: Literal["pll"], name: str) -> Type[pll]: ...
+
+
+@overload
+def get_component_class(kind: str, name: str) -> ComponentType: ...
+
+
+def get_component_class(kind: str, name: str) -> ComponentType:
+    """Resolve a supported component name without evaluating user input."""
+    normalized_kind = kind.lower()
+    if normalized_kind not in COMPONENT_REGISTRY:
+        raise ValueError(f"Unknown component kind {kind!r}")
+    if not isinstance(name, str):
+        raise TypeError("Component name must be a string")
+
+    normalized_name = name.lower()
+    try:
+        component = COMPONENT_REGISTRY[normalized_kind][normalized_name]
+    except KeyError as exc:
+        supported = ", ".join(sorted(COMPONENT_REGISTRY[normalized_kind]))
+        raise ValueError(
+            f"Unknown {normalized_kind} {name!r}. Supported values: {supported}"
+        ) from exc
+
+    if not issubclass(component, _COMPONENT_BASES[normalized_kind]):
+        raise TypeError(
+            f"Registered {normalized_kind} {name!r} has an invalid component type"
+        )
+    return component

--- a/adijif/system.py
+++ b/adijif/system.py
@@ -6,12 +6,12 @@ from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
-import adijif  # noqa: F401
 import adijif.solvers as solvers
 from adijif.clocks.clock import clock as clockc
 from adijif.converters.converter import converter as convc
 from adijif.optimization import Objective, apply_objectives, collect_objectives
 from adijif.plls.pll import pll as pllc
+from adijif.registry import get_component_class
 from adijif.sys.clocks_bundle import ClocksBundle
 from adijif.sys.s_plls import SystemPLL
 from adijif.system_draw import system_draw as system_draw
@@ -99,7 +99,9 @@ class system(SystemPLL, system_draw):
             clk (clockc): Clock chip reference
             cnv (convc): Converter reference
         """
-        pll = eval(f"adijif.{pll_name}(self.model,solver=self.solver)")  # noqa: S307
+        pll = get_component_class("pll", pll_name)(
+            self.model, solver=self.solver
+        )
         self._plls.append(pll)
         pll._connected_to_output = cnv.name
         pll._ref = clk
@@ -189,15 +191,21 @@ class system(SystemPLL, system_draw):
         self.converter: Union[convc, List[convc]] = []
         if isinstance(conv, list):
             for c in conv:
+                converter_class = get_component_class("converter", c)
                 self.converter.append(
-                    eval(f"adijif.{c}(self.model,solver=self.solver)")  # noqa: S307
+                    converter_class(self.model, solver=self.solver)
                 )
         else:
-            self.converter: convc = eval(  # noqa: S307
-                f"adijif.{conv}(self.model,solver=self.solver)"
+            converter_class = get_component_class("converter", conv)
+            self.converter: convc = converter_class(
+                self.model, solver=self.solver
             )
-        self.clock = eval(f"adijif.{clk}(self.model,solver=self.solver)")  # noqa: S307
-        self.fpga = eval(f"adijif.{fpga}(self.model,solver=self.solver)")  # noqa: S307
+        self.clock = get_component_class("clock", clk)(
+            self.model, solver=self.solver
+        )
+        self.fpga = get_component_class("fpga", fpga)(
+            self.model, solver=self.solver
+        )
         self.vcxo = vcxo
 
         # TODO: Add these constraints to solver options
@@ -231,9 +239,9 @@ class system(SystemPLL, system_draw):
     def __del__(self) -> None:
         """Deconstructor: Cleanup system by clearing all leaf objects."""
         self.fpga = []
-        if isinstance(self.converter, list):
-            for c, _ in enumerate(self.converter):
-                del self.converter[c]
+        converter = getattr(self, "converter", None)
+        if isinstance(converter, list):
+            converter.clear()
         self.converter = []
         self.clock = []
 

--- a/tests/test_component_registry.py
+++ b/tests/test_component_registry.py
@@ -1,0 +1,66 @@
+"""Tests for validated device-model construction."""
+
+import gc
+
+import pytest
+
+import adijif
+from adijif.registry import COMPONENT_REGISTRY, get_component_class
+
+
+@pytest.mark.parametrize(
+    ("kind", "name", "expected"),
+    [
+        ("converter", "AD9084_RX", adijif.ad9084_rx),
+        ("clock", "HMC7044", adijif.hmc7044),
+        ("fpga", "XILINX", adijif.xilinx),
+        ("pll", "ADF4382", adijif.adf4382),
+    ],
+)
+def test_registry_resolves_supported_names_case_insensitively(
+    kind, name, expected
+):
+    """Existing lowercase names and uppercase aliases resolve identically."""
+    assert get_component_class(kind, name) is expected
+
+
+def test_registry_rejects_unknown_and_executable_names():
+    """Component names are data and cannot execute arbitrary expressions."""
+    with pytest.raises(ValueError, match="Unknown converter"):
+        get_component_class("converter", "__import__('os').system('false')")
+    with pytest.raises(ValueError, match="Unknown component kind"):
+        get_component_class("unknown", "ad9084_rx")
+
+
+def test_registry_matches_public_supported_part_lists():
+    """Public discovery lists cannot silently drift from construction support."""
+    from adijif.clocks import supported_parts as clocks
+    from adijif.converters import supported_parts as converters
+    from adijif.plls import supported_parts as plls
+
+    assert set(clocks) <= set(COMPONENT_REGISTRY["clock"])
+    assert set(converters) <= set(COMPONENT_REGISTRY["converter"])
+    assert set(plls) <= set(COMPONENT_REGISTRY["pll"])
+
+
+def test_system_uses_registry_for_component_construction():
+    """System construction supports aliases and rejects unknown names clearly."""
+    system = adijif.system("AD9680", "HMC7044", "XILINX", 125_000_000, "gekko")
+    assert isinstance(system.converter, adijif.ad9680)
+    assert isinstance(system.clock, adijif.hmc7044)
+    assert isinstance(system.fpga, adijif.xilinx)
+
+    system.add_pll_inline("ADF4382", system.clock, system.converter)
+    assert isinstance(system.plls[-1], adijif.adf4382)
+
+    with pytest.raises(ValueError, match="Unknown converter"):
+        adijif.system("not_a_device", "hmc7044", "xilinx", 125_000_000, "gekko")
+
+
+def test_failed_system_construction_has_safe_cleanup(recwarn):
+    """Partially initialized systems must not raise from their destructor."""
+    with pytest.raises(Exception, match="Unknown solver"):
+        adijif.system("ad9680", "hmc7044", "xilinx", 125_000_000, "invalid")
+
+    gc.collect()
+    assert not [warning for warning in recwarn if "system.__del__" in str(warning.message)]


### PR DESCRIPTION
## Summary

- replace `eval`-based system component and inline PLL construction with a validated typed registry
- preserve existing lowercase model names and uppercase aliases through case-insensitive lookup
- reject unknown or executable component-name strings with clear supported-value errors
- verify registry coverage against public clock, converter, and PLL discovery lists
- make partially initialized system teardown safe after constructor validation failures
- generalize the abstract clock discovery signatures to cover existing brute-force call arguments

## Verification

```text
pytest -q tests/test_component_registry.py tests/test_abstract_device_interfaces.py tests/test_system.py tests/test_ad9084.py tests/test_ad9084_rx_ebz.py
108 passed, 1 skipped, 1 warning

ruff check <changed files>
All checks passed!

ty check <project CI arguments>
All checks passed!

git diff --check
passed
```