### PR TITLE
Isolate clock divider selection state

### DIFF
--- a/adijif/clocks/clock.py
+++ b/adijif/clocks/clock.py
@@ -1,5 +1,6 @@
 """Clock parent metaclass to maintain consistency for all clock chip."""
 
+import copy
 from abc import ABCMeta, abstractmethod
 from typing import Any, Dict, List, Union
 
@@ -39,6 +40,19 @@ class clock(core, gekko_translation, metaclass=ABCMeta):
     via properties (e.g. ``n2``, ``r2``, ``d``) before either entry point
     if you want to constrain the search space.
     """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize solver state and isolate mutable clock selections."""
+        super().__init__(*args, **kwargs)
+        for cls in type(self).mro():
+            for name, value in vars(cls).items():
+                if (
+                    name.startswith("_")
+                    and not name.startswith("__")
+                    and name not in self.__dict__
+                    and isinstance(value, (list, dict, set))
+                ):
+                    setattr(self, name, copy.deepcopy(value))
 
     def _parse_reference(
         self, vcxo: Union[int, float, CpoExpr]

--- a/tests/test_clock_state_ownership.py
+++ b/tests/test_clock_state_ownership.py
@@ -1,0 +1,38 @@
+"""Regression tests for per-instance clock-chip runtime state."""
+
+import pytest
+
+from adijif.registry import get_component_class
+
+CLOCKS = ["ad9523_1", "ad9528", "ad9545", "hmc7044", "ltc6952", "ltc6953"]
+
+
+@pytest.mark.parametrize("name", CLOCKS)
+def test_clock_private_mutable_state_is_instance_local(name):
+    """Mutable divider selections and clock names must not leak across chips."""
+    clock_class = get_component_class("clock", name)
+    first = clock_class(solver="gekko")
+    second = clock_class(solver="gekko")
+
+    mutable_fields = {
+        field
+        for cls in type(first).mro()
+        for field, value in vars(cls).items()
+        if field.startswith("_")
+        and not field.startswith("__")
+        and isinstance(value, (list, dict, set))
+    }
+
+    for field in mutable_fields:
+        first_value = getattr(first, field)
+        second_value = getattr(second, field)
+        assert first_value is not second_value, f"{name}.{field} is shared"
+
+        before = list(second_value) if isinstance(second_value, list) else second_value.copy()
+        if isinstance(first_value, list):
+            first_value.append("ownership-probe")
+        elif isinstance(first_value, dict):
+            first_value["ownership-probe"] = True
+        else:
+            first_value.add("ownership-probe")
+        assert second_value == before


### PR DESCRIPTION
## Summary

- deep-copy private mutable clock runtime defaults during common clock initialization
- prevent divider selections and requested-clock names from leaking between clock instances
- preserve public capability tables and every chip's existing default values
- cover all supported clock models with identity and mutation regressions

## TDD evidence

Before the fix, the ownership regression failed for all six supported clock models. Shared state included AD9523-1 divider lists, AD9528 divider lists, HMC7044 divider/doubler lists, LTC6952 divider lists, LTC6953 input-divider lists, and requested-clock name lists.

## Verification

```text
pytest -q tests/test_clock_state_ownership.py tests/test_clocks.py tests/test_clocks_more_coverage.py tests/test_device_state_cleanup.py tests/test_final_coverage.py::test_system_initialize_edge_cases tests/test_system.py
88 passed, 1 skipped

ruff check <changed files>
All checks passed!

ty check <project CI arguments>
All checks passed!

git diff --check
passed
```