### PR TITLE
Isolate PLL selection state

### DIFF
--- a/adijif/plls/adf4030.py
+++ b/adijif/plls/adf4030.py
@@ -239,7 +239,7 @@ class adf4030(pll, adf4030_drawer):
 
         """
         self._check_in_range(value, self.r_available, "r")
-        self._r = value
+        self._r = self._own_selection(value)
 
     _n = [*range(8, 255 + 1)]
     n_available = [*range(8, 255 + 1)]
@@ -266,7 +266,7 @@ class adf4030(pll, adf4030_drawer):
 
         """
         self._check_in_range(value, self.n_available, "n")
-        self._n = value
+        self._n = self._own_selection(value)
 
     _o = [*range(10, 4095 + 1)]
     o_available = [*range(10, 4095 + 1)]
@@ -293,7 +293,7 @@ class adf4030(pll, adf4030_drawer):
 
         """
         self._check_in_range(value, self.o_available, "o")
-        self._o = value
+        self._o = self._own_selection(value)
 
     def get_config(self, solution: CpoSolveResult = None) -> Dict:
         """Extract configurations from solver results.

--- a/adijif/plls/adf4371.py
+++ b/adijif/plls/adf4371.py
@@ -167,7 +167,7 @@ class adf4371(pll, adf4371_drawer):
 
         """
         self._check_in_range(value, self.d_available, "d")
-        self._d = value
+        self._d = self._own_selection(value)
 
     _r = [*range(1, 32 + 1)]
     r_available = [*range(1, 32 + 1)]
@@ -194,7 +194,7 @@ class adf4371(pll, adf4371_drawer):
 
         """
         self._check_in_range(value, self.r_available, "r")
-        self._r = value
+        self._r = self._own_selection(value)
 
     _t = [0, 1]
     t_available = [0, 1]
@@ -221,7 +221,7 @@ class adf4371(pll, adf4371_drawer):
 
         """
         self._check_in_range(value, self.t_available, "t")
-        self._t = value
+        self._t = self._own_selection(value)
 
     _rf_div = [1, 2, 4, 8, 16, 32, 64]
     rf_div_available = [1, 2, 4, 8, 16, 32, 64]
@@ -248,7 +248,7 @@ class adf4371(pll, adf4371_drawer):
 
         """
         self._check_in_range(value, self.rf_div_available, "rf_div")
-        self._rf_div = value
+        self._rf_div = self._own_selection(value)
 
     _mode = ["integer", "fractional"]
     mode_available = ["integer", "fractional"]
@@ -275,7 +275,7 @@ class adf4371(pll, adf4371_drawer):
 
         """
         self._check_in_range(value, self.mode_available, "mode")
-        self._mode = value
+        self._mode = self._own_selection(value)
 
     # These are too large for user to set
     _int_4d5_min_max = [20, 32767]

--- a/adijif/plls/adf4382.py
+++ b/adijif/plls/adf4382.py
@@ -246,7 +246,7 @@ class adf4382(pll, adf4382_drawer):
 
         """
         self._check_in_range(value, self.d_available, "d")
-        self._d = value
+        self._d = self._own_selection(value)
 
     _r = [*range(1, 63 + 1)]
     r_available = [*range(1, 63 + 1)]
@@ -273,7 +273,7 @@ class adf4382(pll, adf4382_drawer):
 
         """
         self._check_in_range(value, self.r_available, "r")
-        self._r = value
+        self._r = self._own_selection(value)
 
     _o = [1, 2, 4]
     o_available = [1, 2, 4]
@@ -300,7 +300,7 @@ class adf4382(pll, adf4382_drawer):
 
         """
         self._check_in_range(value, self.o_available, "o")
-        self._o = value
+        self._o = self._own_selection(value)
 
     _n = [*range(4, 2**12)]
     n_available = [*range(4, 2**12)]
@@ -327,7 +327,7 @@ class adf4382(pll, adf4382_drawer):
 
         """
         self._check_in_range(value, self.n_available, "n")
-        self._n = value
+        self._n = self._own_selection(value)
 
     _mode = ["integer"]  # Dont use fractional mode by default
     mode_available = ["integer", "fractional"]
@@ -354,7 +354,7 @@ class adf4382(pll, adf4382_drawer):
 
         """
         self._check_in_range(value, self.mode_available, "mode")
-        self._mode = value
+        self._mode = self._own_selection(value)
 
     # These are too large for user to set
     _frac1_min_max = [0, 2**25 - 1]
@@ -409,7 +409,7 @@ class adf4382(pll, adf4382_drawer):
 
         """
         self._check_in_range(value, self.EFM3_MODE_available, "EFM3_MODE")
-        self._EFM3_MODE = value
+        self._EFM3_MODE = self._own_selection(value)
 
     def get_config(self, solution: CpoSolveResult = None) -> Dict:
         """Extract configurations from solver results.

--- a/adijif/plls/pll.py
+++ b/adijif/plls/pll.py
@@ -1,7 +1,8 @@
 """PLL parent metaclass to maintain consistency for all pll chips."""
 
+import copy
 from abc import ABCMeta
-from typing import Union
+from typing import Any, Union
 
 from docplex.cp.solution import CpoSolveResult  # type: ignore
 
@@ -12,6 +13,26 @@ from adijif.optimization import apply_objectives
 
 class pll(core, gekko_translation, metaclass=ABCMeta):
     """Parent metaclass for all pll chip classes."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize solver state and isolate mutable PLL selections."""
+        super().__init__(*args, **kwargs)
+        for cls in type(self).__mro__:
+            for name, value in vars(cls).items():
+                if (
+                    name.startswith("_")
+                    and not name.startswith("__")
+                    and isinstance(value, (list, dict, set))
+                    and name not in self.__dict__
+                ):
+                    setattr(self, name, copy.deepcopy(value))
+
+    @staticmethod
+    def _own_selection(value: Any) -> Any:
+        """Copy mutable public selections before retaining them."""
+        if isinstance(value, (list, dict, set)):
+            return copy.deepcopy(value)
+        return value
 
     # @property
     # @abstractmethod

--- a/tests/test_pll_state_ownership.py
+++ b/tests/test_pll_state_ownership.py
@@ -1,0 +1,54 @@
+"""Regression tests for per-instance PLL selection ownership."""
+
+import pytest
+
+from adijif.registry import get_component_class
+
+SETTER_CASES = [
+    ("adf4030", "r", [1, 2]),
+    ("adf4030", "n", [8, 9]),
+    ("adf4030", "o", [10, 11]),
+    ("adf4371", "d", [0, 1]),
+    ("adf4371", "r", [1, 2]),
+    ("adf4371", "t", [0, 1]),
+    ("adf4371", "rf_div", [1, 2]),
+    ("adf4371", "mode", ["integer", "fractional"]),
+    ("adf4382", "d", [1, 2]),
+    ("adf4382", "r", [1, 2]),
+    ("adf4382", "o", [1, 2]),
+    ("adf4382", "n", [4, 5]),
+    ("adf4382", "mode", ["integer", "fractional"]),
+    ("adf4382", "EFM3_MODE", [0, 4]),
+]
+
+
+@pytest.mark.parametrize("name,attribute,selection", SETTER_CASES)
+def test_pll_setters_copy_mutable_selections(name, attribute, selection):
+    """A caller mutation must not alter a configured PLL selection."""
+    pll = get_component_class("pll", name)(solver="CPLEX")
+    expected = list(selection)
+
+    setattr(pll, attribute, selection)
+    selection.clear()
+
+    assert getattr(pll, attribute) == expected
+
+
+@pytest.mark.parametrize("name", ["adf4030", "adf4371", "adf4382"])
+def test_pll_instances_isolate_private_mutable_defaults(name):
+    """Each PLL instance must own its mutable runtime defaults."""
+    pll_type = get_component_class("pll", name)
+    first = pll_type(solver="CPLEX")
+    second = pll_type(solver="CPLEX")
+
+    mutable_fields = {
+        field
+        for cls in pll_type.__mro__
+        for field, value in vars(cls).items()
+        if field.startswith("_")
+        and not field.startswith("__")
+        and isinstance(value, (list, dict, set))
+    }
+
+    for field in mutable_fields:
+        assert getattr(first, field) is not getattr(second, field), field


### PR DESCRIPTION
## Summary
- deep-copy private mutable runtime defaults for every supported PLL instance
- copy mutable divider and mode selections retained by public PLL setters
- add ownership regressions across ADF4030, ADF4371, and ADF4382

## Validation
- 739 passed, 11 skipped, 5 xfailed (`pytest --ignore=tests/tools/e2e`)
- Ruff passed
- ty passed
- `git diff --check` passed