### PR TITLE
Invalidate AD9084 cache before profile loading

### DIFF
--- a/adijif/converters/ad9084.py
+++ b/adijif/converters/ad9084.py
@@ -103,6 +103,7 @@ class ad9084_core(ad9084_draw, converter, metaclass=ABCMeta):
             profile_json (str): Path to the profile JSON file.
             bypass_version_check (bool): Bypass the version check for profile
         """
+        self._last_config = None
         settings = parse_json_cfg(profile_json, bypass_version_check)
         apply_settings(self, settings)
 

--- a/tests/test_ad9084_profile_cache_invalidation.py
+++ b/tests/test_ad9084_profile_cache_invalidation.py
@@ -1,0 +1,37 @@
+"""Regression tests for AD9084 profile cache invalidation."""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import adijif
+
+PROFILE = (
+    Path(__file__).parent
+    / "apollo_profiles"
+    / "ad9084_profiles"
+    / "id00_stock_mode.json"
+)
+
+
+@pytest.mark.parametrize("device_type", [adijif.ad9084_rx, adijif.ad9084_tx])
+def test_profile_application_invalidates_converter_cache(device_type):
+    """Applying a profile must make prior solved converter state stale."""
+    device: Any = device_type(solver="CPLEX")
+    device._last_config = object()
+
+    device.apply_profile_settings(str(PROFILE))
+
+    assert device._last_config is None
+
+
+def test_rejected_profile_application_invalidates_converter_cache():
+    """A rejected profile must not leave an old solution looking current."""
+    device: Any = adijif.ad9084_rx(solver="CPLEX")
+    device._last_config = object()
+
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        device.apply_profile_settings("missing-profile.json")
+
+    assert device._last_config is None


### PR DESCRIPTION
## Summary
- invalidate solved AD9084 converter state at the public profile-loading boundary
- clear stale state before parsing so missing or malformed profiles cannot preserve an old solution
- cover successful RX/TX loads and rejected profile paths

## Validation
- 781 passed, 11 skipped, 5 xfailed (`pytest --ignore=tests/tools/e2e`)
- focused AD9084/profile suite: 131 passed
- Ruff passed
- ty passed
- `git diff --check` passed