### PR TITLE
Invalidate converter cache on JESD mode changes

### DIFF
--- a/adijif/converters/converter.py
+++ b/adijif/converters/converter.py
@@ -332,6 +332,7 @@ class converter(core, jesd, gekko_translation, metaclass=ABCMeta):
         Raises:
             Exception: Invalid mode selected
         """
+        self._last_config = None
         smode = str(mode)
         if jesd_class not in self.available_jesd_modes:
             raise Exception(

--- a/tests/test_converter_cache_invalidation.py
+++ b/tests/test_converter_cache_invalidation.py
@@ -1,0 +1,39 @@
+"""Regression tests for converter quick-mode cache invalidation."""
+
+from typing import Any
+
+import pytest
+
+import adijif
+
+
+@pytest.mark.parametrize(
+    "device_type,mode,jesd_class",
+    [
+        (adijif.ad9680, "1", "jesd204b"),
+        (adijif.ad9144, "4", "jesd204b"),
+        (adijif.ad9084_rx, "47", "jesd204c"),
+        (adijif.ad9084_tx, "3", "jesd204c"),
+    ],
+)
+def test_quick_mode_change_invalidates_converter_drawing_cache(
+    device_type, mode, jesd_class
+):
+    """Changing JESD mode must make a prior solved converter state stale."""
+    device: Any = device_type(solver="CPLEX")
+    device._last_config = object()
+
+    device.set_quick_configuration_mode(mode, jesd_class)
+
+    assert device._last_config is None
+
+
+def test_invalid_quick_mode_attempt_invalidates_converter_drawing_cache():
+    """A failed mode change must not leave an old solution looking current."""
+    device: Any = adijif.ad9680(solver="CPLEX")
+    device._last_config = object()
+
+    with pytest.raises(Exception, match="not among configurations"):
+        device.set_quick_configuration_mode("not-a-mode")
+
+    assert device._last_config is None


### PR DESCRIPTION
## Summary
- invalidate solved converter drawing state before applying quick JESD modes
- clear stale state on both successful and invalid mode changes
- cover ADC, DAC, and AD908x RX/TX converter families

## Validation
- 778 passed, 11 skipped, 5 xfailed (`pytest --ignore=tests/tools/e2e`)
- focused converter/Explorer/drawing suite: 141 passed
- Ruff passed
- ty passed
- `git diff --check` passed