### PR TITLE
Own AD9545 request topology

### DIFF
--- a/adijif/clocks/ad9545.py
+++ b/adijif/clocks/ad9545.py
@@ -311,7 +311,7 @@ class ad9545(clock):
         Raises:
             Exception: Invalid solver
         """
-        self.input_refs = input_refs
+        self.input_refs = list(input_refs)
 
         self.PLL_used = [False, False]
         for i in range(0, 10):
@@ -566,11 +566,13 @@ class ad9545(clock):
         if self.solver == "gekko":
             raise Exception("Gekko solver not supported for AD9545")
 
-        self.out_freqs = out_freqs
+        self.out_freqs = list(out_freqs)
 
         self._setup_solver_constraints(input_refs, out_freqs)
 
-    def set_requested_clocks(self, ins: List[int], outs: List[int]) -> None:
+    def set_requested_clocks(
+        self, ins: List[List[int]], outs: List[List[int]]
+    ) -> None:
         """Define necessary clocks to be generated in model.
 
         Args:

--- a/tests/test_ad9545_request_ownership.py
+++ b/tests/test_ad9545_request_ownership.py
@@ -1,0 +1,31 @@
+"""Regression tests for AD9545 request ownership."""
+
+import adijif
+
+
+def test_ad9545_setup_copies_reference_and_output_lists():
+    """Low-level setup must not retain caller-owned topology lists."""
+    clock = adijif.ad9545(solver="CPLEX")
+    input_refs = [125_000_000, 0, 0, 0]
+    out_freqs = [156_250_000] + [0] * 9
+
+    clock.setup_constraints(input_refs, out_freqs)
+    input_refs[0] = 1
+    out_freqs[0] = 2
+
+    assert clock.input_refs == [125_000_000, 0, 0, 0]
+    assert clock.out_freqs == [156_250_000] + [0] * 9
+
+
+def test_ad9545_requested_clock_pairs_are_caller_independent():
+    """The convenience API must derive independent fixed-width topology lists."""
+    clock = adijif.ad9545(solver="CPLEX")
+    inputs = [[0, 125_000_000]]
+    outputs = [[0, 156_250_000]]
+
+    clock.set_requested_clocks(inputs, outputs)
+    inputs[0][1] = 1
+    outputs[0][1] = 2
+
+    assert clock.input_refs == [125_000_000, 0, 0, 0]
+    assert clock.out_freqs == [156_250_000] + [0] * 9


### PR DESCRIPTION
## Summary

- copy AD9545 input-reference and output-frequency topology lists during low-level setup
- prevent subsequent caller mutations from changing configured clock topology
- correct the convenience API type contract to describe indexed `[channel, rate]` pairs
- cover both low-level and convenience setup paths

## TDD evidence

Before the fix, mutating either caller list after `setup_constraints()` immediately changed `clock.input_refs` and `clock.out_freqs`; both attributes had identical object identities to their inputs.

## Verification

```text
pytest -q tests/test_ad9545_request_ownership.py tests/test_clock_request_ownership.py tests/test_clock_state_ownership.py tests/test_clocks.py tests/test_clocks_more_coverage.py tests/test_system.py
81 passed, 1 skipped

ruff check <changed files>
All checks passed!

ty check <project CI arguments>
All checks passed!

git diff --check
passed
```