### PR TITLE
Restore converter state after sample-rate scans

### DIFF
--- a/adijif/utils.py
+++ b/adijif/utils.py
@@ -2,7 +2,8 @@
 
 import copy
 import operator
-from typing import List, Optional
+from functools import wraps
+from typing import Any, Callable, List, Optional
 
 import numpy as np
 
@@ -11,6 +12,25 @@ import adijif.fpgas.xilinx.ultrascaleplus as us
 from adijif.converters.converter import converter
 from adijif.fpgas.fpga import fpga
 from adijif.solvers import CpoModel, cplex_solver, integer_var  # type: ignore
+
+
+def _preserve_converter_jesd_state(func: Callable) -> Callable:
+    """Restore caller-owned JESD state after a converter utility returns."""
+
+    @wraps(func)
+    def wrapper(conv: converter, *args: Any, **kwargs: Any) -> Any:
+        original_config = conv.get_current_jesd_mode_settings()
+        original_jesd_class = conv.jesd_class
+        original_sample_clock = conv.sample_clock
+        try:
+            return func(conv, *args, **kwargs)
+        finally:
+            conv.jesd_class = original_jesd_class
+            for attr, value in original_config.items():
+                setattr(conv, attr, value)
+            conv.sample_clock = original_sample_clock
+
+    return wrapper
 
 
 def get_jesd_mode_from_params(conv: converter, **kwargs: int) -> List[dict]:
@@ -63,6 +83,7 @@ def get_jesd_mode_from_params(conv: converter, **kwargs: int) -> List[dict]:
     return results
 
 
+@_preserve_converter_jesd_state
 def get_max_sample_rates(
     conv: converter, fpga: Optional[fpga] = None, limits: Optional[dict] = None
 ) -> dict:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -105,6 +105,31 @@ def test_generate_max_rates_with_invalid_property():
         jif.utils.get_max_sample_rates(conv, limits=limits)
 
 
+@pytest.mark.parametrize(
+    "limits, error",
+    [
+        (None, None),
+        ({"nonexistent_property": {"==": 10}}, AttributeError),
+    ],
+)
+def test_get_max_sample_rates_restores_converter_state(limits, error):
+    """Rate enumeration must not change caller-owned converter settings."""
+    conv = jif.ad9680(solver="gekko")
+    conv.set_quick_configuration_mode("1", "jesd204b")
+    conv.sample_clock = 500_000_000
+    attrs = ("jesd_class", "L", "M", "F", "S", "N", "Np", "K", "sample_clock")
+    before = tuple(getattr(conv, attr) for attr in attrs)
+
+    if error:
+        with pytest.raises(error):
+            jif.utils.get_max_sample_rates(conv, limits=limits)
+    else:
+        assert jif.utils.get_max_sample_rates(conv, limits=limits)
+
+    after = tuple(getattr(conv, attr) for attr in attrs)
+    assert after == before
+
+
 def test_generate_max_rates_with_string_limits():
     """Test get_max_sample_rates with string value limits."""
     conv = jif.ad9680()


### PR DESCRIPTION
## Summary

- preserve the caller's JESD configuration and sample clock while `get_max_sample_rates()` enumerates modes
- restore state on successful returns and exceptions
- add regressions for both paths

## TDD evidence

Before the fix, scanning an AD9680 configured for mode 1 changed it from `L=1, M=1, F=2, sample_clock=500 MHz` to `L=4, M=8, F=4, sample_clock=312.5 MHz`.

## Verification

```text
pytest -q tests/test_utils.py tests/tools/test_jesd_helpers.py tests/tools/test_jesdmodeselector.py
49 passed

ruff check adijif/utils.py tests/test_utils.py
All checks passed!

ty check <project CI arguments>
All checks passed!

git diff --check
passed
```