### PR TITLE
Validate LTC6953 GEKKO divider selections

### DIFF
--- a/adijif/clocks/ltc6953.py
+++ b/adijif/clocks/ltc6953.py
@@ -546,7 +546,7 @@ class ltc6953(clock):
         self.config["out_dividers"] = []
 
     def request_clock_constraint(
-        self, clk_name: List[str]
+        self, clk_name: str
     ) -> Union[int, float, CpoExpr, GK_Intermediate]:
         """Get abstract clock output.
 
@@ -562,9 +562,9 @@ class ltc6953(clock):
         """
         if self.solver == "gekko":
             __m = self._m if isinstance(self._m, list) else [self._m]
-            if __m.sort() != self.m_available.sort():
+            if sorted(__m) != sorted(self.m_available):
                 raise Exception(
-                    "For solver gekko d is not configurable for LTC6952"
+                    "For solver gekko m is not configurable for LTC6953"
                 )
             mp = self.model.Var(integer=True, lb=1, ub=32)
             nx = self.model.Var(integer=True, lb=0, ub=7)

--- a/tests/test_ltc_coverage.py
+++ b/tests/test_ltc_coverage.py
@@ -27,6 +27,16 @@ def test_ltc6953_set_requested_clocks_size_mismatch_should_raise():
         clk.set_requested_clocks(1e9, [500e6], ["CLK1", "CLK2"])
 
 
+def test_ltc6953_rejects_restricted_m_in_gekko_system_mode():
+    """Verify the GEKKO system path requires the full divider domain."""
+    clk = adijif.ltc6953(solver="gekko")
+    clk.m = [1, 2]
+    clk.setup_constraints(1_000_000_000)
+
+    with pytest.raises(Exception, match="m is not configurable for LTC6953"):
+        clk.request_clock_constraint("out")
+
+
 def test_ltc6953_solve_range_input():
     """Verify solving with range input reference."""
     clk = adijif.ltc6953(solver="CPLEX")


### PR DESCRIPTION
## Summary

- reject restricted LTC6953 `m` selections in the GEKKO system request path
- avoid mutating divider capability lists during validation
- correct the stale LTC6952/`d` error text
- align the clock-name annotation with the documented string API

## Verification

- focused clock and lifecycle suites: 70 passed
- full non-browser suite: 803 passed, 11 skipped, 5 xfailed
- `nox -s ty lint`: passed
- `git diff --check`: passed