### PR TITLE
feat(dt): export versioned solved-system contracts

### DIFF
--- a/adijif/__init__.py
+++ b/adijif/__init__.py
@@ -33,6 +33,13 @@ from adijif.converters.ad9680 import ad9680
 from adijif.converters.adrv9009 import adrv9009, adrv9009_rx, adrv9009_tx
 from adijif.fpgas.xilinx import xilinx
 from adijif.fpgas.xilinx.bf import xilinx_bf
+from adijif.jif_dt import (
+    ClockRequirement,
+    JesdLink,
+    JesdParameters,
+    JifDtContract,
+    Producer,
+)
 from adijif.plls.adf4030 import adf4030
 from adijif.plls.adf4371 import adf4371
 from adijif.plls.adf4382 import adf4382

--- a/adijif/jif_dt.py
+++ b/adijif/jif_dt.py
@@ -1,0 +1,277 @@
+"""Versioned pyadi-jif producer model for the pyadi-dt handoff."""
+
+from __future__ import annotations
+
+import json
+import re
+from copy import deepcopy
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+CONTRACT_NAME = "adi.jif-dt"
+CONTRACT_VERSION = "1.0"
+
+
+def _semantic_id(value: str) -> str:
+    """Normalize a component or clock name into a stable contract ID segment."""
+    return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+
+
+def _integer_hz(value: Any, field_name: str) -> int:
+    """Convert an integral solver rate to integer hertz without truncation."""
+    converted = int(value)
+    if converted <= 0 or float(value) != converted:
+        raise ValueError(f"{field_name} must be a positive integral Hz value")
+    return converted
+
+
+@dataclass(frozen=True)
+class Producer:
+    """Identity of the package that generated a contract."""
+
+    version: str
+    name: Literal["pyadi-jif"] = "pyadi-jif"
+
+    def __post_init__(self) -> None:
+        """Validate producer identity and version provenance."""
+        if self.name != "pyadi-jif" or not self.version:
+            raise ValueError("producer must identify a pyadi-jif version")
+
+
+@dataclass(frozen=True)
+class JesdParameters:
+    """JESD transport parameters shared by converter and FPGA endpoints."""
+
+    F: int
+    K: int
+    L: int
+    M: int
+    N: int
+    Np: int
+    S: int
+    HD: int
+    CS: int = 0
+    CF: int = 0
+
+    def __post_init__(self) -> None:
+        """Validate positive integer framing values and transport identity."""
+        values = (self.F, self.K, self.L, self.M, self.N, self.Np, self.S)
+        if any(type(value) is not int or value <= 0 for value in values):
+            raise ValueError("JESD parameters must be positive integers")
+        if self.HD not in (0, 1):
+            raise ValueError("HD must be 0 or 1")
+        if self.M * self.S * self.Np != 8 * self.L * self.F:
+            raise ValueError("M*S*Np must equal 8*L*F")
+
+
+@dataclass(frozen=True)
+class JesdLink:
+    """One solved unidirectional JESD link."""
+
+    id: str
+    direction: Literal["adc-to-fpga", "fpga-to-dac"]
+    converter: str
+    fpga: str
+    standard: Literal["jesd204b", "jesd204c"]
+    sample_rate_hz: int
+    lane_rate_hz: int
+    parameters: JesdParameters
+    fpga_config: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Validate the solved lane rate against framing and encoding."""
+        if not re.fullmatch(r"[a-z0-9][a-z0-9_.-]*", self.id):
+            raise ValueError(f"invalid JESD link ID: {self.id}")
+        if type(self.sample_rate_hz) is not int or self.sample_rate_hz <= 0:
+            raise ValueError("sample_rate_hz must be a positive integer")
+        if type(self.lane_rate_hz) is not int or self.lane_rate_hz <= 0:
+            raise ValueError("lane_rate_hz must be a positive integer")
+        ratio = (10, 8) if self.standard == "jesd204b" else (66, 64)
+        p = self.parameters
+        expected_num = self.sample_rate_hz * p.M * p.Np * ratio[0]
+        expected_den = p.L * ratio[1]
+        if abs(self.lane_rate_hz * expected_den - expected_num) > expected_den:
+            raise ValueError(
+                "lane_rate_hz is inconsistent with JESD parameters"
+            )
+
+
+@dataclass(frozen=True)
+class ClockRequirement:
+    """A solved semantic clock requirement, independent of output placement."""
+
+    id: str
+    role: Literal[
+        "converter-device",
+        "converter-sysref",
+        "fpga-ref",
+        "fpga-link",
+        "pll-ref",
+        "other",
+    ]
+    sink: str
+    rate_hz: int
+    source: str
+    divider: int | None = None
+
+    def __post_init__(self) -> None:
+        """Validate semantic identity and solved integer values."""
+        if not re.fullmatch(r"[a-z0-9][a-z0-9_.-]*", self.id):
+            raise ValueError(f"invalid clock requirement ID: {self.id}")
+        if type(self.rate_hz) is not int or self.rate_hz <= 0:
+            raise ValueError("rate_hz must be a positive integer")
+        if self.divider is not None and (
+            type(self.divider) is not int or self.divider <= 0
+        ):
+            raise ValueError("divider must be a positive integer")
+
+
+@dataclass(frozen=True)
+class JifDtContract:
+    """Portable solved electrical intent for a pyadi-dt consumer."""
+
+    producer: Producer
+    jesd_links: tuple[JesdLink, ...]
+    clock_requirements: tuple[ClockRequirement, ...]
+    metadata: dict[str, Any] = field(default_factory=dict)
+    schema: Literal["adi.jif-dt"] = CONTRACT_NAME
+    version: Literal["1.0"] = CONTRACT_VERSION
+
+    def __post_init__(self) -> None:
+        """Reject duplicate IDs and values that cannot cross a JSON boundary."""
+        if self.schema != CONTRACT_NAME or self.version != CONTRACT_VERSION:
+            raise ValueError(
+                f"unsupported contract identity: {self.schema} {self.version}"
+            )
+        for kind, entries in (
+            ("JESD link", self.jesd_links),
+            ("clock requirement", self.clock_requirements),
+        ):
+            ids = [entry.id for entry in entries]
+            duplicates = sorted({item for item in ids if ids.count(item) > 1})
+            if duplicates:
+                raise ValueError(f"duplicate {kind} IDs: {duplicates}")
+        # Reject backend objects hidden in extension dictionaries.
+        json.dumps(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a detached JSON-compatible snapshot."""
+        return asdict(self)
+
+    def to_json(self, *, indent: int = 2) -> str:
+        """Serialize the contract deterministically."""
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=True) + "\n"
+
+    def to_json_file(self, path: str | Path) -> None:
+        """Write deterministic interchange JSON to *path*."""
+        Path(path).write_text(self.to_json())
+
+    @classmethod
+    def from_system_solution(
+        cls, system: Any, solution: dict[str, Any]
+    ) -> "JifDtContract":
+        """Project a solved single-converter system into the 1.0 contract.
+
+        Physical clock output channels and device-tree labels are intentionally
+        absent. A pyadi-dt board profile binds these semantic requirements later.
+        """
+        converter = system.converter
+        if isinstance(converter, list) or getattr(converter, "_nested", None):
+            raise ValueError(
+                "from_system_solution currently supports one non-nested converter"
+            )
+
+        name = converter.name
+        jesd = solution[f"jesd_{name}"]
+        fpga_config = solution[f"fpga_{name}"]
+        converter_type = converter.converter_type.lower()
+        if converter_type == "adc":
+            direction = "adc-to-fpga"
+            direction_id = "rx"
+        elif converter_type == "dac":
+            direction = "fpga-to-dac"
+            direction_id = "tx"
+        else:
+            raise ValueError(f"unsupported converter type: {converter_type}")
+
+        parameters = JesdParameters(
+            F=int(jesd["F"]),
+            K=int(jesd["K"]),
+            L=int(jesd["L"]),
+            M=int(jesd["M"]),
+            N=int(converter.N),
+            Np=int(jesd["Np"]),
+            S=int(jesd["S"]),
+            HD=int(jesd["HD"]),
+            CS=int(jesd.get("CS", 0)),
+            CF=int(jesd.get("CF", 0)),
+        )
+        link = JesdLink(
+            id=f"{_semantic_id(name)}.{direction_id}",
+            direction=direction,
+            converter=name,
+            fpga=system.fpga.name,
+            standard=jesd["jesd_class"].lower(),
+            sample_rate_hz=_integer_hz(jesd["sample_clock"], "sample_rate_hz"),
+            lane_rate_hz=_integer_hz(jesd["bit_clock"], "lane_rate_hz"),
+            parameters=parameters,
+            fpga_config=deepcopy(fpga_config),
+        )
+
+        clocks = tuple(
+            _clock_requirement(
+                clock_name, clock, name, system.fpga.name, system.clock.name
+            )
+            for clock_name, clock in solution["clock"]["output_clocks"].items()
+        )
+        import adijif
+
+        return cls(
+            producer=Producer(version=adijif.__version__),
+            jesd_links=(link,),
+            clock_requirements=clocks,
+            metadata={"solver": system.solver},
+        )
+
+
+def _clock_requirement(
+    clock_name: str,
+    config: dict[str, Any],
+    converter_name: str,
+    fpga_name: str,
+    source_name: str,
+) -> ClockRequirement:
+    """Translate one semantic requested clock from a solved clock configuration."""
+    lower = clock_name.lower()
+    converter_id = _semantic_id(converter_name)
+    if lower.endswith("_sysref"):
+        role = "converter-sysref"
+        sink = converter_name
+        requirement_id = f"{converter_id}.sysref"
+    elif lower.startswith(fpga_name.lower()) and lower.endswith("_ref_clk"):
+        role = "fpga-ref"
+        sink = fpga_name
+        requirement_id = f"{converter_id}.fpga-ref"
+    elif lower.startswith(fpga_name.lower()) and lower.endswith("_device_clk"):
+        role = "fpga-link"
+        sink = fpga_name
+        requirement_id = f"{converter_id}.fpga-link"
+    elif lower.endswith("_ref_clk"):
+        role = "converter-device"
+        sink = converter_name
+        requirement_id = f"{converter_id}.device-clock"
+    else:
+        role = "other"
+        sink = clock_name
+        requirement_id = _semantic_id(clock_name)
+
+    divider = config.get("divider")
+    return ClockRequirement(
+        id=requirement_id,
+        role=role,
+        sink=sink,
+        rate_hz=_integer_hz(config["rate"], f"{clock_name}.rate_hz"),
+        source=source_name,
+        divider=int(divider) if divider is not None else None,
+    )

--- a/adijif/system.py
+++ b/adijif/system.py
@@ -2,7 +2,19 @@
 
 import os
 import shutil  # noqa: F401
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
+
+if TYPE_CHECKING:
+    from adijif.jif_dt import JifDtContract
 
 import numpy as np
 
@@ -411,6 +423,26 @@ class system(SystemPLL, system_draw):
         if constrain is not None:
             constrain(clocks)
         return self.do_solve()
+
+    def export_config(
+        self, *, format: str, solution: Optional[Dict] = None
+    ) -> "JifDtContract":
+        """Export a solved system through a versioned interchange contract.
+
+        Args:
+            format: Interchange format. Only ``"adi.jif-dt"`` is supported.
+            solution: Existing :meth:`solve` result. When omitted, solve the
+                current system before exporting it.
+
+        Returns:
+            Detached :class:`adijif.jif_dt.JifDtContract` snapshot.
+        """
+        if format != "adi.jif-dt":
+            raise ValueError(f"unsupported export format: {format}")
+        from adijif.jif_dt import JifDtContract
+
+        solved = self.solve() if solution is None else solution
+        return JifDtContract.from_system_solution(self, solved)
 
     def _apply_out_clock_constraints(
         self, clocks: ClocksBundle, out_clock_constraints: dict

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -118,6 +118,7 @@ tools_quickstart.md
 tools.md
 mcp_server.md
 flow.md
+jif_dt.md
 optimization.md
 finding_extreme_rates.md
 converters.md

--- a/doc/source/jif_dt.md
+++ b/doc/source/jif_dt.md
@@ -77,7 +77,7 @@ The output begins with:
 pyadi-dt loads the JSON with its strict `JifDtContract` projection, then uses a
 separate `JifDtBindings` object to map semantic requirements to physical clock
 channels and XSA/device-tree labels. See the
-[pyadi-dt interface contract documentation](https://developer.analog.com/docs/pyadi-dt/latest/developer/jif_dt_contract/)
+[pyadi-dt interface contract documentation](https://github.com/analogdevicesinc/pyadi-dt/blob/main/doc/source/developer/jif_dt_contract.md)
 for binding examples, validation order, and compatibility rules.
 
 The producer and consumer both enforce contract version 1.0. Unsupported

--- a/doc/source/jif_dt.md
+++ b/doc/source/jif_dt.md
@@ -1,0 +1,92 @@
+# Export solved configurations to pyadi-dt
+
+pyadi-jif can export a solved system as the versioned `adi.jif-dt` contract.
+The contract contains solved electrical intent—JESD links, semantic clock
+requirements, rates, dividers, and FPGA settings—but deliberately excludes
+physical clock output channels and device-tree labels.
+
+pyadi-dt owns that physical placement and joins each semantic ID to a board
+profile before generating or modifying a device tree. This prevents requested
+clock order inside the solver from being mistaken for HMC7044 or AD952x output
+channel numbering.
+
+## Solve and export an AD9680 system
+
+The complete runnable example is checked by the normal example test suite:
+
+```{literalinclude} ../../examples/ad9680_jif_dt_contract.py
+:language: python
+:caption: examples/ad9680_jif_dt_contract.py
+```
+
+Run it directly or redirect the portable result to a file:
+
+```bash
+python examples/ad9680_jif_dt_contract.py > ad9680.jif-dt.json
+```
+
+The important API boundary is:
+
+```python
+solution = system.solve()
+contract = system.export_config(format="adi.jif-dt", solution=solution)
+contract.to_json_file("ad9680.jif-dt.json")
+```
+
+Passing the existing `solution` avoids solving twice. If it is omitted,
+`export_config()` solves the current system first.
+
+## What the producer emits
+
+For the AD9680 example, the contract contains one `ad9680.rx` link and four
+semantic clock requirements:
+
+- `ad9680.device-clock`
+- `ad9680.sysref`
+- `ad9680.fpga-ref`
+- `ad9680.fpga-link`
+
+Each clock has a solved rate and divider, but no `output_index` or `dt_label`.
+Those values depend on the carrier and FPGA design, not the solver.
+
+The output begins with:
+
+```json
+{
+  "clock_requirements": [
+    {
+      "divider": 3,
+      "id": "ad9680.device-clock",
+      "rate_hz": 1000000000,
+      "role": "converter-device",
+      "sink": "AD9680",
+      "source": "HMC7044"
+    }
+  ],
+  "producer": {
+    "name": "pyadi-jif",
+    "version": "0.1.6"
+  },
+  "schema": "adi.jif-dt",
+  "version": "1.0"
+}
+```
+
+## Consumer-side binding
+
+pyadi-dt loads the JSON with its strict `JifDtContract` projection, then uses a
+separate `JifDtBindings` object to map semantic requirements to physical clock
+channels and XSA/device-tree labels. See the
+[pyadi-dt interface contract documentation](https://developer.analog.com/docs/pyadi-dt/latest/developer/jif_dt_contract/)
+for binding examples, validation order, and compatibility rules.
+
+The producer and consumer both enforce contract version 1.0. Unsupported
+versions, inconsistent JESD transport/lane rates, duplicate IDs, fractional
+hertz, and non-JSON solver objects fail before a device tree can be changed.
+
+## Current topology support
+
+`system.export_config()` initially supports one non-nested ADC or DAC converter.
+Nested transceivers and MxFE systems require an explicit follow-up extension so
+their multiple links retain stable identities rather than relying on computed
+dictionary key parsing.

--- a/examples/ad9680_jif_dt_contract.py
+++ b/examples/ad9680_jif_dt_contract.py
@@ -1,0 +1,18 @@
+"""Solve AD9680 clocks and export the versioned pyadi-jif -> pyadi-dt contract."""
+
+import adijif
+
+system = adijif.system("ad9680", "hmc7044", "xilinx", 125_000_000)
+system.converter.sample_clock = 1_000_000_000
+system.converter.decimation = 1
+system.converter.set_quick_configuration_mode(str(0x88))
+system.converter.K = 32
+system.fpga.setup_by_dev_kit_name("zc706")
+system.fpga.force_qpll = 1
+
+solution = system.solve()
+contract = system.export_config(format="adi.jif-dt", solution=solution)
+
+# The JSON contains semantic requirements only. A pyadi-dt board profile maps
+# them onto physical output channels and device-tree labels.
+print(contract.to_json(), end="")

--- a/tests/test_jif_dt.py
+++ b/tests/test_jif_dt.py
@@ -1,0 +1,105 @@
+"""Tests for the versioned pyadi-jif -> pyadi-dt producer contract."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+
+from adijif.jif_dt import JifDtContract
+from adijif.system import system as System
+
+
+def _fake_system_and_solution():
+    converter = SimpleNamespace(
+        name="AD9680", converter_type="ADC", N=14, _nested=None
+    )
+    system = SimpleNamespace(
+        converter=converter,
+        fpga=SimpleNamespace(name="zc706"),
+        clock=SimpleNamespace(name="HMC7044"),
+        solver="CPLEX",
+    )
+    solution = {
+        "jesd_AD9680": {
+            "bit_clock": 10_000_000_000.0,
+            "sample_clock": 1_000_000_000,
+            "F": 1,
+            "HD": 1,
+            "K": 32,
+            "L": 4,
+            "M": 2,
+            "Np": 16,
+            "S": 1,
+            "CS": 0,
+            "jesd_class": "jesd204b",
+        },
+        "fpga_AD9680": {"type": "qpll", "sys_clk_select": "XCVR_QPLL0"},
+        "clock": {
+            "output_clocks": {
+                "AD9680_ref_clk": {"rate": 1_000_000_000.0, "divider": 3},
+                "AD9680_sysref": {"rate": 31_250_000.0, "divider": 96},
+                "zc706_AD9680_ref_clk": {"rate": 250_000_000.0, "divider": 12},
+                "zc706_AD9680_device_clk": {
+                    "rate": 250_000_000.0,
+                    "divider": 12,
+                },
+            }
+        },
+    }
+    return system, solution
+
+
+def test_system_solution_exports_semantic_contract_without_physical_channels():
+    system, solution = _fake_system_and_solution()
+    contract = JifDtContract.from_system_solution(system, solution)
+    payload = contract.to_dict()
+
+    assert payload["schema"] == "adi.jif-dt"
+    assert payload["version"] == "1.0"
+    assert payload["jesd_links"][0]["id"] == "ad9680.rx"
+    assert payload["jesd_links"][0]["lane_rate_hz"] == 10_000_000_000
+    assert {clock["id"] for clock in payload["clock_requirements"]} == {
+        "ad9680.device-clock",
+        "ad9680.sysref",
+        "ad9680.fpga-ref",
+        "ad9680.fpga-link",
+    }
+    assert all(
+        "output_index" not in clock for clock in payload["clock_requirements"]
+    )
+    assert all(
+        "dt_label" not in clock for clock in payload["clock_requirements"]
+    )
+
+
+def test_export_is_a_detached_deterministic_json_snapshot():
+    system, solution = _fake_system_and_solution()
+    contract = JifDtContract.from_system_solution(system, solution)
+    before = contract.to_json()
+
+    solution["fpga_AD9680"]["type"] = "cpll"
+    solution["clock"]["output_clocks"]["AD9680_ref_clk"]["divider"] = 999
+
+    assert contract.to_json() == before
+    assert json.loads(before)["jesd_links"][0]["fpga_config"]["type"] == "qpll"
+
+
+def test_export_rejects_fractional_hertz_and_unsupported_topology():
+    system, solution = _fake_system_and_solution()
+    fractional = deepcopy(solution)
+    fractional["jesd_AD9680"]["bit_clock"] = 10_000_000_000.5
+    with pytest.raises(ValueError, match="integral Hz"):
+        JifDtContract.from_system_solution(system, fractional)
+
+    system.converter = [system.converter]
+    with pytest.raises(ValueError, match="one non-nested converter"):
+        JifDtContract.from_system_solution(system, solution)
+
+
+def test_system_rejects_unknown_export_format_before_solving():
+    fake = object.__new__(System)
+    with pytest.raises(ValueError, match="unsupported export format"):
+        fake.export_config(format="raw-dict")


### PR DESCRIPTION
## Summary

- add the canonical pyadi-jif producer model for the versioned `adi.jif-dt` 1.0 interchange contract
- add `system.export_config(format="adi.jif-dt", solution=...)`
- project a real solved AD9680 + HMC7044 + ZC706 system into semantic JESD and clock requirements
- keep physical clock output channels and device-tree labels out of solver output
- add a runnable producer example and task-oriented documentation
- validate identity, framing, lane rate, integer-Hz values, duplicate IDs, JSON safety, and unsupported topology/format failures

## Cross-repository agreement

This is the producer counterpart to analogdevicesinc/pyadi-dt#84, with the byte-for-byte producer fixture alignment in analogdevicesinc/pyadi-dt#85. The generated AD9680 JSON was consumed successfully by pyadi-dt's strict `JifDtContract` model, and pyadi-dt's checked-in example fixture is byte-for-byte the output of this PR's `examples/ad9680_jif_dt_contract.py`.

The initial exporter intentionally supports one non-nested ADC or DAC. Nested transceivers and MxFE links are left for a follow-up so their semantic identities can be designed explicitly rather than inferred from computed solve-dictionary keys.

## Verification

- full pyadi-jif suite: 810 passed, 11 skipped, 5 xfailed
- focused contract + all executable examples: 28 passed
- Ruff: passed
- CI-style ty check: passed
- strict Sphinx build: passed
- rendered producer example inspected for expected API/code markers
- real CPLEX AD9680 solve produced valid JSON
- pyadi-dt consumed that exact JSON successfully
