### PR TITLE
Remove remaining dynamic expression evaluation

### DIFF
--- a/adijif/sys/s_plls.py
+++ b/adijif/sys/s_plls.py
@@ -2,11 +2,11 @@
 
 from typing import List, Tuple, Union
 
-import adijif  # noqa: F401
 from adijif.clocks.clock import clock as clockc
 from adijif.converters.converter import converter as convc
 from adijif.fpgas.fpga import fpga as fpgac
 from adijif.plls.pll import pll as pllc
+from adijif.registry import get_component_class
 
 
 class SystemPLL:
@@ -57,7 +57,9 @@ class SystemPLL:
             fpga (fpgac): FPGA to be driven by PLL
             bsync_reference (Union[clockc, int, float]): Optional clock to be used as BSYNC reference for PLL. If not provided, BSYNC will not be synchronized to any reference.
         """
-        pll = eval(f"adijif.{pll_name}(self.model,solver=self.solver)")  # noqa: S307
+        pll = get_component_class("pll", pll_name)(
+            self.model, solver=self.solver
+        )
         self._plls_sysref.append(pll)
         pll._connected_to_output = []
         pll._ref = clk

--- a/adijif/tools/explorer/src/pages/clockconfigurator.py
+++ b/adijif/tools/explorer/src/pages/clockconfigurator.py
@@ -6,6 +6,7 @@ from typing import Optional
 import streamlit as st
 
 from adijif.clocks import supported_parts as sp
+from adijif.registry import get_component_class
 
 from ..utils import Page
 
@@ -106,9 +107,7 @@ class ClockConfigurator(Page):
                     )
                 )
 
-        import adijif  # noqa: F401
-
-        class_def = eval(f"adijif.{sb}")  # noqa: S307
+        class_def = get_component_class("clock", sb)
         props = dir(class_def)
 
         props = [p for p in props if not p.startswith("__")]
@@ -145,7 +144,7 @@ class ClockConfigurator(Page):
                     key=f"clock_internal_{prop}_multiselect",
                 )
 
-        clk_chip = eval(f"adijif.{sb}()")  # noqa: S307
+        clk_chip = class_def()
 
         for prop, values in selections.items():
             if isinstance(values, dict):

--- a/adijif/tools/explorer/src/pages/jesdmodeselector.py
+++ b/adijif/tools/explorer/src/pages/jesdmodeselector.py
@@ -6,6 +6,7 @@ import pandas as pd
 import streamlit as st
 
 from adijif.converters import supported_parts as sp
+from adijif.registry import get_component_class
 
 from ..utils import Page
 from .helpers.datapath import gen_datapath
@@ -45,12 +46,10 @@ class JESDModeSelector(Page):
     def write(self) -> None:
         """Render the JESD mode selector page."""
         # Get supported parts that have quick_configuration_modes
-        import adijif  # noqa: F401
-
         supported_parts_filtered = []
         for part in sp:
             try:
-                converter = eval(f"adijif.{part}()")  # noqa: S307
+                converter = get_component_class("converter", part)()
                 qsm = converter.quick_configuration_modes  # noqa: F841
                 supported_parts_filtered.append(part)
             except Exception:  # noqa: S110
@@ -66,7 +65,7 @@ class JESDModeSelector(Page):
             key="converter_part_select",
         )
 
-        converter = eval(f"adijif.{sb}()")  # noqa: S307
+        converter = get_component_class("converter", sb)()
 
         # Show diagram
         self.section("Diagram")

--- a/adijif/utils.py
+++ b/adijif/utils.py
@@ -1,6 +1,7 @@
 """Collection of utility scripts for specialized checks."""
 
 import copy
+import operator
 from typing import List, Optional
 
 import numpy as np
@@ -151,12 +152,16 @@ def get_max_sample_rates(
                         elif isinstance(limits[limit], dict):
                             ld = limits[limit]
                             for lc in ld:
-                                if lc in [">", "<", "<=", ">=", "=="]:
+                                comparisons = {
+                                    ">": operator.gt,
+                                    "<": operator.lt,
+                                    "<=": operator.le,
+                                    ">=": operator.ge,
+                                    "==": operator.eq,
+                                }
+                                if lc in comparisons:
                                     attr = getattr(conv, limit)
-                                    e = eval(  # noqa: S307
-                                        f"{attr} {lc} {limits[limit][lc]}"
-                                    )
-                                    if not e:
+                                    if not comparisons[lc](attr, limits[limit][lc]):
                                         b = True
                                         break
                             if b:

--- a/tests/test_component_registry.py
+++ b/tests/test_component_registry.py
@@ -53,8 +53,23 @@ def test_system_uses_registry_for_component_construction():
     system.add_pll_inline("ADF4382", system.clock, system.converter)
     assert isinstance(system.plls[-1], adijif.adf4382)
 
+    system.add_pll_sysref("ADF4030", system.clock, system.converter, system.fpga)
+    assert isinstance(system.plls_sysref[-1], adijif.adf4030)
+
     with pytest.raises(ValueError, match="Unknown converter"):
         adijif.system("not_a_device", "hmc7044", "xilinx", 125_000_000, "gekko")
+
+
+def test_sysref_pll_rejects_executable_name():
+    """SYSREF PLL names cannot execute expressions."""
+    system = adijif.system("ad9680", "hmc7044", "xilinx", 125_000_000, "gekko")
+    with pytest.raises(ValueError, match="Unknown pll"):
+        system.add_pll_sysref(
+            "__import__('os').system('false')",
+            system.clock,
+            system.converter,
+            system.fpga,
+        )
 
 
 def test_failed_system_construction_has_safe_cleanup(recwarn):


### PR DESCRIPTION
## Summary

- route SYSREF PLL construction through the validated component registry
- use registry lookup for Explorer clock and converter model construction
- replace comparison-string `eval` in sample-rate filtering with explicit `operator` dispatch
- preserve case-insensitive model aliases and existing comparison behavior
- add SYSREF PLL alias and executable-name regression coverage

## Verification

```text
pytest -q tests/test_component_registry.py tests/test_utils.py tests/test_ad9084.py tests/tools/test_jesdmodeselector.py
69 passed, 1 warning

ruff check <changed files>
All checks passed!

ty check <project CI arguments>
All checks passed!

git diff --check
passed

git grep eval( under adijif Python sources
no matches
```