### PR TITLE
Invalidate caches during low-level setup

### DIFF
--- a/adijif/clocks/ad9523.py
+++ b/adijif/clocks/ad9523.py
@@ -260,6 +260,7 @@ class ad9523_1(ad9523_1_bf):
                 plain ``int``.
         """
         # FIXME: ADD SPLIT m1 configuration support
+        self._last_config = None
         if self.use_vcxo_double and not isinstance(vcxo, int):
             raise Exception("VCXO doubler not supported in this mode TBD")
         if self.use_vcxo_double:

--- a/adijif/clocks/ad9528.py
+++ b/adijif/clocks/ad9528.py
@@ -390,6 +390,7 @@ class ad9528(ad9528_bf):
                 arb_source callable.
         """
         # FIXME: ADD SPLIT m1 configuration support
+        self._last_config = None
         if self.use_vcxo_double:
             vcxo *= 2
         self._setup_solver_constraints(vcxo)

--- a/adijif/clocks/ad9545.py
+++ b/adijif/clocks/ad9545.py
@@ -561,6 +561,7 @@ class ad9545(clock):
         Raises:
             Exception: gekko solver is selected (AD9545 is CPLEX-only).
         """
+        self._last_config = None
         if self.solver == "gekko":
             raise Exception("Gekko solver not supported for AD9545")
 

--- a/adijif/clocks/hmc7044.py
+++ b/adijif/clocks/hmc7044.py
@@ -461,6 +461,7 @@ class hmc7044(hmc7044_bf):
                 arb_source callable.
         """
         # FIXME: ADD SPLIT m1 configuration support
+        self._last_config = None
         vcxo = self._parse_reference(vcxo)
         self._setup_solver_constraints(vcxo)
 

--- a/adijif/clocks/ltc6952.py
+++ b/adijif/clocks/ltc6952.py
@@ -553,6 +553,7 @@ class ltc6952(ltc6952_bf):
                 arb_source callable.
         """
         # FIXME: ADD SPLIT m1 configuration support
+        self._last_config = None
         vcxo = self._parse_reference(vcxo)
         self._setup_solver_constraints(vcxo)
 

--- a/adijif/clocks/ltc6953.py
+++ b/adijif/clocks/ltc6953.py
@@ -533,6 +533,7 @@ class ltc6953(clock):
             input_ref (int): Input reference frequency in hertz, range
                 expression, or arb_source callable.
         """
+        self._last_config = None
         if isinstance(input_ref, (float, int)):
             assert self.input_freq_max >= input_ref >= 0, (
                 "Input frequency out of range"

--- a/adijif/plls/adf4030.py
+++ b/adijif/plls/adf4030.py
@@ -401,6 +401,7 @@ class adf4030(pll, adf4030_drawer):
                 hertz or a clock-object placeholder whose value is
                 resolved by the solver.
         """
+        self._last_config = None
         if isinstance(input_ref, (float, int)):
             assert self.input_freq_max >= input_ref >= self.input_freq_min, (
                 "Input frequency out of range"

--- a/adijif/plls/adf4371.py
+++ b/adijif/plls/adf4371.py
@@ -534,6 +534,7 @@ class adf4371(pll, adf4371_drawer):
             input_ref (int): Reference frequency in hertz, range
                 expression, or arb_source callable.
         """
+        self._last_config = None
         if isinstance(input_ref, (float, int)):
             assert self.input_freq_max >= input_ref >= self.input_freq_min, (
                 "Input frequency out of range"

--- a/adijif/plls/adf4382.py
+++ b/adijif/plls/adf4382.py
@@ -739,6 +739,7 @@ class adf4382(pll, adf4382_drawer):
             input_ref (int): Reference frequency in hertz, range
                 expression, or arb_source callable.
         """
+        self._last_config = None
         if isinstance(input_ref, (float, int)):
             assert self.input_freq_max >= input_ref >= self.input_freq_min, (
                 "Input frequency out of range"

--- a/tests/test_setup_cache_invalidation.py
+++ b/tests/test_setup_cache_invalidation.py
@@ -1,0 +1,45 @@
+"""Regression tests for low-level setup cache invalidation."""
+
+import pytest
+
+import adijif
+
+
+@pytest.mark.parametrize(
+    "component,configure,reset",
+    [
+        (
+            adijif.ltc6953,
+            lambda device: device.set_requested_clocks(
+                1_000_000_000, [500_000_000], ["output"]
+            ),
+            lambda device: device.setup_constraints(1_000_000_000),
+        ),
+        (
+            adijif.adf4030,
+            lambda device: device.set_requested_clocks(
+                125_000_000, [100_000_000], ["output"]
+            ),
+            lambda device: device.setup_constraints(125_000_000),
+        ),
+    ],
+)
+def test_setup_constraints_invalidates_solved_config_cache(
+    component, configure, reset
+):
+    """Low-level setup must invalidate any prior solved drawing state."""
+    device = component(solver="CPLEX")
+    configure(device)
+    device.solve()
+    device.get_config()
+    assert device._last_config is not None
+
+    try:
+        reset(device)
+    except Exception as ex:
+        # Reusing a standalone CPLEX model can reject duplicate variable names.
+        assert "already exists in model" in str(ex)
+
+    assert device._last_config is None
+    with pytest.raises(Exception, match="No solution to draw"):
+        device.draw()


### PR DESCRIPTION
## Summary
- invalidate solved clock and PLL caches at the public `setup_constraints()` boundary
- prevent advanced callers and system orchestration from retaining stale drawing state
- cover successful and duplicate-variable setup paths with real CPLEX solves

## Validation
- 773 passed, 11 skipped, 5 xfailed (`pytest --ignore=tests/tools/e2e`)
- focused lifecycle/drawing/system suite: 107 passed, 1 skipped
- Ruff passed
- ty passed
- `git diff --check` passed