### PR TITLE
Own clock divider setter inputs

### DIFF
--- a/adijif/clocks/ad9523.py
+++ b/adijif/clocks/ad9523.py
@@ -77,7 +77,7 @@ class ad9523_1(ad9523_1_bf):
 
         """
         self._check_in_range(value, self.m1_available, "m1")
-        self._m1 = value
+        self._m1 = self._own_selection(value)
 
     @property
     def d(self) -> Union[int, List[int]]:
@@ -101,7 +101,7 @@ class ad9523_1(ad9523_1_bf):
 
         """
         self._check_in_range(value, self.d_available, "d")
-        self._d = value
+        self._d = self._own_selection(value)
 
     @property
     def n2(self) -> Union[int, List[int]]:
@@ -125,7 +125,7 @@ class ad9523_1(ad9523_1_bf):
 
         """
         self._check_in_range(value, self.n2_available, "n2")
-        self._n2 = value
+        self._n2 = self._own_selection(value)
 
     @property
     def r2(self) -> Union[int, List[int]]:
@@ -149,7 +149,7 @@ class ad9523_1(ad9523_1_bf):
 
         """
         self._check_in_range(value, self.r2_available, "r2")
-        self._r2 = value
+        self._r2 = self._own_selection(value)
 
     def get_config(self, solution: CpoSolveResult = None) -> Dict:
         """Extract configurations from solver results.

--- a/adijif/clocks/ad9528.py
+++ b/adijif/clocks/ad9528.py
@@ -26,6 +26,7 @@ class ad9528(ad9528_bf):
     """ VCO calibration dividers """
     a_available = [0, 1, 2, 3]
     b_availble = [*range(3, 64)]
+    b_available = b_availble
     # N = (PxB) + A, P=4, A==[0,1,2,3], B=[3..63]
     # See table 46 of DS for limits
     """ VCXO dividers """
@@ -77,7 +78,7 @@ class ad9528(ad9528_bf):
 
         """
         self._check_in_range(value, self.m1_available, "m1")
-        self._m1 = value
+        self._m1 = self._own_selection(value)
 
     @property
     def d(self) -> Union[int, List[int]]:
@@ -101,7 +102,7 @@ class ad9528(ad9528_bf):
 
         """
         self._check_in_range(value, self.d_available, "d")
-        self._d = value
+        self._d = self._own_selection(value)
 
     @property
     def k(self) -> Union[int, List[int]]:
@@ -125,7 +126,7 @@ class ad9528(ad9528_bf):
 
         """
         self._check_in_range(value, self.d_available, "k")
-        self._k = value
+        self._k = self._own_selection(value)
 
     @property
     def n2(self) -> Union[int, List[int]]:
@@ -149,7 +150,7 @@ class ad9528(ad9528_bf):
 
         """
         self._check_in_range(value, self.n2_available, "n2")
-        self._n2 = value
+        self._n2 = self._own_selection(value)
 
     @property
     def r1(self) -> Union[int, List[int]]:
@@ -173,7 +174,7 @@ class ad9528(ad9528_bf):
 
         """
         self._check_in_range(value, self.r1_available, "r1")
-        self._r1 = value
+        self._r1 = self._own_selection(value)
 
     @property
     def a(self) -> Union[int, List[int]]:
@@ -197,7 +198,7 @@ class ad9528(ad9528_bf):
 
         """
         self._check_in_range(value, self.a_available, "a")
-        self._a = value
+        self._a = self._own_selection(value)
 
     @property
     def b(self) -> Union[int, List[int]]:
@@ -221,7 +222,7 @@ class ad9528(ad9528_bf):
 
         """
         self._check_in_range(value, self.b_available, "b")
-        self._b = value
+        self._b = self._own_selection(value)
 
     @property
     def vco(self) -> float:

--- a/adijif/clocks/clock.py
+++ b/adijif/clocks/clock.py
@@ -54,6 +54,11 @@ class clock(core, gekko_translation, metaclass=ABCMeta):
                 ):
                     setattr(self, name, copy.deepcopy(value))
 
+    @staticmethod
+    def _own_selection(value: Any) -> Any:
+        """Copy mutable public selections before retaining them."""
+        return copy.deepcopy(value) if isinstance(value, (list, dict, set)) else value
+
     def _parse_reference(
         self, vcxo: Union[int, float, CpoExpr]
     ) -> Union[int, float, CpoExpr]:

--- a/adijif/clocks/hmc7044.py
+++ b/adijif/clocks/hmc7044.py
@@ -93,7 +93,7 @@ class hmc7044(hmc7044_bf):
             value (int, list[int]): Allowable values for divider
         """
         self._check_in_range(value, self.d_available, "d")
-        self._d = value
+        self._d = self._own_selection(value)
 
     @property
     def n2(self) -> Union[int, List[int]]:
@@ -116,7 +116,7 @@ class hmc7044(hmc7044_bf):
             value (int, list[int]): Allowable values for divider
         """
         self._check_in_range(value, self.n2_available, "n2")
-        self._n2 = value
+        self._n2 = self._own_selection(value)
 
     @property
     def r2(self) -> Union[int, List[int]]:
@@ -139,7 +139,7 @@ class hmc7044(hmc7044_bf):
             value (int, list[int]): Allowable values for divider
         """
         self._check_in_range(value, self.r2_available, "r2")
-        self._r2 = value
+        self._r2 = self._own_selection(value)
 
     @property
     def vcxo_doubler(self) -> Union[int, List[int]]:
@@ -163,7 +163,7 @@ class hmc7044(hmc7044_bf):
 
         """
         self._check_in_range(value, self.vcxo_doubler_available, "vcxo_doubler")
-        self._vcxo_doubler = value
+        self._vcxo_doubler = self._own_selection(value)
 
     def _init_diagram(self) -> None:
         """Initialize diagram for HMC7044 alone."""

--- a/adijif/clocks/ltc6952.py
+++ b/adijif/clocks/ltc6952.py
@@ -403,7 +403,7 @@ class ltc6952(ltc6952_bf):
 
         """
         self._check_in_range(value, self.d_available, "d")
-        self._d = value
+        self._d = self._own_selection(value)
 
     @property
     def n2(self) -> Union[int, List[int]]:
@@ -427,7 +427,7 @@ class ltc6952(ltc6952_bf):
 
         """
         self._check_in_range(value, self.n2_available, "n2")
-        self._n2 = value
+        self._n2 = self._own_selection(value)
 
     @property
     def r2(self) -> Union[int, List[int]]:
@@ -451,7 +451,7 @@ class ltc6952(ltc6952_bf):
 
         """
         self._check_in_range(value, self.r2_available, "r2")
-        self._r2 = value
+        self._r2 = self._own_selection(value)
 
     def get_config(self, solution: CpoSolveResult = None) -> Dict:
         """Extract configurations from solver results.

--- a/adijif/clocks/ltc6953.py
+++ b/adijif/clocks/ltc6953.py
@@ -347,7 +347,10 @@ class ltc6953(clock):
             value (int, list[int]): Allowable values for divider
 
         """
-        self._check_in_range(value, self.m_available, "m")
+        self._check_in_range(value, self.m_available, "d")
+        self._d = self._own_selection(value)
+        # Keep the solver-facing field synchronized while preserving the
+        # historical private storage used by downstream code.
         self._m = self._own_selection(value)
 
     def find_dividers(self) -> Dict:

--- a/adijif/clocks/ltc6953.py
+++ b/adijif/clocks/ltc6953.py
@@ -335,7 +335,7 @@ class ltc6953(clock):
         Returns:
             int: Current allowable dividers
         """
-        return self._d
+        return self._m
 
     @m.setter
     def m(self, value: Union[int, List[int]]) -> None:
@@ -347,8 +347,8 @@ class ltc6953(clock):
             value (int, list[int]): Allowable values for divider
 
         """
-        self._check_in_range(value, self.m_available, "d")
-        self._d = value
+        self._check_in_range(value, self.m_available, "m")
+        self._m = self._own_selection(value)
 
     def find_dividers(self) -> Dict:
         """Find the best dividers for the current configuration.

--- a/tests/test_clock_setter_ownership.py
+++ b/tests/test_clock_setter_ownership.py
@@ -38,3 +38,7 @@ def test_clock_setter_copies_mutable_selection(name, attribute, selection):
     selection.clear()
 
     assert getattr(clock, attribute) == expected
+    if name == "ltc6953":
+        assert clock._d == expected
+        assert clock._m == expected
+        assert clock._d is not clock._m

--- a/tests/test_clock_setter_ownership.py
+++ b/tests/test_clock_setter_ownership.py
@@ -1,0 +1,40 @@
+"""Regression tests for clock-divider setter ownership."""
+
+import pytest
+
+from adijif.registry import get_component_class
+
+SETTER_CASES = [
+    ("ad9523_1", "m1", [3, 4]),
+    ("ad9523_1", "d", [1, 2]),
+    ("ad9523_1", "n2", [12, 16]),
+    ("ad9523_1", "r2", [1, 2]),
+    ("ad9528", "m1", [3, 4]),
+    ("ad9528", "d", [1, 2]),
+    ("ad9528", "k", [1, 2]),
+    ("ad9528", "n2", [12, 16]),
+    ("ad9528", "r1", [1, 2]),
+    ("ad9528", "a", [0, 1]),
+    ("ad9528", "b", [3, 4]),
+    ("hmc7044", "d", [1, 2]),
+    ("hmc7044", "n2", [8, 9]),
+    ("hmc7044", "r2", [1, 2]),
+    ("hmc7044", "vcxo_doubler", [1, 2]),
+    ("ltc6952", "d", [1, 2]),
+    ("ltc6952", "n2", [1, 2]),
+    ("ltc6952", "r2", [1, 2]),
+    ("ltc6953", "m", [1, 2]),
+]
+
+
+@pytest.mark.parametrize("name,attribute,selection", SETTER_CASES)
+def test_clock_setter_copies_mutable_selection(name, attribute, selection):
+    """Changing a setter input later must not alter the clock selection."""
+    clock_class = get_component_class("clock", name)
+    clock = clock_class(solver="gekko")
+    expected = list(selection)
+
+    setattr(clock, attribute, selection)
+    selection.clear()
+
+    assert getattr(clock, attribute) == expected


### PR DESCRIPTION
## Summary

- copy mutable divider selections accepted by clock property setters
- prevent later caller mutations from changing configured divider domains
- add a parameterized ownership matrix covering 19 setters across five clock models
- expose the canonical AD9528 `b_available` name while preserving legacy `b_availble`
- align LTC6953 `m` getter/setter storage with the `_m` field used by its solver path

## TDD evidence

The new regression initially produced 19 failures. Eighteen setters retained their input lists directly; AD9528 `b` additionally failed because its setter referenced missing `b_available`. The matrix also confirmed LTC6953 `m` was backed by `_d` even though the GEKKO path consumes `_m`.

## Verification

```text
pytest -q tests/test_clock_setter_ownership.py tests/test_clock_request_ownership.py tests/test_clock_state_ownership.py tests/test_clocks.py tests/test_clocks_more_coverage.py tests/test_device_state_cleanup.py tests/test_final_coverage.py::test_system_initialize_edge_cases tests/test_system.py
112 passed, 1 skipped

ruff check <changed files>
All checks passed!

ty check <project CI arguments>
All checks passed!

git diff --check
passed
```