### PR TITLE
Preserve system topology across model resets

### DIFF
--- a/adijif/system.py
+++ b/adijif/system.py
@@ -2,7 +2,7 @@
 
 import os
 import shutil  # noqa: F401
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -106,32 +106,44 @@ class system(SystemPLL, system_draw):
         pll._connected_to_output = cnv.name
         pll._ref = clk
 
-    def _model_reset(self) -> None:
+    def _new_solver_model(self) -> Any:
+        """Create an empty model for the configured solver backend."""
         if self.solver == "gekko":
             if not solvers.gekko_solver:
                 raise Exception("GEKKO Solver not installed")
-            model = solvers.GEKKO(remote=False)
+            return solvers.GEKKO(remote=False)
         elif self.solver == "CPLEX":
             if not solvers.cplex_solver:
                 raise Exception("CPLEX Solver not installed")
-            model = solvers.CpoModel()
+            return solvers.CpoModel()
         else:
             raise Exception(f"Unknown solver {self.solver}")
 
-        self.model = model
-        self.clock.model = model
-        self.clock._reset_config()
-        self.fpga.model = model
-        self.fpga._reset_config()
-        if isinstance(self.converter, list):
-            for conv in self.converter:
-                conv.model = model
-                conv._reset_config()
-        else:
-            self.converter._reset_config()
-            self.converter.model = model
+    def _rebind_component(self, component) -> None:
+        """Bind a component hierarchy to the new, unsolved model."""
+        component.model = self.model
+        component._reset_config()
+        component._solution = None
+        component._last_config = None
+        component.configs = []
+        for name in getattr(component, "_nested", []) or []:
+            self._rebind_component(getattr(component, name))
 
-        self._plls = []
+    def _model_reset(self) -> None:
+        """Rebuild solver state while preserving the configured topology."""
+        self.model = self._new_solver_model()
+        components = [self.clock, self.fpga]
+        components.extend(
+            self.converter
+            if isinstance(self.converter, list)
+            else [self.converter]
+        )
+        components.extend(self._plls)
+        components.extend(self._plls_sysref)
+        for component in components:
+            self._rebind_component(component)
+
+        self._solution = None
         self._initialized = False
         self._last_clocks = None
 
@@ -159,18 +171,7 @@ class system(SystemPLL, system_draw):
         """
         if solver:
             self.solver = solver
-        if self.solver == "gekko":
-            if not solvers.gekko_solver:
-                raise Exception("GEKKO Solver not installed")
-            model = solvers.GEKKO(remote=False)
-        elif self.solver == "CPLEX":
-            if not solvers.cplex_solver:
-                raise Exception("CPLEX Solver not installed")
-            model = solvers.CpoModel()
-        else:
-            raise Exception(f"Unknown solver {self.solver}")
-
-        self.model = model
+        self.model = self._new_solver_model()
         self.vcxo = vcxo
         self._plls = []
         self._plls_sysref = []

--- a/tests/test_system_reset_lifecycle.py
+++ b/tests/test_system_reset_lifecycle.py
@@ -1,0 +1,66 @@
+"""Regression tests for complete system model resets."""
+
+from pathlib import Path
+from typing import Any
+
+import adijif
+
+PROFILE = (
+    Path(__file__).parent
+    / "apollo_profiles"
+    / "ad9084_profiles"
+    / "id00_stock_mode.json"
+)
+
+
+def test_model_reset_preserves_topology_and_rebinds_every_component():
+    """A reset must rebuild solver state without changing system topology."""
+    system: Any = adijif.system(
+        "ad9084", "hmc7044", "xilinx", 125_000_000, solver="CPLEX"
+    )
+    system.add_pll_inline("adf4382", system.clock, system.converter)
+    system.add_pll_sysref(
+        "adf4030", system.clock, system.converter, system.fpga
+    )
+    system.converter.apply_profile_settings(str(PROFILE))
+    system.fpga.setup_by_dev_kit_name("vcu118")
+    system.converter.clocking_option = "direct"
+
+    inline_pll = system.plls[0]
+    sysref_pll = system.plls_sysref[0]
+    sysref_connections = list(sysref_pll._connected_to_output)
+    nested = [getattr(system.converter, name) for name in system.converter._nested]
+    components: list[Any] = [
+        system.clock,
+        system.fpga,
+        system.converter,
+        *nested,
+        inline_pll,
+        sysref_pll,
+    ]
+    old_model = system.model
+    system._solution = object()
+    for component in components:
+        component._solution = object()
+        component._last_config = {"stale": True}
+
+    system._model_reset()
+
+    assert system.model is not old_model
+    assert system.plls == [inline_pll]
+    assert system.plls_sysref == [sysref_pll]
+    assert inline_pll._connected_to_output == system.converter.name
+    assert sysref_pll._connected_to_output == sysref_connections
+    assert system._solution is None
+    assert system._initialized is False
+    assert system._last_clocks is None
+    for component in components:
+        assert component.model is system.model
+        assert component._solution is None
+        assert component._last_config is None
+
+    clocks = system.initialize()
+    assert "AD9084_ref_clk_from_ext_pll" in clocks
+    assert "adf4030_ref_clk" in clocks
+    assert "adc_sysref" in clocks
+    assert "dac_sysref" in clocks


### PR DESCRIPTION
## Summary
- consolidate duplicated solver-model creation in `system.py`
- preserve inline and SYSREF PLL topology across `_model_reset()`
- recursively rebind nested converter children and clear stale solver/config caches
- verify a real AD9084 RX/TX topology rebuilds inline PLL and SYSREF constraints after reset

## Validation
- 782 passed, 11 skipped, 5 xfailed (`pytest --ignore=tests/tools/e2e`)
- focused system/reset/AD9084/PLL suite: 107 passed, 1 skipped
- Ruff passed
- ty passed
- `git diff --check` passed