### PR TITLE
Keep JESD mode tables immutable in Explorer

### DIFF
--- a/adijif/tools/explorer/src/pages/helpers/jesd.py
+++ b/adijif/tools/explorer/src/pages/helpers/jesd.py
@@ -105,7 +105,9 @@ def get_valid_jesd_modes(
     # Get remaining mode parameters
     modes_all_info = []
     for mode in found_modes:
-        jesd_cfg = all_modes[mode["jesd_class"]][mode["mode"]]
+        jesd_cfg = copy.deepcopy(
+            all_modes[mode["jesd_class"]][mode["mode"]]
+        )
         jesd_cfg["mode"] = mode["mode"]
         jesd_cfg["jesd_class"] = mode["jesd_class"]
 
@@ -120,8 +122,6 @@ def get_valid_jesd_modes(
         rate = converter.sample_clock
         # print("A", converter.sample_clock)
         converter.set_quick_configuration_mode(mode["mode"], mode["jesd_class"])
-        # print("B", converter.sample_clock)
-        log.warning("Logical BUG")
         converter.sample_clock = rate
 
         clocks = {

--- a/tests/tools/test_jesd_helpers.py
+++ b/tests/tools/test_jesd_helpers.py
@@ -1,0 +1,40 @@
+"""Tests for Explorer JESD mode helper ownership."""
+
+import copy
+
+import adijif
+from adijif.tools.explorer.src.pages.helpers.jesd import (
+    get_jesd_controls,
+    get_valid_jesd_modes,
+)
+
+
+def test_get_valid_jesd_modes_does_not_mutate_mode_table():
+    """Formatting mode results must not modify its caller-owned mode table."""
+    converter = adijif.ad9680(solver="gekko")
+    _, modes = get_jesd_controls(converter)
+    before = copy.deepcopy(modes)
+
+    results, found = get_valid_jesd_modes(converter, modes, {})
+
+    assert found
+    assert results
+    assert modes == before
+    assert all(
+        "mode" not in config for table in modes.values() for config in table.values()
+    )
+
+
+def test_get_valid_jesd_modes_returns_independent_rows():
+    """Derived columns belong only to result rows, not capability records."""
+    converter = adijif.ad9680(solver="gekko")
+    _, modes = get_jesd_controls(converter)
+
+    results, _ = get_valid_jesd_modes(converter, modes, {})
+    results[0]["result_only"] = True
+
+    assert all(
+        "result_only" not in config
+        for table in modes.values()
+        for config in table.values()
+    )


### PR DESCRIPTION
## Summary

- deep-copy JESD capability records before adding Explorer-only columns
- prevent filtering and derived-rate calculation from modifying caller-owned mode tables
- ensure returned rows are independent from the underlying capability data
- remove the unconditional `Logical BUG` warning emitted once per mode

## Verification

The new regression tests failed twice before the fix: the helper modified its input table and returned rows aliasing source records.

```text
pytest -q tests/tools/test_jesd_helpers.py tests/tools/test_jesdmodeselector.py tests/test_utils.py
46 passed

ruff check <changed files>
All checks passed!

ty check <project CI arguments>
All checks passed!

git diff --check
passed
```