### PR TITLE
Invalidate stale solved configurations

### DIFF
--- a/adijif/clocks/ad9523.py
+++ b/adijif/clocks/ad9523.py
@@ -304,6 +304,7 @@ class ad9523_1(ad9523_1_bf):
         Raises:
             Exception: If len(out_freqs) != len(clk_names)
         """
+        self._last_config = None
         if len(clk_names) != len(out_freqs):
             raise Exception("clk_names is not the same size as out_freqs")
 

--- a/adijif/clocks/ad9528.py
+++ b/adijif/clocks/ad9528.py
@@ -431,6 +431,7 @@ class ad9528(ad9528_bf):
         Raises:
             Exception: If len(out_freqs) != len(clk_names)
         """
+        self._last_config = None
         if len(clk_names) != len(out_freqs):
             raise Exception("clk_names is not the same size as out_freqs")
 

--- a/adijif/clocks/ad9545.py
+++ b/adijif/clocks/ad9545.py
@@ -581,6 +581,7 @@ class ad9545(clock):
             Exception: if the number of input references is not equal to the
                 number of output rates
         """
+        self._last_config = None
         input_refs = [0] * 4
         out_freqs = [0] * 10
 

--- a/adijif/clocks/hmc7044.py
+++ b/adijif/clocks/hmc7044.py
@@ -522,6 +522,7 @@ class hmc7044(hmc7044_bf):
         Raises:
             Exception: If len(out_freqs) != len(clk_names)
         """
+        self._last_config = None
         if len(clk_names) != len(out_freqs):
             raise Exception("clk_names is not the same size as out_freqs")
 
@@ -530,8 +531,6 @@ class hmc7044(hmc7044_bf):
         self._clk_names = list(clk_names)
         # if type(self.vcxo) not in [int,float]:
         #     vcxo = self.vcxo['range']
-
-        self._last_config = None
 
         # Add requested clocks to output constraints
         for d_n, out_freq in enumerate(out_freqs):

--- a/adijif/clocks/ltc6952.py
+++ b/adijif/clocks/ltc6952.py
@@ -608,6 +608,7 @@ class ltc6952(ltc6952_bf):
         Raises:
             Exception: If len(out_freqs) != len(clk_names)
         """
+        self._last_config = None
         if len(clk_names) != len(out_freqs):
             raise Exception("clk_names is not the same size as out_freqs")
 

--- a/adijif/clocks/ltc6953.py
+++ b/adijif/clocks/ltc6953.py
@@ -588,6 +588,7 @@ class ltc6953(clock):
         Raises:
             Exception: If len(out_freqs) != len(clk_names)
         """
+        self._last_config = None
         if len(clk_names) != len(out_freqs):
             raise Exception("clk_names is not the same size as out_freqs")
         self._clk_names = list(clk_names)

--- a/adijif/plls/adf4030.py
+++ b/adijif/plls/adf4030.py
@@ -491,6 +491,7 @@ class adf4030(pll, adf4030_drawer):
         Raises:
             Exception: If out_freq and clk_names are not the same length
         """
+        self._last_config = None
         if not isinstance(out_freq, list):
             out_freq = [out_freq]
         if not isinstance(clk_names, list):

--- a/adijif/plls/adf4371.py
+++ b/adijif/plls/adf4371.py
@@ -573,6 +573,7 @@ class adf4371(pll, adf4371_drawer):
             out_freq (int): list of required clocks to be output
 
         """
+        self._last_config = None
         self.setup_constraints(ref_in)
         self._clk_names = ["rf_out"]
 

--- a/adijif/plls/adf4382.py
+++ b/adijif/plls/adf4382.py
@@ -780,6 +780,7 @@ class adf4382(pll, adf4382_drawer):
             out_freq (int): list of required clocks to be output
 
         """
+        self._last_config = None
         self.setup_constraints(ref_in)
         self._clk_names = ["rf_out"]
 

--- a/tests/test_config_cache_invalidation.py
+++ b/tests/test_config_cache_invalidation.py
@@ -1,0 +1,40 @@
+"""Regression tests for solved-configuration cache invalidation."""
+
+import pytest
+
+import adijif
+
+
+@pytest.mark.parametrize(
+    "component,first,second",
+    [
+        (
+            adijif.ltc6953,
+            (1_000_000_000, [500_000_000], ["first"]),
+            (1_000_000_000, [250_000_000], ["second"]),
+        ),
+        (
+            adijif.adf4030,
+            (125_000_000, [100_000_000], ["first"]),
+            (125_000_000, [50_000_000], ["second"]),
+        ),
+    ],
+)
+def test_reconfiguration_invalidates_solved_config_cache(component, first, second):
+    """A new request must make the prior solved configuration stale."""
+    device = component(solver="CPLEX")
+    device.set_requested_clocks(*first)
+    device.solve()
+    device.get_config()
+    assert device._last_config is not None
+
+    try:
+        device.set_requested_clocks(*second)
+    except Exception as ex:
+        # Some standalone solver models cannot redefine named variables without
+        # rebuilding the model. The stale cache must still be invalidated.
+        assert "already exists in model" in str(ex)
+
+    assert device._last_config is None
+    with pytest.raises(Exception, match="No solution to draw"):
+        device.draw()


### PR DESCRIPTION
## Summary
- invalidate cached solved configurations when clock or PLL requests change
- prevent drawing stale topology after successful or failed reconfiguration
- cover both clock-chip and standalone PLL lifecycle behavior

## Validation
- 771 passed, 11 skipped, 5 xfailed (`pytest --ignore=tests/tools/e2e`)
- focused lifecycle/drawing/system suite: 105 passed, 1 skipped
- Ruff passed
- ty passed
- `git diff --check` passed