### PR TITLE
Own clock request metadata

### DIFF
--- a/adijif/clocks/ad9523.py
+++ b/adijif/clocks/ad9523.py
@@ -311,7 +311,7 @@ class ad9523_1(ad9523_1_bf):
 
         # Setup clock chip internal constraints
         self.setup_constraints(vcxo)
-        self._clk_names = clk_names
+        self._clk_names = list(clk_names)
 
         # Add requested clocks to output constraints
         for out_freq in out_freqs:

--- a/adijif/clocks/ad9528.py
+++ b/adijif/clocks/ad9528.py
@@ -437,7 +437,7 @@ class ad9528(ad9528_bf):
 
         # Setup clock chip internal constraints
         self.setup_constraints(vcxo)
-        self._clk_names = clk_names
+        self._clk_names = list(clk_names)
 
         if self._sysref:
             if self.sysref_external:

--- a/adijif/clocks/clock.py
+++ b/adijif/clocks/clock.py
@@ -1,5 +1,6 @@
 """Clock parent metaclass to maintain consistency for all clock chip."""
 
+import copy
 from abc import ABCMeta, abstractmethod
 from typing import Any, Dict, List, Union
 
@@ -39,6 +40,19 @@ class clock(core, gekko_translation, metaclass=ABCMeta):
     via properties (e.g. ``n2``, ``r2``, ``d``) before either entry point
     if you want to constrain the search space.
     """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize solver state and isolate mutable clock selections."""
+        super().__init__(*args, **kwargs)
+        for cls in type(self).mro():
+            for name, value in vars(cls).items():
+                if (
+                    name.startswith("_")
+                    and not name.startswith("__")
+                    and name not in self.__dict__
+                    and isinstance(value, (list, dict, set))
+                ):
+                    setattr(self, name, copy.deepcopy(value))
 
     def _parse_reference(
         self, vcxo: Union[int, float, CpoExpr]

--- a/adijif/clocks/hmc7044.py
+++ b/adijif/clocks/hmc7044.py
@@ -529,7 +529,7 @@ class hmc7044(hmc7044_bf):
 
         # Setup clock chip internal constraints
         self.setup_constraints(vcxo)
-        self._clk_names = clk_names
+        self._clk_names = list(clk_names)
         # if type(self.vcxo) not in [int,float]:
         #     vcxo = self.vcxo['range']
 

--- a/adijif/clocks/ltc6952.py
+++ b/adijif/clocks/ltc6952.py
@@ -615,7 +615,7 @@ class ltc6952(ltc6952_bf):
 
         # Setup clock chip internal constraints
         self.setup_constraints(vcxo)
-        self._clk_names = clk_names
+        self._clk_names = list(clk_names)
 
         # Add requested clocks to output constraints
         for out_freq, clk_name in zip(out_freqs, clk_names):  # noqa: B905

--- a/adijif/clocks/ltc6953.py
+++ b/adijif/clocks/ltc6953.py
@@ -589,7 +589,7 @@ class ltc6953(clock):
         """
         if len(clk_names) != len(out_freqs):
             raise Exception("clk_names is not the same size as out_freqs")
-        self._clk_names = clk_names
+        self._clk_names = list(clk_names)
 
         # Setup clock chip internal constraints
         self.setup_constraints(input_ref)
@@ -597,8 +597,8 @@ class ltc6953(clock):
         # Add requested clocks to output constraints
         for out_freq, clk_name in zip(out_freqs, clk_names):  # noqa: B905
             if self.solver == "gekko":
-                __m = self._d if isinstance(self.__m, list) else [self.__m]
-                if __m.sort() != self.m_available.sort():
+                __m = self._m if isinstance(self._m, list) else [self._m]
+                if sorted(__m) != sorted(self.m_available):
                     raise Exception(
                         "For solver gekko m is not configurable for LTC6953"
                     )

--- a/tests/test_clock_request_ownership.py
+++ b/tests/test_clock_request_ownership.py
@@ -1,0 +1,28 @@
+"""Tests for ownership of clock request inputs."""
+
+import pytest
+
+from adijif.registry import get_component_class
+
+
+@pytest.mark.parametrize(
+    "name,vcxo",
+    [
+        ("ad9523_1", 125_000_000),
+        ("ad9528", 125_000_000),
+        ("hmc7044", 125_000_000),
+        ("ltc6952", 125_000_000),
+        ("ltc6953", 3_000_000_000),
+    ],
+)
+def test_clock_does_not_retain_caller_clock_names(name, vcxo):
+    """Configured output names must not alias the caller's mutable list."""
+    clock_class = get_component_class("clock", name)
+    clock = clock_class(solver="gekko")
+    names = ["output"]
+
+    clock.set_requested_clocks(vcxo, [10_000_000], names)
+    names[0] = "renamed-by-caller"
+    names.append("extra")
+
+    assert clock._clk_names == ["output"]

--- a/tests/test_clock_state_ownership.py
+++ b/tests/test_clock_state_ownership.py
@@ -1,0 +1,38 @@
+"""Regression tests for per-instance clock-chip runtime state."""
+
+import pytest
+
+from adijif.registry import get_component_class
+
+CLOCKS = ["ad9523_1", "ad9528", "ad9545", "hmc7044", "ltc6952", "ltc6953"]
+
+
+@pytest.mark.parametrize("name", CLOCKS)
+def test_clock_private_mutable_state_is_instance_local(name):
+    """Mutable divider selections and clock names must not leak across chips."""
+    clock_class = get_component_class("clock", name)
+    first = clock_class(solver="gekko")
+    second = clock_class(solver="gekko")
+
+    mutable_fields = {
+        field
+        for cls in type(first).mro()
+        for field, value in vars(cls).items()
+        if field.startswith("_")
+        and not field.startswith("__")
+        and isinstance(value, (list, dict, set))
+    }
+
+    for field in mutable_fields:
+        first_value = getattr(first, field)
+        second_value = getattr(second, field)
+        assert first_value is not second_value, f"{name}.{field} is shared"
+
+        before = list(second_value) if isinstance(second_value, list) else second_value.copy()
+        if isinstance(first_value, list):
+            first_value.append("ownership-probe")
+        elif isinstance(first_value, dict):
+            first_value["ownership-probe"] = True
+        else:
+            first_value.add("ownership-probe")
+        assert second_value == before


### PR DESCRIPTION
## Summary

- copy caller-provided output-name lists when configuring clock models
- prevent later caller mutations from silently changing configured output names
- repair the LTC6953 GEKKO output-divider validation path exposed by the ownership matrix
- compare divider domains with `sorted()` rather than comparing `.sort()` return values

## TDD evidence

The new parameterized regression initially failed for AD9523-1, AD9528, HMC7044, LTC6952, and LTC6953 because each retained `clk_names` by reference. LTC6953 additionally raised `AttributeError` from its nonexistent `self.__m` field before reaching the ownership assertion.

## Verification

```text
pytest -q tests/test_clock_request_ownership.py tests/test_clock_state_ownership.py tests/test_clocks.py tests/test_clocks_more_coverage.py tests/test_device_state_cleanup.py tests/test_final_coverage.py::test_system_initialize_edge_cases tests/test_system.py
93 passed, 1 skipped

ruff check <changed files>
All checks passed!

ty check <project CI arguments>
All checks passed!

git diff --check
passed
```