### PR TITLE
Add light and dark JIF diagram variants

### DIFF
--- a/adijif/clocks/ad9545.py
+++ b/adijif/clocks/ad9545.py
@@ -216,7 +216,7 @@ class ad9545(clock):
         config = self._last_config
         system_draw = lo is not None
         if not system_draw:
-            lo = Layout("AD9545 Example")
+            lo = Layout("AD9545 Example", theme=self.diagram_theme)
         else:
             assert isinstance(lo, Layout), "lo must be a Layout object"
 

--- a/adijif/clocks/clock.py
+++ b/adijif/clocks/clock.py
@@ -195,7 +195,7 @@ class clock(core, gekko_translation, metaclass=ABCMeta):
         name = self.name.lower()
 
         if not system_draw:
-            lo = Layout(f"{name} Example")
+            lo = Layout(f"{name} Example", theme=self.diagram_theme)
         else:
             assert isinstance(lo, Layout), "lo must be a Layout object"
 

--- a/adijif/clocks/hmc7044.py
+++ b/adijif/clocks/hmc7044.py
@@ -170,7 +170,7 @@ class hmc7044(hmc7044_bf):
         self.ic_diagram_node = None
         self._diagram_output_dividers = []
 
-        # lo = Layout("HMC7044 Example")
+        # lo = Layout("HMC7044 Example", theme=self.diagram_theme)
 
         self.ic_diagram_node = Node("HMC7044")
         # lo.add_node(root)
@@ -267,7 +267,7 @@ class hmc7044(hmc7044_bf):
 
         system_draw = lo is not None
         if not system_draw:
-            lo = Layout("HMC7044 Example")
+            lo = Layout("HMC7044 Example", theme=self.diagram_theme)
         else:
             # Verify lo is a Layout object
             assert isinstance(lo, Layout), "lo must be a Layout object"

--- a/adijif/clocks/ltc6953.py
+++ b/adijif/clocks/ltc6953.py
@@ -440,7 +440,7 @@ class ltc6953(clock):
 
         system_draw = lo is not None
         if not system_draw:
-            lo = Layout("LTC6953 Example")
+            lo = Layout("LTC6953 Example", theme=self.diagram_theme)
         else:
             assert isinstance(lo, Layout), "lo must be a Layout object"
 

--- a/adijif/common.py
+++ b/adijif/common.py
@@ -16,6 +16,17 @@ class core:
 
     solver = "CPLEX"
 
+    @property
+    def diagram_theme(self) -> str:
+        """Palette used by standalone component diagrams."""
+        return self._diagram_theme
+
+    @diagram_theme.setter
+    def diagram_theme(self, value: str) -> None:
+        if value not in ("light", "dark"):
+            raise ValueError("diagram_theme must be 'light' or 'dark'")
+        self._diagram_theme = value
+
     def _add_objective(
         self,
         expr: Any,
@@ -107,6 +118,7 @@ class core:
             Exception: If solver is not valid
         """
         self._last_config = None
+        self._diagram_theme = "dark"
         self.config: Dict = {}
         self._reset_config()
         self._objectives: List[Objective] = []

--- a/adijif/converters/ad9081_draw.py
+++ b/adijif/converters/ad9081_draw.py
@@ -79,7 +79,7 @@ class ad9081_rx_draw:
         N = 4
 
         if not system_draw:
-            lo = Layout(f"{name} Example")
+            lo = Layout(f"{name} Example", theme=self.diagram_theme)
             lo.show_rates = self.show_rates
         else:
             assert isinstance(lo, Layout), "lo must be a Layout object"
@@ -271,7 +271,7 @@ class ad9081_tx_draw:
         N = 4
 
         if not system_draw:
-            lo = Layout(f"{name} Example")
+            lo = Layout(f"{name} Example", theme=self.diagram_theme)
             lo.show_rates = self.show_rates
         else:
             assert isinstance(lo, Layout), "lo must be a Layout object"

--- a/adijif/converters/ad9084_draw.py
+++ b/adijif/converters/ad9084_draw.py
@@ -114,7 +114,7 @@ class ad9084_draw:
 
         if not system_draw:
             name = "AD9084" if "9084" in self.name else "AD9088"
-            lo = Layout(f"{name} Example")
+            lo = Layout(f"{name} Example", theme=self.diagram_theme)
             lo.show_rates = self.show_rates
         else:
             name = self.name

--- a/adijif/converters/ad9144_draw.py
+++ b/adijif/converters/ad9144_draw.py
@@ -56,7 +56,7 @@ class ad9144_draw:
         num_dacs = 2 if "9152" in name else 4
 
         if not system_draw:
-            lo = Layout(f"{name} Example")
+            lo = Layout(f"{name} Example", theme=self.diagram_theme)
             lo.show_rates = self.show_rates
         else:
             assert isinstance(lo, Layout), "lo must be a Layout object"

--- a/adijif/converters/ad9680_draw.py
+++ b/adijif/converters/ad9680_draw.py
@@ -94,7 +94,7 @@ class ad9680_draw:
         system_draw = lo is not None
 
         if not system_draw:
-            lo = Layout("AD9680 Example")
+            lo = Layout("AD9680 Example", theme=self.diagram_theme)
             lo.show_rates = self.show_rates
         else:
             # Verify lo is a Layout object

--- a/adijif/converters/adrv9009_draw.py
+++ b/adijif/converters/adrv9009_draw.py
@@ -52,7 +52,7 @@ class adrv9009_rx_draw:
         name = self.name
 
         if not system_draw:
-            lo = Layout(f"{name} Example")
+            lo = Layout(f"{name} Example", theme=self.diagram_theme)
             lo.show_rates = self.show_rates
         else:
             assert isinstance(lo, Layout), "lo must be a Layout object"
@@ -191,7 +191,7 @@ class adrv9009_tx_draw:
         name = self.name
 
         if not system_draw:
-            lo = Layout(f"{name} Example")
+            lo = Layout(f"{name} Example", theme=self.diagram_theme)
             lo.show_rates = self.show_rates
         else:
             assert isinstance(lo, Layout), "lo must be a Layout object"

--- a/adijif/converters/converter.py
+++ b/adijif/converters/converter.py
@@ -59,7 +59,7 @@ class converter(core, jesd, gekko_translation, metaclass=ABCMeta):
         name = self.name.lower()
 
         if not system_draw:
-            lo = Layout(f"{name} Example")
+            lo = Layout(f"{name} Example", theme=self.diagram_theme)
             lo.show_rates = self.show_rates
         else:
             assert isinstance(lo, Layout), "lo must be a Layout object"
@@ -184,7 +184,7 @@ class converter(core, jesd, gekko_translation, metaclass=ABCMeta):
         name = self.name.lower()
 
         if not system_draw:
-            lo = Layout(f"{name} Example")
+            lo = Layout(f"{name} Example", theme=self.diagram_theme)
             lo.show_rates = self.show_rates
         else:
             assert isinstance(lo, Layout), "lo must be a Layout object"

--- a/adijif/draw.py
+++ b/adijif/draw.py
@@ -211,13 +211,20 @@ class Layout:
     use_d2_cli = False
     _write_out_d2_file = False
 
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, theme: str = "dark") -> None:
         """Initialize layout with name.
 
         Args:
             name (str): Name of the layout.
+            theme (str): JIF palette, either ``"light"`` or ``"dark"``.
+
+        Raises:
+            ValueError: Theme is not ``"light"`` or ``"dark"``.
         """
+        if theme not in ("light", "dark"):
+            raise ValueError("theme must be 'light' or 'dark'")
         self.name = name
+        self.theme = theme
         self.nodes = []
         self.connections = []
         self.use_unit_conversion_for_rate = True
@@ -573,7 +580,7 @@ class Layout:
                     "d2 support not installed. Please install package pyd2lang-native"
                 )
 
-            out = compile(diag, library="jif", theme="dark")
+            out = compile(diag, library="jif", theme=self.theme)
             # with open(self.output_image_filename, "w") as f:
             #     f.write(out)
 

--- a/adijif/fpgas/xilinx/xilinx_draw.py
+++ b/adijif/fpgas/xilinx/xilinx_draw.py
@@ -297,7 +297,7 @@ class xilinx_draw:
         system_draw = lo is not None
 
         if not system_draw:
-            lo = Layout(f"{self.name} Example")
+            lo = Layout(f"{self.name} Example", theme=self.diagram_theme)
             converters = []
         else:
             # Verify lo is a Layout object

--- a/adijif/plls/adf4030.py
+++ b/adijif/plls/adf4030.py
@@ -103,7 +103,7 @@ class adf4030_drawer(object):
 
         system_draw = lo is not None
         if not system_draw:
-            lo = Layout("ADF4030 Diagram")
+            lo = Layout("ADF4030 Diagram", theme=self.diagram_theme)
         else:
             assert isinstance(lo, Layout), (
                 "Layout object must be provided for system drawing"

--- a/adijif/plls/adf4371.py
+++ b/adijif/plls/adf4371.py
@@ -79,7 +79,7 @@ class adf4371_drawer(object):
 
         system_draw = lo is not None
         if not system_draw:
-            lo = Layout("ADF4371 Diagram")
+            lo = Layout("ADF4371 Diagram", theme=self.diagram_theme)
         else:
             assert isinstance(lo, Layout), (
                 "Layout object must be provided for system drawing"

--- a/adijif/plls/adf4382.py
+++ b/adijif/plls/adf4382.py
@@ -128,7 +128,7 @@ class adf4382_drawer(object):
 
         system_draw = lo is not None
         if not system_draw:
-            lo = Layout("ADF4382 Diagram")
+            lo = Layout("ADF4382 Diagram", theme=self.diagram_theme)
         else:
             assert isinstance(lo, Layout), (
                 "Layout object must be provided for system drawing"

--- a/adijif/plls/utils/adf4030_arch.py
+++ b/adijif/plls/utils/adf4030_arch.py
@@ -385,12 +385,15 @@ class Adf4030Architecture:
                 fpga.add_connection(c)
         return ub
 
-    def draw(self, scope: str = "ub", path: str | None = None) -> str:
+    def draw(
+        self, scope: str = "ub", path: str | None = None, theme: str = "dark"
+    ) -> str:
         """Render the architecture as an SVG diagram.
 
         Args:
             scope (str): ``"ub"`` for one Unit Board, ``"system"`` for the full multi-Unit-Board diagram.
             path (str): If set, also write the rendered SVG to this file.
+            theme (str): JIF palette, either ``"light"`` or ``"dark"``.
 
         Returns:
             str: SVG content as a string.
@@ -402,7 +405,7 @@ class Adf4030Architecture:
             raise ValueError(
                 f"scope must be 'ub' or 'system', got {scope!r}"
             )
-        lo = Layout(f"ADF4030 {self.architecture} ({scope})")
+        lo = Layout(f"ADF4030 {self.architecture} ({scope})", theme=theme)
         if scope == "ub":
             lo.add_node(self._build_unit_board_node("UnitBoard"))
         else:

--- a/adijif/system_draw.py
+++ b/adijif/system_draw.py
@@ -1,6 +1,8 @@
 """Diagram drawing for System level."""
 
-from typing import Dict
+import copy
+from contextlib import contextmanager
+from typing import Iterator
 
 from adijif.draw import Layout, Node  # type: ignore # isort: skip  # noqa: I202
 
@@ -14,16 +16,52 @@ class system_draw:
 
         self.ic_diagram_node = Node("System")
 
-    def draw(self, config: Dict) -> str:
+    def _drawing_components(self) -> list:
+        """Return components whose diagram state participates in a system render."""
+        components = [self.clock, self.converter, self.fpga]
+        for value in (self.plls, getattr(self, "plls_sysref", None)):
+            if isinstance(value, list):
+                components.extend(value)
+            elif value is not None:
+                components.append(value)
+        for name in getattr(self.converter, "_nested", []) or []:
+            components.append(getattr(self.converter, name))
+        return components
+
+    @contextmanager
+    def _preserve_component_diagrams(self) -> Iterator[None]:
+        """Keep rendering from changing reusable solved component state."""
+        snapshots = []
+        for component in self._drawing_components():
+            state = {
+                name: copy.deepcopy(value)
+                for name, value in vars(component).items()
+                if name == "ic_diagram_node" or name.startswith("_diagram_")
+            }
+            snapshots.append((component, state))
+        try:
+            yield
+        finally:
+            for component, state in snapshots:
+                for name, value in state.items():
+                    setattr(component, name, value)
+
+    def draw(self, config: dict, theme: str = "dark") -> str:
         """Draw clocking model for system.
 
         Args:
-            config(Dict): System solution configuration
+            config (dict): Configuration to draw
+            theme (str): JIF palette, either ``"light"`` or ``"dark"``.
 
         Returns:
             str: Drawn diagram
         """
-        lo = Layout("System Diagram")
+        with self._preserve_component_diagrams():
+            return self._draw(config, theme)
+
+    def _draw(self, config: dict, theme: str) -> str:
+        """Build one system diagram while public ``draw`` owns state cleanup."""
+        lo = Layout("System Diagram", theme=theme)
         if hasattr(self, "use_d2_cli"):
             lo.use_d2_cli = self.use_d2_cli
         self._init_diagram()

--- a/adijif/tools/explorer/src/pages/adf4030_system_designer.py
+++ b/adijif/tools/explorer/src/pages/adf4030_system_designer.py
@@ -6,7 +6,7 @@ import streamlit as st
 
 from adijif.plls.utils.adf4030_arch import ARCHITECTURES, Adf4030Architecture
 
-from ..utils import Page
+from ..utils import Page, get_diagram_theme
 
 
 class Adf4030SystemDesigner(Page):
@@ -87,5 +87,5 @@ class Adf4030SystemDesigner(Page):
         self.section("Partition summary")
         st.text(arch.summary)
         self.section("Diagram")
-        svg = arch.draw(scope=scope)
+        svg = arch.draw(scope=scope, theme=get_diagram_theme())
         st.components.v1.html(svg, height=600, scrolling=True)

--- a/adijif/tools/explorer/src/pages/clockconfigurator.py
+++ b/adijif/tools/explorer/src/pages/clockconfigurator.py
@@ -8,7 +8,7 @@ import streamlit as st
 from adijif.clocks import supported_parts as sp
 from adijif.registry import get_component_class
 
-from ..utils import Page
+from ..utils import Page, get_diagram_theme
 
 try:
     import adidt as dt
@@ -201,6 +201,7 @@ class ClockConfigurator(Page):
             #         st.write(o)
 
             config_out = o
+            clk_chip.diagram_theme = get_diagram_theme()
             image_data = clk_chip.draw()
 
             warning = False

--- a/adijif/tools/explorer/src/pages/helpers/drawers.py
+++ b/adijif/tools/explorer/src/pages/helpers/drawers.py
@@ -1,7 +1,7 @@
 """Helper functions for drawing ADC diagrams."""
 
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 import adijif as jif
 
@@ -9,11 +9,12 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-def draw_adc(adc: Optional[object] = None) -> str:
+def draw_adc(adc: Optional[Any] = None, theme: str = "dark") -> str:
     """Draw ADC clock tree diagram.
 
     Args:
         adc: ADC converter object. If None, uses ad9680 as default.
+        theme: JIF palette, either ``"light"`` or ``"dark"``.
 
     Returns:
         Path to generated SVG file.
@@ -45,14 +46,16 @@ def draw_adc(adc: Optional[object] = None) -> str:
     settings["clocks"] = clock_values
 
     adc.show_rates = False
+    adc.diagram_theme = theme
     return adc.draw(settings["clocks"])
 
 
-def draw_dac(dac: Optional[object] = None) -> str:
+def draw_dac(dac: Optional[Any] = None, theme: str = "dark") -> str:
     """Draw DAC clock tree diagram.
 
     Args:
         dac: DAC converter object. If None, uses ad9144 as default.
+        theme: JIF palette, either ``"light"`` or ``"dark"``.
 
     Returns:
         Path to generated SVG file.
@@ -84,4 +87,5 @@ def draw_dac(dac: Optional[object] = None) -> str:
     settings["clocks"] = clock_values
 
     dac.show_rates = False
+    dac.diagram_theme = theme
     return dac.draw(settings["clocks"])

--- a/adijif/tools/explorer/src/pages/jesdmodeselector.py
+++ b/adijif/tools/explorer/src/pages/jesdmodeselector.py
@@ -8,7 +8,7 @@ import streamlit as st
 from adijif.converters import supported_parts as sp
 from adijif.registry import get_component_class
 
-from ..utils import Page
+from ..utils import Page, get_diagram_theme
 from .helpers.datapath import gen_datapath
 from .helpers.drawers import draw_adc, draw_dac
 from .helpers.jesd import get_jesd_controls, get_valid_jesd_modes
@@ -69,19 +69,25 @@ class JESDModeSelector(Page):
 
         # Show diagram
         self.section("Diagram")
-        if sb not in self.part_images:
+        diagram_theme = get_diagram_theme()
+        diagram_key = (sb, diagram_theme)
+        if diagram_key not in self.part_images:
             try:
                 if converter.converter_type.lower() == "adc":
-                    self.part_images[sb] = draw_adc(converter)
+                    self.part_images[diagram_key] = draw_adc(
+                        converter, theme=diagram_theme
+                    )
                     # FIXME: State is not being saved
                 else:
-                    self.part_images[sb] = draw_dac(converter)
+                    self.part_images[diagram_key] = draw_dac(
+                        converter, theme=diagram_theme
+                    )
             except Exception:
                 # Diagram generation requires a solver (e.g. CPLEX) that
                 # may not be installed in all environments.
-                self.part_images[sb] = None
-        if self.part_images[sb]:
-            st.image(self.part_images[sb], width="stretch")
+                self.part_images[diagram_key] = None
+        if self.part_images[diagram_key]:
+            st.image(self.part_images[diagram_key], width="stretch")
 
         # Datapath Configuration
         self.section("Datapath configuration")

--- a/adijif/tools/explorer/src/pages/systemconfigurator.py
+++ b/adijif/tools/explorer/src/pages/systemconfigurator.py
@@ -10,7 +10,7 @@ from adijif.clocks import supported_parts as csp
 from adijif.converters import supported_parts as xsp
 
 # from adijif.utils import get_jesd_mode_from_params
-from ..utils import Page
+from ..utils import Page, get_diagram_theme
 from .helpers.datapath import gen_datapath
 from .helpers.optimization import gen_clock_constraints, gen_clock_objectives
 
@@ -353,7 +353,7 @@ class SystemConfigurator(Page):
                 st.subheader("Converter JESD Configuration")
                 st.write(cfg["jesd_" + sys.converter.name.upper()])
 
-                diagram = sys.draw(cfg)
+                diagram = sys.draw(cfg, theme=get_diagram_theme())
 
         self.section("Diagram")
         if diagram:

--- a/adijif/tools/explorer/src/utils.py
+++ b/adijif/tools/explorer/src/utils.py
@@ -92,6 +92,13 @@ def _logo_data_uri(name: str) -> str:
     return f"data:image/png;base64,{encoded}"
 
 
+def get_diagram_theme(theme_type: str | None = None) -> str:
+    """Return the active Streamlit palette for generated diagrams."""
+    if theme_type is None:
+        theme_type = getattr(st.context.theme, "type", None)
+    return theme_type if theme_type in ("light", "dark") else "light"
+
+
 def render_sidebar_logo() -> None:
     """Render the PyADI-JIF logo with theme-aware variants.
 

--- a/doc/source/draw.md
+++ b/doc/source/draw.md
@@ -6,10 +6,12 @@
 
 To generate the diagrams, you will need to leverage the d2 interface support provided by **pyadi-jif**. This is done by installing [pyd2lang-native](https://pypi.org/project/pyd2lang-native/). pyd2lang-native is a binary distribution and may not exist on all feasible platform, similar to CPLEX.
 
-System diagrams use the dark JIF hardware theme provided by pyd2lang-native
-0.1.6 or newer. Reference inputs, clocks, SYSREF, and JESD data paths use
-distinct semantic colors and line styles so their roles remain visible in
-large clocking diagrams.
+System and component diagrams support coordinated light and dark JIF hardware
+themes provided by pyd2lang-native 0.1.7 or newer. Both variants use the same
+semantic colors: violet references, amber clocks, dashed magenta SYSREF, cyan
+JESD data, green converters, and cyan-blue FPGAs. The dark theme remains the
+Python API default for backward compatibility. Explorer tools automatically
+follow the active Streamlit light or dark theme.
 
 ## Generating diagrams
 
@@ -44,6 +46,7 @@ for clk in clks:
     clock_values.update(clk.get_config(solution))
 settings["clocks"] = clock_values
 
+adc.diagram_theme = "light"  # "dark" is the default
 image_data = adc.draw(settings["clocks"])
 
 with open("ad9680_example.svg", "w") as f:
@@ -93,10 +96,13 @@ sys.fpga.force_qpll = 1
 
 cfg = sys.solve()
 
-data = sys.draw(cfg)
+dark_data = sys.draw(cfg, theme="dark")
+light_data = sys.draw(cfg, theme="light")
 
 with open("daq2_example.svg", "w") as f:
-    f.write(data)
+    f.write(dark_data)
+with open("daq2_example_light.svg", "w") as f:
+    f.write(light_data)
 
 #HIDE:START
 import os
@@ -106,14 +112,30 @@ if os.path.exists("daq2_example.svg"):
     shutil.move("daq2_example.svg", "source/daq2_example.svg")
 else:
     print("File not found")
+if os.path.exists("daq2_example_light.svg"):
+    shutil.move("daq2_example_light.svg", "source/daq2_example_light.svg")
+else:
+    print("Light-theme file not found")
 #HIDE:STOP
 ```
 
-This will generate a file called `daq2_example.svg` in the current working directory. This file can be opened in any SVG viewer. The diagram will look similar to the one below:
+This generates coordinated dark and light diagrams. Both preserve the same
+signal semantics and topology.
+
+#### Dark variant
 
 ```{figure} daq2_example.svg
 ---
 name: daq2_example
+width: 80%
+---
+```
+
+#### Light variant
+
+```{figure} daq2_example_light.svg
+---
+name: daq2_example_light
 width: 80%
 ---
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 [project.optional-dependencies]
 cplex = ["cplex", "docplex"]
 gekko = ["gekko"]
-draw = ["pyd2lang-native>=0.1.6"]
+draw = ["pyd2lang-native>=0.1.7"]
 tools = ["streamlit"]
 e2e = [
     "playwright>=1.40.0",

--- a/tests/test_adf4030_arch.py
+++ b/tests/test_adf4030_arch.py
@@ -191,10 +191,11 @@ def test_draw_ub_builds_layout_with_expected_structure(monkeypatch):
         return "<svg/>"
     monkeypatch.setattr(Layout, "draw", fake_draw)
 
-    svg = arch.draw(scope="ub")
+    svg = arch.draw(scope="ub", theme="light")
     assert svg == "<svg/>"
 
     lo = captured["layout"]
+    assert lo.theme == "light"
     # Top-level container plus its descendants.
     assert len(lo.nodes) == 1
     ub = lo.nodes[0]

--- a/tests/test_drawing_coverage.py
+++ b/tests/test_drawing_coverage.py
@@ -55,6 +55,19 @@ def test_layout_draw_emits_ntype_classes_and_uses_jif_library():
     )
 
 
+def test_layout_selects_light_theme_and_rejects_unknown_theme():
+    """Drawing theme is explicit, validated, and forwarded to pyd2."""
+    lo = Layout("Light", theme="light")
+    lo.add_node(Node("ADC", ntype="adc"))
+
+    with mock.patch("d2.compile", return_value="<svg/>") as compile_mock:
+        assert lo.draw() == "<svg/>"
+
+    assert compile_mock.call_args.kwargs == {"library": "jif", "theme": "light"}
+    with pytest.raises(ValueError, match="theme must be 'light' or 'dark'"):
+        Layout("Invalid", theme="sepia")
+
+
 def test_layout_draw_emits_semantic_signal_classes():
     """Connections use the released JIF system-theme signal vocabulary."""
     lo = Layout("Signals")
@@ -205,5 +218,19 @@ def test_system_draw_smoke():
         mock.patch.object(sys.converter, "draw"),
         mock.patch.object(sys.fpga, "draw"),
     ):
-        res = sys.draw(config)
+        res = sys.draw(config, theme="light")
         assert res is not None
+
+
+def test_system_draw_is_repeatable_across_light_and_dark_themes():
+    """Rendering one palette must not leave component state that breaks the next."""
+    sys = adijif.system("ad9680", "hmc7044", "xilinx", 125e6)
+    sys.fpga.setup_by_dev_kit_name("zc706")
+    sys.converter.sample_clock = 1e9
+    config = sys.solve()
+
+    light = sys.draw(config, theme="light")
+    dark = sys.draw(config, theme="dark")
+
+    assert "#E9F8F1" in light
+    assert "#102B29" in dark

--- a/tests/tools/test_diagram_themes.py
+++ b/tests/tools/test_diagram_themes.py
@@ -1,0 +1,28 @@
+"""Theme selection coverage for Explorer diagram tools."""
+
+import pytest
+
+import adijif
+from adijif.tools.explorer.src.utils import get_diagram_theme
+
+
+@pytest.mark.parametrize("theme", ["light", "dark"])
+def test_explorer_diagram_theme_preserves_known_variants(theme: str) -> None:
+    assert get_diagram_theme(theme) == theme
+
+
+def test_explorer_diagram_theme_defaults_to_light_for_unknown_variant() -> None:
+    assert get_diagram_theme("custom") == "light"
+
+
+def test_component_diagram_theme_is_validated() -> None:
+    converter = adijif.ad9680()
+    assert converter.diagram_theme == "dark"
+
+    converter.diagram_theme = "light"
+    assert converter.diagram_theme == "light"
+
+    with pytest.raises(
+        ValueError, match="diagram_theme must be 'light' or 'dark'"
+    ):
+        converter.diagram_theme = "sepia"


### PR DESCRIPTION
## Summary

- add a validated light/dark theme selector to system layouts and standalone component diagrams
- make all converter, clock, PLL, and FPGA drawing entry points propagate the selected JIF palette
- make Explorer follow the active Streamlit theme for system, converter, clock, and ADF4030 diagrams, with theme-aware image caching
- preserve mutable component drawing state so the same solved system can render light and dark variants consecutively
- require pyd2lang-native 0.1.7 and document both rendered variants

## Validation

- full non-browser suite: 793 passed, 11 skipped, 5 xfailed
- focused theme/drawing suite: 36 passed
- Explorer system/JESD/ADF4030 suites: 55 passed
- Ruff: passed
- ty using repository ignore policy: passed
- strict Sphinx docs build: passed
- real CPLEX-backed AD9680 + HMC7044 + ZC706 light and dark renders using the released pyd2lang-native 0.1.7 wheel: passed