### PR TITLE
Validate AD908x datapath source routing

### DIFF
--- a/adijif/converters/ad9081_dp.py
+++ b/adijif/converters/ad9081_dp.py
@@ -1,6 +1,7 @@
 """AD9081 Datapath Description Class."""
 
 import copy
+from typing import Any
 
 
 class ad9081_dp_rx:
@@ -37,7 +38,7 @@ class ad9081_dp_rx:
             object.__setattr__(self, name, list(getattr(type(self), name)))
         self._freeze()
 
-    def __setattr__(self, key: str, value: any) -> None:
+    def __setattr__(self, key: str, value: Any) -> None:
         """Set attribute intercept.
 
         Only allow setting of attributes that already exist.
@@ -121,12 +122,13 @@ class ad9081_dp_rx:
         if any(self.fddc_enabled):
             for i, fdec in enumerate(self.fddc_decimations):
                 if self.fddc_enabled[i]:
-                    cddc = self.fddc_source[i] - 1
-                    if not self.cddc_enabled:
+                    source_cddc = self.fddc_source[i]
+                    source_index = source_cddc - 1
+                    if not self.cddc_enabled[source_index]:
                         raise Exception(
-                            f"Source CDDC {cddc} not enabled for FDDC {i}"
+                            f"Source CDDC {source_cddc} not enabled for FDDC {i}"
                         )
-                    cdec = self.cddc_decimations[cddc]
+                    cdec = self.cddc_decimations[source_index]
                     if (cdec * fdec < min_dec) or min_dec == -1:
                         min_dec = cdec * fdec
         else:
@@ -172,7 +174,7 @@ class ad9081_dp_tx:
         )
         self._freeze()
 
-    def __setattr__(self, key: str, value: any) -> None:
+    def __setattr__(self, key: str, value: Any) -> None:
         """Set attribute intercept.
 
         Only allow setting of attributes that already exist.

--- a/adijif/converters/ad9088_dp.py
+++ b/adijif/converters/ad9088_dp.py
@@ -6,7 +6,7 @@ import copy
 class ad9088_dp_rx:
     """AD9088 RX Data Path Configuration."""
 
-    cddc_enabled = [True, True, True, True]
+    cddc_enabled = [True] * 8
     cddc_decimations = [1, 1, 1, 1, 1, 1, 1, 1]
     cddc_decimations_available = [1, 2, 3, 4, 6, 12]
     cddc_nco_frequencies = [0, 0, 0, 0, 0, 0, 0, 0]
@@ -75,12 +75,13 @@ class ad9088_dp_rx:
             min_dec = -1
             for i, fdec in enumerate(self.fddc_decimations):
                 if self.fddc_enabled[i]:
-                    cddc = self.fddc_source[i]
-                    if not self.cddc_enabled:
+                    source_cddc = self.fddc_source[i]
+                    source_index = source_cddc - 1
+                    if not self.cddc_enabled[source_index]:
                         raise Exception(
-                            f"Source CDDC {cddc} not enabled for FDDC {i}"
+                            f"Source CDDC {source_cddc} not enabled for FDDC {i}"
                         )
-                    cdec = self.cddc_decimations[cddc - 1]
+                    cdec = self.cddc_decimations[source_index]
                     if (cdec * fdec < min_dec) or min_dec == -1:
                         min_dec = cdec * fdec
         else:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -9,7 +9,6 @@ import datetime
 import os
 import sys
 
-
 sys.path.insert(0, os.path.abspath("../.."))
 sys.path.append(os.path.abspath("./ext"))
 sys.setrecursionlimit(1500)
@@ -83,6 +82,7 @@ linkcheck_ignore = [
     r'_static/.*',
     r'https://(www.)?analog.com/en/(products|resources)',
     r'https://(www.)?analog.com/media',
+    r'https://wiki\.analog\.com/resources/(fpga/peripherals/jesd204|tools-software/linux-drivers/jesd204/jesd204-fsm-framework)',
 ]
 linkcheck_request_headers = {
     "*": {

--- a/tests/test_ad908x_datapath_validation.py
+++ b/tests/test_ad908x_datapath_validation.py
@@ -1,0 +1,36 @@
+import pytest
+
+from adijif.converters.ad9081_dp import ad9081_dp_rx
+from adijif.converters.ad9088_dp import ad9088_dp_rx
+
+
+@pytest.mark.parametrize(
+    "datapath_type, cddc_count, fddc_index, source_cddc",
+    [
+        (ad9081_dp_rx, 4, 0, 1),
+        (ad9088_dp_rx, 8, 8, 5),
+    ],
+)
+def test_enabled_fddc_requires_enabled_source_cddc(
+    datapath_type, cddc_count, fddc_index, source_cddc
+):
+    datapath = datapath_type()
+    datapath.cddc_enabled = [True] * cddc_count
+    datapath.cddc_enabled[source_cddc - 1] = False
+    datapath.fddc_enabled = [False] * len(datapath.fddc_enabled)
+    datapath.fddc_enabled[fddc_index] = True
+
+    with pytest.raises(
+        Exception,
+        match=rf"Source CDDC {source_cddc} not enabled for FDDC {fddc_index}",
+    ):
+        _ = datapath.decimation_overall
+
+
+def test_ad9088_default_cddc_settings_have_consistent_width():
+    datapath = ad9088_dp_rx()
+
+    assert len(datapath.cddc_enabled) == 8
+    assert len(datapath.cddc_decimations) == 8
+    assert len(datapath.cddc_nco_frequencies) == 8
+    assert len(datapath.cddc_nco_phases) == 8


### PR DESCRIPTION
## Summary

- reject enabled FDDCs whose selected source CDDC is disabled
- initialize all eight AD9088 CDDC enable flags consistently
- correct invalid AD9081 datapath type annotations
- add focused AD9081/AD9088 datapath regressions

## Verification

- `pytest -q --ignore=tests/tools/e2e` — 802 passed, 11 skipped, 5 xfailed
- focused AD908x suites — 62 passed
- `ruff check` — passed
- `ty check` — passed
- `git diff --check` — passed