### PR TITLE
Return independent AD908x datapath snapshots

### DIFF
--- a/adijif/converters/ad9081_dp.py
+++ b/adijif/converters/ad9081_dp.py
@@ -1,5 +1,7 @@
 """AD9081 Datapath Description Class."""
 
+import copy
+
 
 class ad9081_dp_rx:
     """AD9081 RX Data Path Configuration."""
@@ -99,7 +101,7 @@ class ad9081_dp_rx:
         datapath["fddc"]["nco_phases"] = self.fddc_nco_phases
         datapath["fddc"]["source"] = self.fddc_source
 
-        return datapath
+        return copy.deepcopy(datapath)
 
     @property
     def decimation_overall(self) -> int:
@@ -222,7 +224,7 @@ class ad9081_dp_tx:
         datapath["fduc"]["nco_frequencies"] = self.fduc_nco_frequencies
         datapath["fduc"]["nco_phases"] = self.fduc_nco_phases
 
-        return datapath
+        return copy.deepcopy(datapath)
 
     @property
     def interpolation_overall(self) -> int:

--- a/adijif/converters/ad9084_dp.py
+++ b/adijif/converters/ad9084_dp.py
@@ -1,5 +1,7 @@
 """AD9084 Datapath Description Class."""
 
+import copy
+
 
 class ad9084_dp_rx:
     """AD9084 RX Data Path Configuration."""
@@ -53,7 +55,7 @@ class ad9084_dp_rx:
         datapath["fddc"]["nco_phases"] = self.fddc_nco_phases
         datapath["fddc"]["source"] = self.fddc_source
 
-        return datapath
+        return copy.deepcopy(datapath)
 
     @property
     def decimation_overall(self) -> int:
@@ -192,4 +194,4 @@ class ad9084_dp_tx:
         datapath["fduc"]["nco_frequencies"] = self.fduc_nco_frequencies
         datapath["fduc"]["nco_phases"] = self.fduc_nco_phases
 
-        return datapath
+        return copy.deepcopy(datapath)

--- a/adijif/converters/ad9088_dp.py
+++ b/adijif/converters/ad9088_dp.py
@@ -1,5 +1,7 @@
 """AD9088 Datapath Description Class."""
 
+import copy
+
 
 class ad9088_dp_rx:
     """AD9088 RX Data Path Configuration."""
@@ -53,7 +55,7 @@ class ad9088_dp_rx:
         datapath["fddc"]["nco_phases"] = self.fddc_nco_phases
         datapath["fddc"]["source"] = self.fddc_source
 
-        return datapath
+        return copy.deepcopy(datapath)
 
     @property
     def decimation_overall(self) -> int:

--- a/tests/test_ad908x_datapath_snapshots.py
+++ b/tests/test_ad908x_datapath_snapshots.py
@@ -1,0 +1,39 @@
+"""Regression tests for AD908x datapath configuration snapshots."""
+
+import pytest
+
+import adijif
+
+DATAPATH_CASES = [
+    (adijif.ad9081_rx, "cddc", "decimations", "cddc_decimations"),
+    (adijif.ad9081_tx, "fduc", "enabled", "fduc_enabled"),
+    (adijif.ad9084_rx, "cddc", "decimations", "cddc_decimations"),
+    (adijif.ad9084_tx, "fduc", "enabled", "fduc_enabled"),
+    (adijif.ad9088_rx, "fddc", "source", "fddc_source"),
+    (adijif.ad9088_tx, "fduc", "enabled", "fduc_enabled"),
+]
+
+
+@pytest.mark.parametrize("device_type,stage,field,attribute", DATAPATH_CASES)
+def test_datapath_get_config_returns_independent_snapshot(
+    device_type, stage, field, attribute
+):
+    """Mutating a returned configuration must not alter the converter datapath."""
+    device = device_type(solver="gekko")
+    expected = list(getattr(device.datapath, attribute))
+
+    config = device.datapath.get_config()
+    config[stage][field][0] = "changed"
+
+    assert getattr(device.datapath, attribute) == expected
+
+
+def test_datapath_snapshots_do_not_alias_each_other():
+    """Separate snapshots must not share nested lists."""
+    device = adijif.ad9084_rx(solver="gekko")
+
+    first = device.datapath.get_config()
+    second = device.datapath.get_config()
+    first["cddc"]["decimations"][0] = 99
+
+    assert second["cddc"]["decimations"][0] != 99


### PR DESCRIPTION
## Summary
- return deep configuration snapshots from AD9081, AD9084, and AD9088 datapaths
- prevent callers from mutating live converter state through `get_config()` results
- verify RX/TX snapshots and separate calls do not alias nested lists

## Validation
- 767 passed, 11 skipped, 5 xfailed (`pytest --ignore=tests/tools/e2e`)
- focused converter suite: 95 passed
- Ruff passed
- ty passed
- `git diff --check` passed