### PR TITLE
Isolate Xilinx PLL selection state

### DIFF
--- a/adijif/fpgas/xilinx/pll.py
+++ b/adijif/fpgas/xilinx/pll.py
@@ -1,6 +1,7 @@
 """Xilinx Common PLL class."""
 
-from typing import Optional, Union
+import copy
+from typing import Any, Optional, Union
 
 from docplex.cp.solution import CpoSolveResult  # type: ignore
 
@@ -209,6 +210,22 @@ class PLLCommon(gekko_translation):
             parent_transceiver (CpoModel): Parent transceiver object
         """
         self.parent = parent_transceiver
+        for cls in type(self).__mro__:
+            for name, value in vars(cls).items():
+                if (
+                    name.startswith("_")
+                    and not name.startswith("__")
+                    and isinstance(value, (list, dict, set))
+                    and name not in self.__dict__
+                ):
+                    setattr(self, name, copy.deepcopy(value))
+
+    @staticmethod
+    def _own_selection(value: Any) -> Any:
+        """Copy mutable public selections before retaining them."""
+        if isinstance(value, (list, dict, set)):
+            return copy.deepcopy(value)
+        return value
 
     @property
     def model(self) -> CpoModel:

--- a/adijif/fpgas/xilinx/sevenseries.py
+++ b/adijif/fpgas/xilinx/sevenseries.py
@@ -140,7 +140,7 @@ class CPLL(PLLCommon):
     def M(self, value: Union[int, List[int]]) -> None:
         """Set the M value for the CPLL."""
         self._check_in_range(value, self.M_available, "M")
-        self._M = value
+        self._M = self._own_selection(value)
 
     N2_available = [1, 2, 3, 4, 5]
     _N2 = [1, 2, 3, 4, 5]
@@ -154,7 +154,7 @@ class CPLL(PLLCommon):
     def N2(self, value: Union[int, List[int]]) -> None:
         """Set the N2 value for the CPLL."""
         self._check_in_range(value, self.N2_available, "N2")
-        self._N2 = value
+        self._N2 = self._own_selection(value)
 
     N1_available = [4, 5]
     _N1 = [4, 5]
@@ -168,7 +168,7 @@ class CPLL(PLLCommon):
     def N1(self, value: Union[int, List[int]]) -> None:
         """Set the N1 value for the CPLL."""
         self._check_in_range(value, self.N1_available, "N1")
-        self._N1 = value
+        self._N1 = self._own_selection(value)
 
     D_available = [1, 2, 4, 8]
     _D = [1, 2, 4, 8]
@@ -182,7 +182,7 @@ class CPLL(PLLCommon):
     def D(self, value: Union[int, List[int]]) -> None:
         """Set the D value for the CPLL."""
         self._check_in_range(value, self.D_available, "D")
-        self._D = value
+        self._D = self._own_selection(value)
 
     def get_config(
         self, config: dict, converter: conv, fpga_ref: Union[int, CpoIntVar]
@@ -305,7 +305,7 @@ class QPLL(PLLCommon):
     def M(self, value: Union[int, List[int]]) -> None:
         """Set the M value for the QPLL."""
         self._check_in_range(value, self.M_available, "M")
-        self._M = value
+        self._M = self._own_selection(value)
 
     N_available = [16, 20, 32, 40, 64, 66, 80, 100]
     _N = [16, 20, 32, 40, 64, 66, 80, 100]
@@ -319,7 +319,7 @@ class QPLL(PLLCommon):
     def N(self, value: Union[int, List[int]]) -> None:
         """Set the N value for the QPLL."""
         self._check_in_range(value, self.N_available, "N")
-        self._N = value
+        self._N = self._own_selection(value)
 
     D_available = [1, 2, 4, 8, 16]
     _D = [1, 2, 4, 8, 16]
@@ -333,7 +333,7 @@ class QPLL(PLLCommon):
     def D(self, value: Union[int, List[int]]) -> None:
         """Set the D value for the QPLL."""
         self._check_in_range(value, self.D_available, "D")
-        self._D = value
+        self._D = self._own_selection(value)
 
     @property
     def vco_min(self) -> int:

--- a/adijif/fpgas/xilinx/ultrascaleplus.py
+++ b/adijif/fpgas/xilinx/ultrascaleplus.py
@@ -188,9 +188,9 @@ class QPLL(SevenSeriesQPLL):
             val, self.QPLL_CLKOUTRATE_available, "QPLL_CLKOUTRATE"
         )
         if "GTH" in self.parent.transceiver_type:
-            self._QPLL_CLKOUTRATE_GTH = val
+            self._QPLL_CLKOUTRATE_GTH = self._own_selection(val)
         elif "GTY" in self.parent.transceiver_type:
-            self._QPLL_CLKOUTRATE_GTY = val
+            self._QPLL_CLKOUTRATE_GTY = self._own_selection(val)
         else:
             raise ValueError(
                 f"QPLL_CLKOUTRATE not available for {self.parent.transceiver_type}"
@@ -261,7 +261,7 @@ class QPLL(SevenSeriesQPLL):
             val (int): SDMWIDTH value.
         """
         self._check_in_range(val, self.SDMWIDTH_available, "SDMWIDTH")
-        self._SDMWIDTH = val
+        self._SDMWIDTH = self._own_selection(val)
 
     _pname = "qpll"
 

--- a/adijif/fpgas/xilinx/versal.py
+++ b/adijif/fpgas/xilinx/versal.py
@@ -157,7 +157,7 @@ class RPLL(PLLCommon):
     def M(self, value: Union[int, List[int]]) -> None:
         """Set the M value for RPLL."""
         self._check_in_range(value, self.M_available, "M")
-        self._M = value
+        self._M = self._own_selection(value)
 
     # N divider: Integer mode has specific values, fractional mode is continuous
     # For solver, we use integer N and add fractional part separately
@@ -176,7 +176,7 @@ class RPLL(PLLCommon):
         if isinstance(value, int):
             if value < 5 or value > 80:
                 raise ValueError(f"N must be between 5 and 80, got {value}")
-        self._N = value
+        self._N = self._own_selection(value)
 
     D_available = [1, 2, 4, 8, 16]
     _D = [1, 2, 4, 8, 16]
@@ -190,7 +190,7 @@ class RPLL(PLLCommon):
     def D(self, value: Union[int, List[int]]) -> None:
         """Set the D value for RPLL."""
         self._check_in_range(value, self.D_available, "D")
-        self._D = value
+        self._D = self._own_selection(value)
 
     # Fractional-N support
     SDMDATA_min_max = [0, 2**24 - 1]
@@ -239,7 +239,7 @@ class RPLL(PLLCommon):
     def SDMWIDTH(self, val: Union[int, List[int]]) -> None:
         """Set the SDMWIDTH."""
         self._check_in_range(val, self.SDMWIDTH_available, "SDMWIDTH")
-        self._SDMWIDTH = val
+        self._SDMWIDTH = self._own_selection(val)
 
     force_integer_mode = False
 
@@ -491,7 +491,7 @@ class LCPLL(PLLCommon):
     def M(self, value: Union[int, List[int]]) -> None:
         """Set the M value for LCPLL."""
         self._check_in_range(value, self.M_available, "M")
-        self._M = value
+        self._M = self._own_selection(value)
 
     # N divider: Integer mode [13-160], fractional mode continuous
     N_available = [*range(13, 161)]  # [13, 14, ..., 160]
@@ -509,7 +509,7 @@ class LCPLL(PLLCommon):
         if isinstance(value, int):
             if value < 13 or value > 160:
                 raise ValueError(f"N must be between 13 and 160, got {value}")
-        self._N = value
+        self._N = self._own_selection(value)
 
     D_available = [1, 2, 4, 8, 16]
     _D = [1, 2, 4, 8, 16]
@@ -523,7 +523,7 @@ class LCPLL(PLLCommon):
     def D(self, value: Union[int, List[int]]) -> None:
         """Set the D value for LCPLL."""
         self._check_in_range(value, self.D_available, "D")
-        self._D = value
+        self._D = self._own_selection(value)
 
     # LCPLL_CLKOUTRATE: 1 = full rate, 2 = half rate
     LCPLL_CLKOUTRATE_available = [1, 2]
@@ -540,7 +540,7 @@ class LCPLL(PLLCommon):
         self._check_in_range(
             val, self.LCPLL_CLKOUTRATE_available, "LCPLL_CLKOUTRATE"
         )
-        self._LCPLL_CLKOUTRATE = val
+        self._LCPLL_CLKOUTRATE = self._own_selection(val)
 
     # Fractional-N support
     SDMDATA_min_max = [0, 2**24 - 1]
@@ -589,7 +589,7 @@ class LCPLL(PLLCommon):
     def SDMWIDTH(self, val: Union[int, List[int]]) -> None:
         """Set the SDMWIDTH."""
         self._check_in_range(val, self.SDMWIDTH_available, "SDMWIDTH")
-        self._SDMWIDTH = val
+        self._SDMWIDTH = self._own_selection(val)
 
     force_integer_mode = False
 

--- a/tests/test_xilinx_pll_state_ownership.py
+++ b/tests/test_xilinx_pll_state_ownership.py
@@ -1,0 +1,76 @@
+"""Regression tests for Xilinx transceiver PLL state ownership."""
+
+import pytest
+
+from adijif.fpgas.xilinx.sevenseries import SevenSeries
+from adijif.fpgas.xilinx.ultrascaleplus import UltraScalePlus
+from adijif.fpgas.xilinx.versal import Versal
+
+PARENTS = {
+    "seven": (SevenSeries, "GTXE2"),
+    "usp": (UltraScalePlus, "GTHE4"),
+    "versal": (Versal, "GTYE5"),
+}
+
+SETTER_CASES = [
+    ("seven", "CPLL", "M", [1, 2]),
+    ("seven", "CPLL", "N2", [1, 2]),
+    ("seven", "CPLL", "N1", [4, 5]),
+    ("seven", "CPLL", "D", [1, 2]),
+    ("seven", "QPLL", "M", [1, 2]),
+    ("seven", "QPLL", "N", [16, 20]),
+    ("seven", "QPLL", "D", [1, 2]),
+    ("usp", "QPLL", "QPLL_CLKOUTRATE", [1, 2]),
+    ("usp", "QPLL", "SDMWIDTH", [16, 20]),
+    ("versal", "RPLL", "M", [1, 2]),
+    ("versal", "RPLL", "N", [5, 6]),
+    ("versal", "RPLL", "D", [1, 2]),
+    ("versal", "RPLL", "SDMWIDTH", [16, 20]),
+    ("versal", "LCPLL", "M", [1, 2]),
+    ("versal", "LCPLL", "N", [13, 14]),
+    ("versal", "LCPLL", "D", [1, 2]),
+    ("versal", "LCPLL", "LCPLL_CLKOUTRATE", [1, 2]),
+    ("versal", "LCPLL", "SDMWIDTH", [16, 20]),
+]
+
+
+def _parent(kind):
+    parent_type, transceiver_type = PARENTS[kind]
+    return parent_type(transceiver_type=transceiver_type, solver="CPLEX")
+
+
+@pytest.mark.parametrize("kind,pll_name,attribute,selection", SETTER_CASES)
+def test_transceiver_pll_setters_copy_mutable_selections(
+    kind, pll_name, attribute, selection
+):
+    """Caller mutations must not alter retained transceiver PLL selections."""
+    pll = _parent(kind).plls[pll_name]
+    expected = list(selection)
+
+    setattr(pll, attribute, selection)
+    selection.clear()
+
+    assert getattr(pll, attribute) == expected
+
+
+@pytest.mark.parametrize("kind", PARENTS)
+def test_transceiver_pll_instances_isolate_private_mutable_defaults(kind):
+    """PLL children in separate FPGA models must not share runtime defaults."""
+    first = _parent(kind)
+    second = _parent(kind)
+
+    for pll_name, first_pll in first.plls.items():
+        second_pll = second.plls[pll_name]
+        mutable_fields = {
+            field
+            for cls in type(first_pll).__mro__
+            for field, value in vars(cls).items()
+            if field.startswith("_")
+            and not field.startswith("__")
+            and isinstance(value, (list, dict, set))
+        }
+        for field in mutable_fields:
+            assert getattr(first_pll, field) is not getattr(second_pll, field), (
+                pll_name,
+                field,
+            )


### PR DESCRIPTION
## Summary
- deep-copy private mutable runtime defaults for Xilinx transceiver PLL children
- copy mutable divider and mode selections retained by public setters
- cover Seven Series, UltraScale+, and Versal PLL families with ownership regressions

## Validation
- 760 passed, 11 skipped, 5 xfailed (`pytest --ignore=tests/tools/e2e`)
- Ruff passed
- ty passed
- `git diff --check` passed