### PR TITLE
Add Python 3.12 and 3.13 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,11 +6,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     name: Python ${{ matrix.python-version }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,7 +14,7 @@ nox.options.default_venv_backend = "uv"
 
 locations = "adijif", "tests", "noxfile.py"
 main_python = "3.10"
-multi_python_versions_support = ["3.10", "3.11"]
+multi_python_versions_support = ["3.10", "3.11", "3.12", "3.13"]
 package = "adijif"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 dependencies = [


### PR DESCRIPTION
## Summary

- declare Python 3.11, 3.12, and 3.13 package classifiers
- extend the Nox multi-version matrix through Python 3.13
- add Python 3.12 and 3.13 to hosted test jobs
- update the test workflow to current checkout and setup-python actions

## Verification

- Python 3.12 full suite: 805 passed, 11 skipped, 5 xfailed
- Python 3.13 full suite: 805 passed, 11 skipped, 5 xfailed
- Python 3.12 notebooks: 5 passed
- Python 3.13 notebooks: 5 passed
- clean installed-wheel smoke tests passed on Python 3.12.13 and 3.13.12
- built wheel metadata contains Python 3.10–3.13 classifiers
- repository `nox -s ty lint`: passed
- workflow YAML parse and `git diff --check`: passed