### PR TITLE
Protect solved configuration caches

### DIFF
--- a/adijif/clocks/ad9523.py
+++ b/adijif/clocks/ad9523.py
@@ -208,9 +208,7 @@ class ad9523_1(ad9523_1_bf):
         config["vco"] = clk
         config["part"] = "AD9523-1"
 
-        self._last_config = config
-
-        return config
+        return self._cache_config(config)
 
     def _setup_solver_constraints(
         self, vcxo: Union[float, int, CpoIntVar]

--- a/adijif/clocks/ad9528.py
+++ b/adijif/clocks/ad9528.py
@@ -328,9 +328,7 @@ class ad9528(ad9528_bf):
 
         config["output_clocks"] = output_cfg
 
-        self._last_config = config
-
-        return config
+        return self._cache_config(config)
 
     def _setup_solver_constraints(self, vcxo: int) -> None:
         """Apply constraints to solver model.

--- a/adijif/clocks/ad9545.py
+++ b/adijif/clocks/ad9545.py
@@ -196,9 +196,7 @@ class ad9545(clock):
         for i in range(0, 10):
             config["q" + str(i)] = self._get_val(self.config["q" + str(i)])
 
-        self._last_config = config
-
-        return config
+        return self._cache_config(config)
 
     def draw(self, lo: Layout = None) -> str:
         """Draw clock tree diagram for AD9545.

--- a/adijif/clocks/hmc7044.py
+++ b/adijif/clocks/hmc7044.py
@@ -392,9 +392,7 @@ class hmc7044(hmc7044_bf):
         config["vcxo"] = self.vcxo
         config["vcxo_doubler"] = vd
 
-        self._last_config = config
-
-        return config
+        return self._cache_config(config)
 
     def _setup_solver_constraints(self, vcxo: int) -> None:
         """Apply constraints to solver model.

--- a/adijif/clocks/ltc6952.py
+++ b/adijif/clocks/ltc6952.py
@@ -509,9 +509,7 @@ class ltc6952(ltc6952_bf):
 
         config["output_clocks"] = output_cfg
 
-        self._last_config = config
-
-        return config
+        return self._cache_config(config)
 
     def _setup_solver_constraints(self, vcxo: int) -> None:
         """Apply constraints to solver model.

--- a/adijif/clocks/ltc6953.py
+++ b/adijif/clocks/ltc6953.py
@@ -421,9 +421,7 @@ class ltc6953(clock):
 
         config["output_clocks"] = output_cfg
 
-        self._last_config = config
-
-        return config
+        return self._cache_config(config)
 
     def draw(self, lo: Layout = None) -> str:
         """Draw clock tree diagram for LTC6953.

--- a/adijif/common.py
+++ b/adijif/common.py
@@ -67,6 +67,11 @@ class core:
                 )
             )
 
+    def _cache_config(self, config: Dict) -> Dict:
+        """Cache an owned configuration snapshot and return the caller's record."""
+        self._last_config = copy.deepcopy(config)
+        return config
+
     def disable_objective(self, name: str) -> None:
         """Suppress a built-in objective by name on subsequent solves.
 

--- a/adijif/plls/adf4030.py
+++ b/adijif/plls/adf4030.py
@@ -338,9 +338,7 @@ class adf4030(pll, adf4030_drawer):
 
         config["output_clocks"] = output_config
 
-        self._last_config = config
-
-        return config
+        return self._cache_config(config)
 
     def _setup_solver_constraints(
         self, input_ref: Union[int, float, CpoExpr, GK_Intermediate]

--- a/adijif/plls/adf4371.py
+++ b/adijif/plls/adf4371.py
@@ -346,9 +346,7 @@ class adf4371(pll, adf4371_drawer):
             }
         config["output_clocks"] = output_clocks
 
-        self._last_config = config
-
-        return config
+        return self._cache_config(config)
 
     def _setup_solver_constraints(
         self, input_ref: Union[int, float, CpoExpr, GK_Intermediate]

--- a/adijif/plls/adf4382.py
+++ b/adijif/plls/adf4382.py
@@ -478,9 +478,7 @@ class adf4382(pll, adf4382_drawer):
             }
         config["output_clocks"] = output_config
 
-        self._last_config = config
-
-        return config
+        return self._cache_config(config)
 
     def _setup_solver_constraints(
         self, input_ref: Union[int, float, CpoExpr, GK_Intermediate]

--- a/tests/test_config_cache_ownership.py
+++ b/tests/test_config_cache_ownership.py
@@ -1,0 +1,38 @@
+"""Regression tests for solved-configuration cache ownership."""
+
+import pytest
+
+import adijif
+
+
+@pytest.mark.parametrize(
+    "component,configure",
+    [
+        (
+            adijif.ltc6953,
+            lambda device: device.set_requested_clocks(
+                1_000_000_000, [500_000_000], ["output"]
+            ),
+        ),
+        (
+            adijif.adf4030,
+            lambda device: device.set_requested_clocks(
+                125_000_000, [100_000_000], ["output"]
+            ),
+        ),
+    ],
+)
+def test_returned_config_does_not_alias_cached_solution(component, configure):
+    """Callers must not be able to corrupt the cache used by drawing."""
+    device = component(solver="CPLEX")
+    configure(device)
+    device.solve()
+
+    config = device.get_config()
+    cached = device._last_config
+    assert cached == config
+    assert cached is not config
+
+    config["output_clocks"]["output"]["rate"] = -1
+
+    assert device._last_config["output_clocks"]["output"]["rate"] != -1


### PR DESCRIPTION
## Summary
- cache deep snapshots of solved clock and PLL configurations
- prevent mutations to returned `get_config()` records from corrupting drawing state
- apply the ownership boundary consistently across six clock chips and three standalone PLLs

## Validation
- 769 passed, 11 skipped, 5 xfailed (`pytest --ignore=tests/tools/e2e`)
- focused clock/PLL/system suite: 110 passed, 1 skipped
- Ruff passed
- ty passed
- `git diff --check` passed