### PR TITLE
Restore converter state after JESD mode scans

### DIFF
--- a/adijif/tools/explorer/src/pages/helpers/jesd.py
+++ b/adijif/tools/explorer/src/pages/helpers/jesd.py
@@ -91,6 +91,9 @@ def get_valid_jesd_modes(
         Tuple of (modes info list, found modes list or None)
     """
     modes_all_info: Any = {}
+    original_config = converter.get_current_jesd_mode_settings()
+    original_jesd_class = converter.jesd_class
+    original_sample_clock = converter.sample_clock
 
     try:
         found_modes = get_jesd_mode_from_params(converter, **selections)
@@ -117,26 +120,32 @@ def get_valid_jesd_modes(
 
         modes_all_info.append(jesd_cfg)
 
-    # For each mode calculate the clocks and if valid
-    for mode in modes_all_info:
-        rate = converter.sample_clock
-        # print("A", converter.sample_clock)
-        converter.set_quick_configuration_mode(mode["mode"], mode["jesd_class"])
-        converter.sample_clock = rate
+    try:
+        # For each mode calculate the clocks and if valid
+        for mode in modes_all_info:
+            converter.set_quick_configuration_mode(
+                mode["mode"], mode["jesd_class"]
+            )
+            converter.sample_clock = original_sample_clock
 
-        clocks = {
-            "Sample Rate (MSPS)": converter.sample_clock / 1e6,
-            "Lane Rate (GSPS)": converter.bit_clock / 1e9,
-        }
+            clocks = {
+                "Sample Rate (MSPS)": converter.sample_clock / 1e6,
+                "Lane Rate (GSPS)": converter.bit_clock / 1e9,
+            }
 
-        for clock in clocks:
-            mode[clock] = clocks[clock]
+            for clock in clocks:
+                mode[clock] = clocks[clock]
 
-        try:
-            converter.validate_config()
-            mode["Valid"] = "Yes"
-        except Exception:
-            mode["Valid"] = "No"
+            try:
+                converter.validate_config()
+                mode["Valid"] = "Yes"
+            except Exception:
+                mode["Valid"] = "No"
+    finally:
+        converter.jesd_class = original_jesd_class
+        for attr, value in original_config.items():
+            setattr(converter, attr, value)
+        converter.sample_clock = original_sample_clock
 
     # from pprint import pprint
     # pprint(modes_all_info)

--- a/tests/tools/test_jesd_helpers.py
+++ b/tests/tools/test_jesd_helpers.py
@@ -38,3 +38,18 @@ def test_get_valid_jesd_modes_returns_independent_rows():
         for table in modes.values()
         for config in table.values()
     )
+
+
+def test_get_valid_jesd_modes_restores_converter_state():
+    """Enumerating modes must not leave the caller on the last tested mode."""
+    converter = adijif.ad9680(solver="gekko")
+    converter.set_quick_configuration_mode("1", "jesd204b")
+    converter.sample_clock = 500_000_000
+    attrs = ("jesd_class", "L", "M", "F", "S", "N", "Np", "K", "sample_clock")
+    before = tuple(getattr(converter, attr) for attr in attrs)
+    _, modes = get_jesd_controls(converter)
+
+    get_valid_jesd_modes(converter, modes, {})
+
+    after = tuple(getattr(converter, attr) for attr in attrs)
+    assert after == before


### PR DESCRIPTION
## Summary

- snapshot converter JESD settings and sample clock before Explorer mode enumeration
- restore the caller's exact configuration after computing derived rates and validity
- use `try/finally` so state is restored even if processing a mode raises unexpectedly
- add a regression proving an AD9680 remains on its original mode after a scan

## TDD evidence

Before the fix, scanning an AD9680 configured for mode 1 changed its JESD parameters from `L=1, M=1, F=2` to the final scanned mode (`L=4, M=8, F=4`). The focused regression failed accordingly.

## Verification

```text
pytest -q tests/tools/test_jesd_helpers.py tests/tools/test_jesdmodeselector.py tests/test_utils.py
47 passed

ruff check <changed files>
All checks passed!

ty check <project CI arguments>
All checks passed!

git diff --check
passed
```