### PR TITLE
Rebuild initialized systems after PLL additions

### DIFF
--- a/adijif/sys/s_plls.py
+++ b/adijif/sys/s_plls.py
@@ -57,13 +57,13 @@ class SystemPLL:
             fpga (fpgac): FPGA to be driven by PLL
             bsync_reference (Union[clockc, int, float]): Optional clock to be used as BSYNC reference for PLL. If not provided, BSYNC will not be synchronized to any reference.
         """
-        pll = get_component_class("pll", pll_name)(
-            self.model, solver=self.solver
-        )
+        assert cnv or fpga, "Converter or FPGA must be connected to PLL"
+        pll_class = get_component_class("pll", pll_name)
+        self._prepare_topology_change()
+        pll = pll_class(self.model, solver=self.solver)
         self._plls_sysref.append(pll)
         pll._connected_to_output = []
         pll._ref = clk
-        assert cnv or fpga, "Converter or FPGA must be connected to PLL"
         if cnv:
             if hasattr(cnv, "_nested") and cnv._nested:
                 # If the converter has nested references (like MxFE)

--- a/adijif/system.py
+++ b/adijif/system.py
@@ -99,12 +99,17 @@ class system(SystemPLL, system_draw):
             clk (clockc): Clock chip reference
             cnv (convc): Converter reference
         """
-        pll = get_component_class("pll", pll_name)(
-            self.model, solver=self.solver
-        )
+        pll_class = get_component_class("pll", pll_name)
+        self._prepare_topology_change()
+        pll = pll_class(self.model, solver=self.solver)
         self._plls.append(pll)
         pll._connected_to_output = cnv.name
         pll._ref = clk
+
+    def _prepare_topology_change(self) -> None:
+        """Discard cached wiring before changing an initialized topology."""
+        if self._initialized:
+            self._model_reset()
 
     def _new_solver_model(self) -> Any:
         """Create an empty model for the configured solver backend."""

--- a/tests/test_system_topology_invalidation.py
+++ b/tests/test_system_topology_invalidation.py
@@ -1,0 +1,64 @@
+"""Regression tests for system topology changes after initialization."""
+
+from typing import Any
+
+import pytest
+
+import adijif
+
+
+@pytest.mark.parametrize(
+    "add_pll,expected_clocks",
+    [
+        (
+            lambda system: system.add_pll_inline(
+                "adf4382", system.clock, system.converter
+            ),
+            {"adf4382_ref_clk", "AD9680_ref_clk_from_ext_pll"},
+        ),
+        (
+            lambda system: system.add_pll_sysref(
+                "adf4030", system.clock, system.converter, system.fpga
+            ),
+            {"adf4030_ref_clk", "AD9680_sysref"},
+        ),
+    ],
+)
+def test_adding_pll_after_initialize_rebuilds_system_topology(
+    add_pll, expected_clocks
+):
+    """A newly added PLL must appear in the next initialized clock bundle."""
+    system: Any = adijif.system(
+        "ad9680", "hmc7044", "xilinx", 125_000_000, solver="CPLEX"
+    )
+    system.fpga.setup_by_dev_kit_name("zc706")
+    old_model = system.model
+    old_clocks = system.initialize()
+
+    add_pll(system)
+
+    assert system.model is not old_model
+    assert system._initialized is False
+    assert system._last_clocks is None
+    new_clocks = system.initialize()
+    assert new_clocks is not old_clocks
+    assert expected_clocks <= set(new_clocks)
+
+
+def test_rejected_pll_change_preserves_initialized_topology():
+    """Validation failures must not discard otherwise valid cached wiring."""
+    system: Any = adijif.system(
+        "ad9680", "hmc7044", "xilinx", 125_000_000, solver="CPLEX"
+    )
+    old_model = system.model
+    system.fpga.setup_by_dev_kit_name("zc706")
+    old_clocks = system.initialize()
+
+    with pytest.raises(ValueError, match="Unknown pll"):
+        system.add_pll_inline("not-a-pll", system.clock, system.converter)
+    with pytest.raises(AssertionError, match="Converter or FPGA"):
+        system.add_pll_sysref("adf4030", system.clock)
+
+    assert system.model is old_model
+    assert system._initialized is True
+    assert system._last_clocks is old_clocks


### PR DESCRIPTION
## Summary
- invalidate and rebuild cached system wiring when an inline or SYSREF PLL is added after initialization
- preserve existing topology through the model-reset lifecycle before attaching the new PLL
- validate PLL names and SYSREF targets before discarding valid cached wiring
- cover inline and SYSREF additions plus rejected topology changes

## Validation
- 785 passed, 11 skipped, 5 xfailed (`pytest --ignore=tests/tools/e2e`)
- focused system/topology/registry/PLL suite: 95 passed, 1 skipped
- Ruff passed
- ty passed
- `git diff --check` passed