### PR TITLE
Apply semantic JIF system diagram theme

### DIFF
--- a/adijif/draw.py
+++ b/adijif/draw.py
@@ -6,8 +6,9 @@ import subprocess  # noqa: S404
 from importlib.util import find_spec
 from typing import Union
 
-connection_style_types = {
-    "data": {"stroke": "blue", "stroke-width": 2},
+connection_class_types = {
+    "data": "jif-signal-data",
+    "sysref": "jif-signal-sysref",
 }
 
 
@@ -353,6 +354,7 @@ class Layout:
             Exception: d2 support not installed.
         """
         diag = "direction: right\n\n"
+        connection_indexes: dict[tuple[str, str], int] = {}
 
         def apply_connection_style(diag: str, connection: dict) -> str:
             """Apply style to the connection in the diagram.
@@ -367,34 +369,42 @@ class Layout:
             """
             from_p_name = get_parents_names(connection["from"])
             to_p_name = get_parents_names(connection["to"])
+            from_name = f"{from_p_name}{connection['from'].name}"
+            to_name = f"{to_p_name}{connection['to'].name}"
+            connection_key = (from_name, to_name)
+            index = connection.get(
+                "index", connection_indexes.get(connection_key, 0)
+            )
+            connection_indexes[connection_key] = index + 1
 
-            if (
-                "type" in connection
-                and connection["type"] in connection_style_types
-            ):
-                style = connection_style_types[connection["type"]]
-                index = 0  # Default index but make sure its not in the diag
-                for key in style:
-                    while True:
-                        con_str = f"({from_p_name}{connection['from'].name} -> "
-                        con_str += (
-                            f"{to_p_name}{connection['to'].name})[{index}]"
-                        )
-                        con_str += f".style.{key}: {style[key]}\n"
-                        if con_str not in diag:
-                            diag += con_str
-                            break
-                        index += 1  # Increment index to avoid duplicates
-                        # Duplicates can happen if multiple connections
-                        # between the same nodes
+            signal_class = connection.get("class")
+            if signal_class is None:
+                connection_type = connection.get("type")
+                if isinstance(connection_type, str):
+                    signal_class = connection_class_types.get(connection_type)
+            if signal_class is None:
+                names = f"{from_name} {to_name}".upper()
+                from_type = (connection["from"].ntype or "").lower()
+                to_type = (connection["to"].ntype or "").lower()
+                if "SYSREF" in names:
+                    signal_class = "jif-signal-sysref"
+                elif "framer" in from_type and "framer" in to_type:
+                    signal_class = "jif-signal-data"
+                elif "framer" in to_type and from_type in {"input", "divider"}:
+                    signal_class = "jif-signal-sysref"
+                elif connection["from"].ntype == "input" and any(
+                    name in connection["from"].name.upper()
+                    for name in ("REF", "VCXO", "OSC")
+                ):
+                    signal_class = "jif-signal-reference"
+                else:
+                    signal_class = "jif-signal-clock"
 
-            index = 0
-            if "index" in connection:
-                index = connection["index"]
+            diag += f"({from_name} -> {to_name})[{index}].class: {signal_class}\n"
+
             if "style" in connection:
                 for key in connection["style"]:
-                    diag += f"({from_p_name}{connection['from'].name} -> "
-                    diag += f"{to_p_name}{connection['to'].name})[{index}]"
+                    diag += f"({from_name} -> {to_name})[{index}]"
                     diag += f".style.{key}: {connection['style'][key]}\n"
             return diag
 
@@ -563,7 +573,7 @@ class Layout:
                     "d2 support not installed. Please install package pyd2lang-native"
                 )
 
-            out = compile(diag, library="jif")
+            out = compile(diag, library="jif", theme="dark")
             # with open(self.output_image_filename, "w") as f:
             #     f.write(out)
 

--- a/adijif/fpgas/xilinx/xilinx_draw.py
+++ b/adijif/fpgas/xilinx/xilinx_draw.py
@@ -479,6 +479,7 @@ class xilinx_draw:
             {
                 "from": sysref,
                 "to": self.ic_diagram_node.get_child("JESD204-Link-IP"),
+                "type": "sysref",
             }
         )
 

--- a/adijif/system_draw.py
+++ b/adijif/system_draw.py
@@ -35,6 +35,7 @@ class system_draw:
         assert not isinstance(self.clock, list), "Only one clocking supported"
 
         self.clock.draw(lo)
+        self.clock.ic_diagram_node.ntype = "jif-container-clock"
 
         # External PLLs (SYSREF and/or Direct)
         if self.plls is not None:
@@ -45,6 +46,7 @@ class system_draw:
 
             for pll in plls:
                 pll.draw(lo)
+                pll.ic_diagram_node.ntype = "jif-container-clock"
 
         if hasattr(self, "plls_sysref") and self.plls_sysref is not None:
             if not isinstance(self.plls_sysref, list):
@@ -54,6 +56,7 @@ class system_draw:
 
             for pll in plls_sysref:
                 pll.draw(lo)
+                pll.ic_diagram_node.ntype = "jif-container-clock"
 
         # Converter
         assert self.converter is not None
@@ -81,6 +84,7 @@ class system_draw:
             cnv_clocking[clk] = rate
 
         self.converter.draw(cnv_clocking, lo, self.clock.ic_diagram_node)
+        self.converter.ic_diagram_node.ntype = "jif-container-converter"
 
         # FPGA
         assert self.fpga is not None
@@ -93,6 +97,7 @@ class system_draw:
         if not isinstance(self.converter, list):
             cnvers = [self.converter]
         self.fpga.draw(fpga_clocking, lo, cnvers)
+        self.fpga.ic_diagram_node.ntype = "jif-container-fpga"
 
         # Draw the diagram
         return lo.draw()

--- a/doc/source/draw.md
+++ b/doc/source/draw.md
@@ -6,6 +6,11 @@
 
 To generate the diagrams, you will need to leverage the d2 interface support provided by **pyadi-jif**. This is done by installing [pyd2lang-native](https://pypi.org/project/pyd2lang-native/). pyd2lang-native is a binary distribution and may not exist on all feasible platform, similar to CPLEX.
 
+System diagrams use the dark JIF hardware theme provided by pyd2lang-native
+0.1.6 or newer. Reference inputs, clocks, SYSREF, and JESD data paths use
+distinct semantic colors and line styles so their roles remain visible in
+large clocking diagrams.
+
 ## Generating diagrams
 
 Generating diagrams is done by calling the `draw` method on the system or component object. This will generate a diagram of the clock tree. Drawing is only valid once the component or system has been solved. Here is an example of generating a diagram for the AD9680 and dummy sources:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 [project.optional-dependencies]
 cplex = ["cplex", "docplex"]
 gekko = ["gekko"]
-draw = ["pyd2lang-native>=0.1.2"]
+draw = ["pyd2lang-native>=0.1.6"]
 tools = ["streamlit"]
 e2e = [
     "playwright>=1.40.0",

--- a/tests/test_drawing_coverage.py
+++ b/tests/test_drawing_coverage.py
@@ -44,7 +44,7 @@ def test_layout_draw_emits_ntype_classes_and_uses_jif_library():
 
     compile_mock.assert_called_once()
     diag = compile_mock.call_args.args[0]
-    assert compile_mock.call_args.kwargs == {"library": "jif"}
+    assert compile_mock.call_args.kwargs == {"library": "jif", "theme": "dark"}
     assert "Parent.class: shell\n" in diag
     assert "    ADC.class: adc\n" in diag
     assert "    ADC.shape: parallelogram\n" in diag
@@ -52,6 +52,56 @@ def test_layout_draw_emits_ntype_classes_and_uses_jif_library():
     assert "    Divider.shape: rectangle\n" not in diag
     assert (
         "    Valued: {tooltip: Valued = 1 }\n    Valued.class: input\n" in diag
+    )
+
+
+def test_layout_draw_emits_semantic_signal_classes():
+    """Connections use the released JIF system-theme signal vocabulary."""
+    lo = Layout("Signals")
+    reference = Node("REF_IN", ntype="input")
+    clock = Node("Clock")
+    sysref = Node("SYSREF_IN", ntype="input")
+    converter = Node("Converter")
+    fpga = Node("FPGA")
+    for node in (reference, clock, sysref, converter, fpga):
+        lo.add_node(node)
+
+    lo.add_connection({"from": reference, "to": clock, "rate": 125e6})
+    lo.add_connection({"from": clock, "to": converter, "rate": 20e9})
+    lo.add_connection({"from": sysref, "to": fpga, "rate": 25e6})
+    lo.add_connection(
+        {"from": converter, "to": fpga, "rate": 20.625e9, "type": "data"}
+    )
+
+    with mock.patch("d2.compile", return_value="<svg/>") as compile_mock:
+        lo.draw()
+
+    diag = compile_mock.call_args.args[0]
+    assert "(REF_IN -> Clock)[0].class: jif-signal-reference\n" in diag
+    assert "(Clock -> Converter)[0].class: jif-signal-clock\n" in diag
+    assert "(SYSREF_IN -> FPGA)[0].class: jif-signal-sysref\n" in diag
+    assert "(Converter -> FPGA)[0].class: jif-signal-data\n" in diag
+
+
+def test_layout_recognizes_rewired_sysref_and_jesd_lane_connections():
+    """System rewiring keeps SYSREF and JESD links visually distinct."""
+    lo = Layout("Rewired signals")
+    divider = Node("D1", ntype="divider")
+    converter_framer = Node("JESD204 Framer", ntype="jesd204framer")
+    fpga_deframer = Node("JESD204 Deframer", ntype="deframer")
+    for node in (divider, converter_framer, fpga_deframer):
+        lo.add_node(node)
+    lo.add_connection({"from": divider, "to": converter_framer})
+    lo.add_connection({"from": converter_framer, "to": fpga_deframer})
+
+    with mock.patch("d2.compile", return_value="<svg/>") as compile_mock:
+        lo.draw()
+
+    diag = compile_mock.call_args.args[0]
+    assert "(D1 -> JESD204 Framer)[0].class: jif-signal-sysref\n" in diag
+    assert (
+        "(JESD204 Framer -> JESD204 Deframer)[0].class: jif-signal-data\n"
+        in diag
     )
 
 


### PR DESCRIPTION
## Summary

- require the released `pyd2lang-native>=0.1.6` drawing backend
- render native JIF diagrams with the static dark hardware theme
- style clock/PLL, converter, and FPGA system regions by semantic role
- classify reference, clock, SYSREF, and JESD/data connections with the new JIF signal classes
- preserve explicit per-connection style overrides and assign deterministic indexes to repeated edges
- document the new system-diagram appearance

## Visual validation

Generated a real solved AD9680 + HMC7044 + ZC706 system with the PyPI `pyd2lang-native==0.1.6` wheel. The SVG contained the expected navy canvas, violet reference, amber clocks, dashed magenta SYSREF, green converter region, and cyan FPGA/JESD paths.

## Validation

- focused drawing/system suite: `76 passed, 1 skipped`
- full non-browser suite: `787 passed, 11 skipped, 5 xfailed`
- Ruff: passed
- repository `ty` invocation: passed
- `git diff --check`: passed
- released-wheel render: passed