### PR TITLE
Make AD908x RX variants explicit

### DIFF
--- a/adijif/converters/ad9084.py
+++ b/adijif/converters/ad9084.py
@@ -296,7 +296,10 @@ class ad9084_rx(adc, ad9084_core):
 
     quick_configuration_modes = _load_rx_config_modes(part="AD9084")
 
-    datapath = ad9084_dp_rx()
+    datapath_type = ad9084_dp_rx
+    default_sample_clock = int(2.5e9)
+    default_jesd_mode = "47"
+    datapath_channel_multiplier = 1
 
     decimation_available = [
         cddc * fddc
@@ -326,17 +329,14 @@ class ad9084_rx(adc, ad9084_core):
             *args (Any): Pass through arguments
             **kwargs (Any): Pass through keyword arguments
         """
-        self.datapath = (
-            ad9084_dp_rx() if "AD9084" in self.name else ad9088_dp_rx()
-        )
-        self.sample_clock = int(2.5e9) if "AD9084" in self.name else int(1e9)
-        N = 1 if "9084" in self.name else 2
-        self.datapath.cddc_decimations = [4] * 4 * N
-        self.datapath.fddc_decimations = [2] * 8 * N
-        self.datapath.fddc_enabled = [True] * 8 * N
-        mode = "47" if "9084" in self.name else "45"
+        self.datapath = self.datapath_type()
+        self.sample_clock = self.default_sample_clock
+        channels = self.datapath_channel_multiplier
+        self.datapath.cddc_decimations = [4] * 4 * channels
+        self.datapath.fddc_decimations = [2] * 8 * channels
+        self.datapath.fddc_enabled = [True] * 8 * channels
 
-        self.set_quick_configuration_mode(mode, "jesd204c")
+        self.set_quick_configuration_mode(self.default_jesd_mode, "jesd204c")
 
         super().__init__(*args, **kwargs)
         self._init_diagram()
@@ -408,7 +408,10 @@ class ad9088_rx(ad9084_rx):
     sample_clock_min = 5e9 / (12 * 64)  # with max decimation
     sample_clock_max = 8e9
 
-    datapath = ad9088_dp_rx()
+    datapath_type = ad9088_dp_rx
+    default_sample_clock = int(1e9)
+    default_jesd_mode = "45"
+    datapath_channel_multiplier = 2
 
     quick_configuration_modes = _load_rx_config_modes(part="AD9088")
 

--- a/tests/test_ad908x_variant_metadata.py
+++ b/tests/test_ad908x_variant_metadata.py
@@ -1,0 +1,42 @@
+"""Tests for explicit AD9084/AD9088 RX variant metadata."""
+
+import pytest
+
+import adijif
+from adijif.converters.ad9084_dp import ad9084_dp_rx
+from adijif.converters.ad9088_dp import ad9088_dp_rx
+
+
+@pytest.mark.parametrize(
+    ("device_type", "datapath_type", "sample_clock", "cddcs", "fddcs", "mode"),
+    [
+        (adijif.ad9084_rx, ad9084_dp_rx, int(2.5e9), 4, 8, "47"),
+        (adijif.ad9088_rx, ad9088_dp_rx, int(1e9), 8, 16, "45"),
+    ],
+)
+def test_rx_variant_metadata_preserves_defaults(
+    device_type, datapath_type, sample_clock, cddcs, fddcs, mode
+):
+    """Explicit metadata preserves each silicon variant's existing defaults."""
+    device = device_type(solver="gekko")
+
+    assert isinstance(device.datapath, datapath_type)
+    assert device.sample_clock == sample_clock
+    assert len(device.datapath.cddc_decimations) == cddcs
+    assert len(device.datapath.fddc_decimations) == fddcs
+    assert device._check_valid_jesd_mode() == mode
+
+
+def test_rx_defaults_do_not_depend_on_display_name():
+    """Aliases and renamed subclasses retain the declared silicon behavior."""
+
+    class renamed_ad9088(adijif.ad9088_rx):
+        name = "MXFE_RX_ALIAS"
+
+    device = renamed_ad9088(solver="gekko")
+
+    assert isinstance(device.datapath, ad9088_dp_rx)
+    assert device.sample_clock == int(1e9)
+    assert len(device.datapath.cddc_decimations) == 8
+    assert len(device.datapath.fddc_decimations) == 16
+    assert device._check_valid_jesd_mode() == "45"


### PR DESCRIPTION
## Summary

- replace AD9084/AD9088 behavior inferred from display-name substrings with explicit class metadata
- declare each RX variant's datapath factory, default sample clock, JESD mode, and channel multiplier
- preserve fresh per-instance datapath construction
- add differential tests for all existing defaults and a renamed-subclass regression

## Motivation

The RX constructor selected silicon behavior using checks such as `"AD9084" in self.name`. Aliases or renamed subclasses could therefore silently receive the wrong datapath topology, channel counts, sample clock, and quick mode. Variant behavior is now declared directly by each class.

## Verification

```text
pytest -q tests/test_ad908x_variant_metadata.py tests/test_ad9084.py tests/test_ad9084_rx_ebz.py tests/test_device_state_cleanup.py
83 passed, 1 warning

ruff check <changed files>
All checks passed!

ty check <project CI arguments>
All checks passed!

git diff --check
passed
```