### PR TITLE
Add JSON CLI for local agents

### DIFF
--- a/adijif/agent_api.py
+++ b/adijif/agent_api.py
@@ -1,0 +1,384 @@
+"""Transport-neutral operations for MCP and local agent clients."""
+
+import inspect
+import json
+from typing import Any, Callable, Dict
+
+import adijif.types
+from adijif.registry import COMPONENT_REGISTRY, get_component_class
+from adijif.system import system as _system
+from adijif.utils import get_jesd_mode_from_params
+
+AgentResult = Dict[str, Any]
+AgentOperation = Callable[..., AgentResult]
+_COMPONENT_KINDS = ("converter", "clock", "fpga", "pll")
+
+
+def _parse_vcxo(vcxo_config: Dict[str, Any]) -> Any:
+    """Parse a JSON VCXO description into a pyadi-jif source."""
+    vcxo_type = vcxo_config.get("type")
+    value = vcxo_config.get("value")
+
+    if vcxo_type == "range":
+        start = vcxo_config.get("start")
+        stop = vcxo_config.get("stop")
+        step = vcxo_config.get("step")
+        if start is None or stop is None or step is None:
+            raise ValueError(
+                "vcxo of type 'range' requires 'start', 'stop', and 'step'."
+            )
+        return adijif.types.range(start, stop, step, "vcxo")
+    if vcxo_type == "arb_source":
+        frequency = vcxo_config.get("frequency")
+        count = vcxo_config.get("count")
+        if frequency is None or count is None:
+            raise ValueError(
+                "vcxo of type 'arb_source' requires 'frequency' and 'count'."
+            )
+        return adijif.types.arb_source(str(frequency), count)
+    return value
+
+
+def _apply_config_recursively(obj: Any, config: Dict[str, Any]) -> None:
+    """Apply nested configuration dictionaries to a component."""
+    for key, value in config.items():
+        if not isinstance(key, str) or key.startswith("_"):
+            raise ValueError(f"Invalid configuration attribute: {key!r}")
+        if not hasattr(obj, key):
+            raise ValueError(
+                f"Unknown configuration attribute '{key}' for "
+                f"{type(obj).__name__}"
+            )
+        current = getattr(obj, key)
+        if isinstance(value, dict):
+            if current is None or isinstance(
+                current, (str, bytes, int, float, bool, list, tuple, dict)
+            ):
+                raise ValueError(
+                    f"Configuration attribute '{key}' does not accept nested values"
+                )
+            _apply_config_recursively(getattr(obj, key), value)
+        else:
+            setattr(obj, key, value)
+
+
+def _registry_for(component_type: str) -> Dict[str, type]:
+    """Return one validated component registry."""
+    if not isinstance(component_type, str):
+        raise ValueError("component_type must be a string")
+    normalized = component_type.lower()
+    if normalized not in COMPONENT_REGISTRY:
+        raise ValueError(
+            f"Invalid component_type '{component_type}'. Must be one of "
+            f"{', '.join(_COMPONENT_KINDS)}."
+        )
+    return COMPONENT_REGISTRY[normalized]  # type: ignore[return-value]
+
+
+def list_components(component_type: str) -> AgentResult:
+    """List supported component names for one component kind."""
+    try:
+        registry = _registry_for(component_type)
+    except ValueError as exc:
+        return {"error": str(exc)}
+    return {"components": sorted(name.upper() for name in registry)}
+
+
+def query_jesd_modes(
+    component_name: str, jesd_params_json: str = "{}"
+) -> AgentResult:
+    """Find converter JESD modes matching JSON parameters."""
+    if not isinstance(component_name, str):
+        return {"error": "component_name must be a string"}
+    if not isinstance(jesd_params_json, str):
+        return {"error": "jesd_params_json must be a string"}
+    try:
+        jesd_params = json.loads(jesd_params_json)
+    except json.JSONDecodeError as exc:
+        return {
+            "error": f"Invalid JSON string for jesd_params_json: {exc}",
+            "jesd_params_json": jesd_params_json,
+        }
+
+    try:
+        converter_class = get_component_class("converter", component_name)
+    except (TypeError, ValueError):
+        available = list_components("converter")["components"]
+        return {
+            "error": f"Component '{component_name}' not found in registry. "
+            f"Available components: {available}"
+        }
+
+    try:
+        converter_instance = converter_class(model=None, solver="CPLEX")
+        found_modes = get_jesd_mode_from_params(converter_instance, **jesd_params)
+        return {
+            "component": component_name,
+            "jesd_modes": found_modes,
+            "query_params": jesd_params,
+        }
+    except Exception as exc:
+        return {
+            "error": f"Failed to query JESD modes for '{component_name}': {exc}",
+            "component": component_name,
+            "query_params": jesd_params,
+        }
+
+
+def get_component_info(component_type: str, component_name: str) -> AgentResult:
+    """Describe a component's constructor and public API."""
+    try:
+        registry = _registry_for(component_type)
+    except ValueError as exc:
+        return {"error": str(exc)}
+
+    if not isinstance(component_name, str):
+        return {"error": "component_name must be a string"}
+    normalized_name = component_name.lower()
+    if normalized_name not in registry:
+        available = sorted(name.upper() for name in registry)
+        return {
+            "error": f"Component '{component_name}' of type '{component_type}' "
+            f"not found. Available {component_type}s: {available}"
+        }
+
+    component_class = registry[normalized_name]
+    info: AgentResult = {
+        "name": component_class.__name__,
+        "docstring": inspect.getdoc(component_class),
+        "constructor_signature": str(inspect.signature(component_class.__init__)),
+        "properties": {},
+    }
+    properties = info["properties"]
+    for name in dir(component_class):
+        if name.startswith("_"):
+            continue
+        member = getattr(component_class, name)
+        if isinstance(member, property):
+            annotations = getattr(member.fget, "__annotations__", {})
+            properties[name] = {
+                "type": str(annotations.get("return", "Any")),
+                "docstring": inspect.getdoc(member),
+            }
+        elif (
+            inspect.isfunction(member)
+            and not name.startswith("set_")
+            and inspect.getmodule(member) == inspect.getmodule(component_class)
+        ):
+            properties[name] = {
+                "type": "method",
+                "signature": str(inspect.signature(member)),
+                "docstring": inspect.getdoc(member),
+            }
+    return info
+
+
+def solve_system(system_config_json: str) -> AgentResult:
+    """Solve a system from the MCP-compatible JSON configuration."""
+    if not isinstance(system_config_json, str):
+        return {"error": "system_config_json must be a string"}
+    try:
+        system_config = json.loads(system_config_json)
+    except json.JSONDecodeError as exc:
+        return {
+            "error": f"Invalid JSON string for system_config_json: {exc}",
+            "system_config_json": system_config_json,
+        }
+    if not isinstance(system_config, dict):
+        return {
+            "error": "Configuration error: system configuration must be an object",
+            "system_config_json": system_config_json,
+        }
+
+    try:
+        conv_name = system_config.get("conv")
+        clk_name = system_config.get("clk")
+        fpga_name = system_config.get("fpga")
+        if not conv_name or not clk_name or not fpga_name:
+            raise ValueError(
+                "System configuration must specify 'conv', 'clk', and 'fpga'."
+            )
+
+        try:
+            get_component_class("converter", conv_name)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"Converter '{conv_name}' not found in registry."
+            ) from exc
+        try:
+            get_component_class("clock", clk_name)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Clock '{clk_name}' not found in registry.") from exc
+        try:
+            get_component_class("fpga", fpga_name)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"FPGA '{fpga_name}' not found in registry.") from exc
+
+        vcxo_config = system_config.get(
+            "vcxo", {"type": "fixed", "value": 100_000_000}
+        )
+        solver = system_config.get("solver", "CPLEX")
+        sys_instance = _system(
+            conv=conv_name,
+            clk=clk_name,
+            fpga=fpga_name,
+            vcxo=_parse_vcxo(vcxo_config),
+            solver=solver,
+        )
+
+        _apply_config_recursively(
+            sys_instance.converter, system_config.get("converter_properties", {})
+        )
+        _apply_config_recursively(
+            sys_instance.clock, system_config.get("clock_properties", {})
+        )
+        _apply_config_recursively(
+            sys_instance.fpga, system_config.get("fpga_properties", {})
+        )
+
+        for pll_config in system_config.get("pll_configurations", []):
+            if not isinstance(pll_config, dict):
+                raise ValueError("Each PLL configuration must be an object")
+            pll_type = pll_config.get("type")
+            pll_name = pll_config.get("name")
+            pll_properties = pll_config.get("pll_properties", {})
+            if not isinstance(pll_name, str):
+                raise ValueError("PLL configuration requires a string 'name'")
+            if not isinstance(pll_properties, dict):
+                raise ValueError("PLL 'pll_properties' must be an object")
+
+            if pll_type == "inline":
+                target = pll_config.get("target_component", "converter")
+                if target != "converter":
+                    raise ValueError(
+                        f"Invalid target_component for inline PLL: {target}"
+                    )
+                try:
+                    get_component_class("pll", pll_name)
+                except (TypeError, ValueError) as exc:
+                    raise ValueError(
+                        f"PLL '{pll_name}' not found in clock registry."
+                    ) from exc
+                if "vcxo" in pll_config:
+                    raise ValueError(
+                        "Per-PLL 'vcxo' is not supported; PLL references are "
+                        "wired from the system clock"
+                    )
+                sys_instance.add_pll_inline(
+                    pll_name, sys_instance.clock, sys_instance.converter
+                )
+                _apply_config_recursively(sys_instance.plls[-1], pll_properties)
+            elif pll_type == "sysref":
+                try:
+                    get_component_class("pll", pll_name)
+                except (TypeError, ValueError) as exc:
+                    raise ValueError(
+                        f"PLL '{pll_name}' not found in clock registry for sysref."
+                    ) from exc
+                if "vcxo" in pll_config:
+                    raise ValueError(
+                        "Per-PLL 'vcxo' is not supported; PLL references are "
+                        "wired from the system clock"
+                    )
+                sys_instance.add_pll_sysref(
+                    pll_name,
+                    sys_instance.clock,
+                    sys_instance.converter,
+                    sys_instance.fpga,
+                )
+                _apply_config_recursively(
+                    sys_instance._plls_sysref[-1], pll_properties
+                )
+            else:
+                raise ValueError(
+                    f"Unsupported PLL configuration type: {pll_type}"
+                )
+
+        solution = sys_instance.solve(
+            out_clock_constraints=system_config.get("constraints", {})
+        )
+        result: AgentResult = {
+            "config": system_config,
+            "solution": solution,
+            "status": "solved",
+        }
+        contract_format = system_config.get("export_format")
+        if contract_format:
+            result["contract"] = sys_instance.export_config(
+                format=contract_format, solution=solution
+            ).to_dict()
+        return result
+    except (TypeError, ValueError) as exc:
+        return {
+            "error": f"Configuration error: {exc}",
+            "system_config_json": system_config_json,
+        }
+    except Exception as exc:
+        return {
+            "error": f"An unexpected error occurred during system solving: {exc}",
+            "system_config_json": system_config_json,
+        }
+
+
+AGENT_OPERATIONS: Dict[str, AgentOperation] = {
+    "list_components": list_components,
+    "query_jesd_modes": query_jesd_modes,
+    "get_component_info": get_component_info,
+    "solve_system": solve_system,
+}
+
+
+def call_operation(name: str, arguments: Dict[str, Any]) -> AgentResult:
+    """Invoke a named operation using JSON-compatible keyword arguments."""
+    if not isinstance(name, str):
+        return {"error": "operation name must be a string"}
+    if not isinstance(arguments, dict):
+        return {"error": "operation arguments must be an object"}
+    operation = AGENT_OPERATIONS.get(name)
+    if operation is None:
+        return {
+            "error": f"Unknown operation '{name}'. Available operations: "
+            f"{sorted(AGENT_OPERATIONS)}"
+        }
+    try:
+        return operation(**arguments)
+    except Exception as exc:
+        return {"error": f"Invalid arguments for '{name}': {exc}"}
+
+
+def describe_operations() -> AgentResult:
+    """Return local discovery metadata for agent operations."""
+    tools = []
+    for name, operation in AGENT_OPERATIONS.items():
+        signature = inspect.signature(operation)
+        properties = {}
+        required = []
+        for parameter in signature.parameters.values():
+            annotation = parameter.annotation
+            json_type = {
+                str: "string",
+                int: "integer",
+                float: "number",
+                bool: "boolean",
+                dict: "object",
+            }.get(annotation, "string")
+            property_schema = {"type": json_type}
+            if parameter.default is inspect.Parameter.empty:
+                required.append(parameter.name)
+            else:
+                property_schema["default"] = parameter.default
+            properties[parameter.name] = property_schema
+        tools.append(
+            {
+                "name": name,
+                "description": inspect.getdoc(operation),
+                "signature": str(signature),
+                "input_schema": {
+                    "type": "object",
+                    "properties": properties,
+                    "required": required,
+                    "additionalProperties": False,
+                },
+            }
+        )
+    return {"tools": tools}

--- a/adijif/cli.py
+++ b/adijif/cli.py
@@ -1,21 +1,178 @@
-"""Console script for adijif."""
+"""JSON command-line interface for local AI agents and automation."""
 
+import contextlib
+import io
+import json
 import sys
-from typing import List
+from pathlib import Path
+from typing import Any, Dict, Optional
 
 import click
 
+from adijif.agent_api import call_operation, describe_operations
 
-@click.command()
-def main(args: List[str] = None) -> None:
-    """Console script for adijif.
 
-    Args:
-        args (List[str]): List of input argument
-    """
-    click.echo("Replace this message by putting your code into adijif.cli.main")
-    click.echo("See click documentation at https://click.palletsprojects.com/")
+def _json_default(value: Any) -> Any:
+    """Convert common numeric and path objects at the JSON boundary."""
+    if hasattr(value, "item"):
+        return value.item()
+    if isinstance(value, Path):
+        return str(value)
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
+
+def _emit(result: Dict[str, Any], pretty: bool) -> None:
+    """Write exactly one JSON document and exit nonzero for API errors."""
+    click.echo(
+        json.dumps(
+            result,
+            indent=2 if pretty else None,
+            sort_keys=True,
+            default=_json_default,
+        )
+    )
+    if "error" in result:
+        raise click.exceptions.Exit(1)
+
+
+def _read_json_source(inline: Optional[str], file_path: Optional[str]) -> str:
+    """Read JSON from an option, a file, or standard input."""
+    if inline is not None and file_path is not None:
+        raise ValueError("Use either inline JSON or a JSON file, not both.")
+    if file_path == "-":
+        return sys.stdin.read()
+    if file_path is not None:
+        return Path(file_path).read_text(encoding="utf-8")
+    return inline if inline is not None else "{}"
+
+
+def _call_cleanly(name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    """Keep solver chatter off stdout so it remains a JSON-only channel."""
+    diagnostics = io.StringIO()
+    with contextlib.redirect_stdout(diagnostics):
+        result = call_operation(name, arguments)
+    output = diagnostics.getvalue()
+    if output:
+        click.echo(output, err=True, nl=False)
+    return result
+
+
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+@click.option("--pretty/--compact", default=True, help="Format JSON output.")
+@click.pass_context
+def main(ctx: click.Context, pretty: bool) -> None:
+    """Call pyadi-jif tools locally without an MCP transport."""
+    ctx.ensure_object(dict)
+    ctx.obj["pretty"] = pretty
+
+
+@main.command("tools")
+@click.pass_context
+def tools_command(ctx: click.Context) -> None:
+    """List available operations and their argument schemas as JSON."""
+    _emit(describe_operations(), ctx.obj["pretty"])
+
+
+@main.command("call")
+@click.argument("operation")
+@click.option("--arguments", help="JSON object containing operation arguments.")
+@click.option(
+    "--arguments-file",
+    type=click.Path(dir_okay=False),
+    help="JSON argument file, or '-' for standard input.",
+)
+@click.pass_context
+def call_command(
+    ctx: click.Context,
+    operation: str,
+    arguments: Optional[str],
+    arguments_file: Optional[str],
+) -> None:
+    """Call an MCP-equivalent operation using a JSON argument object."""
+    try:
+        raw = _read_json_source(arguments, arguments_file)
+        parsed = json.loads(raw)
+        if not isinstance(parsed, dict):
+            raise ValueError("arguments must be a JSON object")
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as exc:
+        _emit({"error": f"Invalid arguments JSON: {exc}"}, ctx.obj["pretty"])
+        return
+    _emit(_call_cleanly(operation, parsed), ctx.obj["pretty"])
+
+
+@main.command("components")
+@click.argument("component_type")
+@click.pass_context
+def components_command(ctx: click.Context, component_type: str) -> None:
+    """List components of TYPE (converter, clock, fpga, or pll)."""
+    result = _call_cleanly(
+        "list_components", {"component_type": component_type}
+    )
+    _emit(result, ctx.obj["pretty"])
+
+
+@main.command("info")
+@click.argument("component_type")
+@click.argument("component_name")
+@click.pass_context
+def info_command(
+    ctx: click.Context, component_type: str, component_name: str
+) -> None:
+    """Describe one component as JSON."""
+    result = _call_cleanly(
+        "get_component_info",
+        {
+            "component_type": component_type,
+            "component_name": component_name,
+        },
+    )
+    _emit(result, ctx.obj["pretty"])
+
+
+@main.command("jesd-modes")
+@click.argument("component_name")
+@click.option("--params", help="Inline JSON JESD filter parameters.")
+@click.option(
+    "--params-file",
+    type=click.Path(dir_okay=False),
+    help="JSON parameter file, or '-' for standard input.",
+)
+@click.pass_context
+def jesd_modes_command(
+    ctx: click.Context,
+    component_name: str,
+    params: Optional[str],
+    params_file: Optional[str],
+) -> None:
+    """Query matching JESD modes for a converter."""
+    try:
+        raw = _read_json_source(params, params_file)
+    except (OSError, UnicodeError, ValueError) as exc:
+        _emit({"error": f"Unable to read parameters: {exc}"}, ctx.obj["pretty"])
+        return
+    result = _call_cleanly(
+        "query_jesd_modes",
+        {"component_name": component_name, "jesd_params_json": raw},
+    )
+    _emit(result, ctx.obj["pretty"])
+
+
+@main.command("solve")
+@click.argument("config_file", type=click.Path(dir_okay=False))
+@click.pass_context
+def solve_command(ctx: click.Context, config_file: str) -> None:
+    """Solve a system from CONFIG_FILE, or '-' for standard input."""
+    try:
+        raw = _read_json_source(None, config_file)
+    except (OSError, UnicodeError, ValueError) as exc:
+        _emit(
+            {"error": f"Unable to read system configuration: {exc}"},
+            ctx.obj["pretty"],
+        )
+        return
+    result = _call_cleanly("solve_system", {"system_config_json": raw})
+    _emit(result, ctx.obj["pretty"])
 
 
 if __name__ == "__main__":
-    sys.exit(main())  # pragma: no cover
+    main()

--- a/adijif/mcp_server.py
+++ b/adijif/mcp_server.py
@@ -1,463 +1,92 @@
 # flake8: noqa
-"""MCP server exposing pyadi-jif component configuration and system solving tools."""
+"""MCP transport for the shared pyadi-jif agent operations."""
 
-import importlib
-import inspect
-import json
-from pathlib import Path
-from typing import Any, Dict, Type
+from typing import Any, Dict
 
 import click
 from fastmcp import FastMCP
 
-import adijif.clocks
-import adijif.converters
-import adijif.fpgas
-import adijif.types
-from adijif.clocks.clock import clock as BaseClock
-from adijif.converters.converter import converter as BaseConverter
-from adijif.fpgas.fpga import fpga as BaseFPGA
-from adijif.system import system as _system
-from adijif.utils import get_jesd_mode_from_params
-
-_converter_registry: Dict[str, Type[BaseConverter]] = {}
-_clock_registry: Dict[str, Type[BaseClock]] = {}
-_fpga_registry: Dict[str, Type[BaseFPGA]] = {}
-_all_registries_populated = False
-
-
-def _populate_registry(registry: Dict, base_class: Type, package: Any):
-    """Dynamically populate a component registry."""
-    package_path = Path(package.__file__).parent
-    for file_path in package_path.glob("**/*.py"):
-        relative_path = file_path.relative_to(package_path)
-
-        if file_path.name == "__init__.py":
-            # Include subpackage __init__.py (e.g. fpgas/xilinx/__init__.py)
-            # but skip the top-level package __init__.py itself.
-            parent_parts = relative_path.parent.parts
-            if not parent_parts:
-                continue
-            module_name = ".".join(parent_parts)
-        elif file_path.name.startswith("__"):
-            continue
-        else:
-            module_name = ".".join(relative_path.with_suffix("").parts)
-
-        module_path_str = f"{package.__name__}.{module_name}"
-
-        try:
-            module = importlib.import_module(module_path_str)
-            for name, obj in inspect.getmembers(module):
-                if (
-                    inspect.isclass(obj)
-                    and issubclass(obj, base_class)
-                    and obj is not base_class
-                    and not inspect.isabstract(obj)
-                ):
-                    # Use the uppercase class name as the key
-                    registry[obj.__name__.upper()] = obj
-        except (ImportError, TypeError, AttributeError, ValueError):
-            # Silently ignore errors, as some files might not be importable
-            # or contain abstract base classes that fail on instantiation.
-            pass
-
-
-def _populate_all_registries():
-    """Populate all component registries if not already populated."""
-    global _all_registries_populated
-    if _all_registries_populated:
-        return
-
-    _populate_registry(_converter_registry, BaseConverter, adijif.converters)
-    _populate_registry(_clock_registry, BaseClock, adijif.clocks)
-    _populate_registry(_fpga_registry, BaseFPGA, adijif.fpgas)
-
-    _all_registries_populated = True
-
-
-def _parse_vcxo(vcxo_config: Dict[str, Any]) -> Any:
-    """Helper to parse vcxo configuration from JSON into adijif.types objects."""
-    vcxo_type = vcxo_config.get("type")
-    value = vcxo_config.get("value")
-
-    if vcxo_type == "range":
-        start = vcxo_config.get("start")
-        stop = vcxo_config.get("stop")
-        step = vcxo_config.get("step")
-        if start is None or stop is None or step is None:
-            raise ValueError(
-                "vcxo of type 'range' requires 'start', 'stop', and 'step'."
-            )
-        return adijif.types.range(start, stop, step, "vcxo")
-    elif vcxo_type == "arb_source":
-        # arb_source takes frequency and count as args
-        frequency = vcxo_config.get("frequency")
-        count = vcxo_config.get("count")
-        if frequency is None or count is None:
-            raise ValueError(
-                "vcxo of type 'arb_source' requires 'frequency' and 'count'."
-            )
-        return adijif.types.arb_source(str(frequency), count)
-    else:
-        # Default to raw value (int/float)
-        return value
-
-
-def _apply_config_recursively(obj: Any, config: Dict[str, Any]):
-    """Recursively apply configuration to an object's attributes."""
-    for key, value in config.items():
-        if isinstance(value, dict):
-            # If the attribute exists and is an object, recurse
-            if hasattr(obj, key) and isinstance(getattr(obj, key), object):
-                _apply_config_recursively(getattr(obj, key), value)
-            else:
-                # If it's a dict but not an object, set directly (e.g., config for a property)
-                setattr(obj, key, value)
-        else:
-            setattr(obj, key, value)
+from adijif.agent_api import (
+    _apply_config_recursively,
+    _parse_vcxo,
+    get_component_info as _get_component_info,
+    list_components as _list_components,
+    query_jesd_modes as _query_jesd_modes,
+    solve_system as _solve_system,
+)
 
 
 def create_mcp_server() -> FastMCP:
-    """Creates and configures the FastMCP server instance with all tools."""
+    """Create the MCP server backed by the transport-neutral agent API."""
     mcp_instance = FastMCP(name="pyadi-jif MCP Server")
 
     @mcp_instance.tool
-    def list_components(
-        component_type: str,
-    ) -> Dict[str, Any]:
-        """
-        Lists all available components of a given type.
+    def list_components(component_type: str) -> Dict[str, Any]:
+        """List registered converter, clock, FPGA, or PLL components.
 
         Args:
-            component_type: The type of component ('converter', 'clock', or 'fpga').
+            component_type: One of ``converter``, ``clock``, ``fpga``, or
+                ``pll``.
 
         Returns:
-            A dictionary containing a list of available component names.
+            A dictionary with a ``components`` list, or an ``error`` string.
         """
-        _populate_all_registries()
-
-        registry = None
-        if component_type.lower() == "converter":
-            registry = _converter_registry
-        elif component_type.lower() == "clock":
-            registry = _clock_registry
-        elif component_type.lower() == "fpga":
-            registry = _fpga_registry
-        else:
-            return {
-                "error": f"Invalid component_type '{component_type}'. "
-                "Must be 'converter', 'clock', or 'fpga'."
-            }
-
-        return {"components": list(registry.keys())}
+        return _list_components(component_type)
 
     @mcp_instance.tool
     def query_jesd_modes(
-        component_name: str,
-        jesd_params_json: str = "{}",
+        component_name: str, jesd_params_json: str = "{}"
     ) -> Dict[str, Any]:
-        """
-        Queries the available JESD modes for a given component based on provided parameters.
+        """Find converter JESD modes matching JSON parameters.
 
         Args:
-            component_name: The name of the component (e.g., 'AD9081_RX', 'ADRV9009_TX').
-            jesd_params_json: A JSON string representing keyword arguments for JESD parameters
-                              (e.g., '{"M": 4, "L": 8, "K": 32}').
+            component_name: Registered converter name, such as ``AD9081_RX``.
+            jesd_params_json: JSON object encoded as a string. Keys can include
+                JESD parameters such as ``M``, ``L``, ``K``, ``F``, and ``S``.
 
         Returns:
-            A dictionary containing information about the available JESD modes.
+            Matching ``jesd_modes`` and normalized ``query_params``, or an
+            ``error`` string.
         """
-        _populate_all_registries()
-
-        if component_name.upper() not in _converter_registry:
-            return {
-                "error": f"Component '{component_name}' not found in registry. "
-                f"Available components: {list(_converter_registry.keys())}"
-            }
-
-        ConverterClass = _converter_registry[component_name.upper()]
-
-        try:
-            jesd_params = json.loads(jesd_params_json)
-            converter_instance = ConverterClass(model=None, solver="CPLEX")
-
-            found_modes = get_jesd_mode_from_params(
-                converter_instance, **jesd_params
-            )
-
-            return {
-                "component": component_name,
-                "jesd_modes": found_modes,
-                "query_params": jesd_params,
-            }
-        except json.JSONDecodeError as e:
-            return {
-                "error": f"Invalid JSON string for jesd_params_json: {str(e)}",
-                "jesd_params_json": jesd_params_json,
-            }
-        except Exception as e:
-            return {
-                "error": f"Failed to query JESD modes for '{component_name}': {str(e)}",
-                "component": component_name,
-                "query_params": jesd_params,
-            }
+        return _query_jesd_modes(component_name, jesd_params_json)
 
     @mcp_instance.tool
     def get_component_info(
-        component_type: str,
-        component_name: str,
+        component_type: str, component_name: str
     ) -> Dict[str, Any]:
-        """
-        Retrieves detailed information about a specific component (converter, clock, or FPGA).
+        """Describe a component's constructor and public API.
 
         Args:
-            component_type: The type of component ('converter', 'clock', or 'fpga').
-            component_name: The name of the component (e.g., 'AD9081_RX', 'HMC7044', 'XILINX').
+            component_type: One of ``converter``, ``clock``, ``fpga``, or
+                ``pll``.
+            component_name: Name returned by ``list_components``.
 
         Returns:
-            A dictionary containing information about the component, including its docstring,
-            constructor signature, and public properties.
+            Class name, docstring, constructor signature, and public
+            properties/methods, or an ``error`` string.
         """
-        _populate_all_registries()
-
-        registry = None
-        if component_type.lower() == "converter":
-            registry = _converter_registry
-        elif component_type.lower() == "clock":
-            registry = _clock_registry
-        elif component_type.lower() == "fpga":
-            registry = _fpga_registry
-        else:
-            return {
-                "error": f"Invalid component_type '{component_type}'. "
-                "Must be 'converter', 'clock', or 'fpga'."
-            }
-
-        if component_name.upper() not in registry:
-            return {
-                "error": f"Component '{component_name}' of type '{component_type}' not found. "
-                f"Available {component_type}s: {list(registry.keys())}"
-            }
-
-        ComponentClass = registry[component_name.upper()]
-
-        info = {
-            "name": ComponentClass.__name__,
-            "docstring": inspect.getdoc(ComponentClass),
-            "constructor_signature": str(
-                inspect.signature(ComponentClass.__init__)
-            ),
-            "properties": {},
-        }
-
-        # Inspect public properties and methods
-        for name in dir(ComponentClass):
-            if not name.startswith("_"):  # Exclude private/protected members
-                member = getattr(ComponentClass, name)
-                if isinstance(member, property):
-                    info["properties"][name] = {
-                        "type": str(
-                            member.fget.__annotations__.get("return", "Any")
-                        ),
-                        "docstring": inspect.getdoc(member),
-                    }
-                elif inspect.isfunction(member) and not name.startswith(
-                    "set_"
-                ):  # Exclude setters
-                    if (
-                        inspect.getmodule(member) == ComponentClass.__module__
-                    ):  # Only own methods
-                        info["properties"][name] = {
-                            "type": "method",
-                            "signature": str(inspect.signature(member)),
-                            "docstring": inspect.getdoc(member),
-                        }
-        return info
+        return _get_component_info(component_type, component_name)
 
     @mcp_instance.tool
-    def solve_system(
-        system_config_json: str,
-    ) -> Dict[str, Any]:
-        """
-        Performs system-level solving based on the provided JSON configuration.
+    def solve_system(system_config_json: str) -> Dict[str, Any]:
+        """Solve a converter, clock, and FPGA system from JSON.
 
-        The system_config_json should be a JSON string with the following structure:
-        {
-            "conv": "AD9081_RX",
-            "clk": "HMC7044",
-            "fpga": "XILINX",
-            "vcxo": {
-                "type": "fixed",
-                "value": 100000000
-            },
-            "solver": "CPLEX",
-            "converter_properties": {
-                "sample_clock": 1000000000,
-                "jesd_class": "jesd204c",
-                "M": 4,
-                "L": 8,
-                "F": 1
-            },
-            "clock_properties": {
-                "jesd_class": "jesd204c"
-            },
-            "fpga_properties": {},
-            "pll_configurations": [
-                {
-                    "type": "inline",
-                    "name": "ADF4371",
-                    "vcxo": { "type": "fixed", "value": 122880000 },
-                    "target_component": "converter",
-                    "pll_properties": {
-                        "r_divider": 1,
-                        "n_divider": 20
-                    }
-                }
-            ],
-            "constraints": {}
-        }
-        For "vcxo", "type" can be "fixed" (value: int/float), "range" (start: int, stop: int, step: int),
-        or "arb_source" (frequency: int, count: int).
+        The encoded object requires ``conv``, ``clk``, and ``fpga``. Optional
+        fields are ``vcxo``, ``solver``, ``converter_properties``,
+        ``clock_properties``, ``fpga_properties``, ``pll_configurations``,
+        ``constraints``, and ``export_format``. A VCXO can be fixed, a range,
+        or an arbitrary source. Inline PLLs are wired from the system clock to
+        the converter; sysref PLLs drive converter/FPGA SYSREF. Set
+        ``export_format`` to ``adi.jif-dt`` to include a versioned contract.
 
         Args:
-            system_config_json: A JSON string containing the system configuration.
+            system_config_json: System configuration object encoded as JSON.
 
         Returns:
-            A dictionary containing the solving results or an error message.
+            ``status``, ``config``, and ``solution`` on success, optionally a
+            ``contract``; otherwise an ``error`` string.
         """
-        _populate_all_registries()
-
-        try:
-            system_config = json.loads(system_config_json)
-
-            conv_name = system_config.get("conv")
-            clk_name = system_config.get("clk")
-            fpga_name = system_config.get("fpga")
-            vcxo_config = system_config.get(
-                "vcxo", {"type": "fixed", "value": 100000000}
-            )  # Default to 100MHz fixed
-            solver = system_config.get("solver", "CPLEX")
-            pll_configurations = system_config.get("pll_configurations", [])
-            constraints = system_config.get("constraints", {})
-
-            if not conv_name or not clk_name or not fpga_name:
-                raise ValueError(
-                    "System configuration must specify 'conv', 'clk', and 'fpga'."
-                )
-
-            # Resolve component classes from registries
-            # Use the simple component names (e.g., "AD9081_RX") which adijif.system.system expects as top-level aliases
-            if conv_name.upper() not in _converter_registry:
-                raise ValueError(
-                    f"Converter '{conv_name}' not found in registry."
-                )
-            if clk_name.upper() not in _clock_registry:
-                raise ValueError(f"Clock '{clk_name}' not found in registry.")
-            if fpga_name.upper() not in _fpga_registry:
-                raise ValueError(f"FPGA '{fpga_name}' not found in registry.")
-
-            # Instantiate system using simple component names (top-level aliases)
-            vcxo_parsed = _parse_vcxo(vcxo_config)
-            sys_instance = _system(
-                conv=conv_name,  # Pass the simple name, which is now a top-level alias
-                clk=clk_name,  # Pass the simple name
-                fpga=fpga_name,  # Pass the simple name
-                vcxo=vcxo_parsed,
-                solver=solver,
-            )
-
-            # Apply properties to components
-            converter_properties = system_config.get("converter_properties", {})
-            _apply_config_recursively(
-                sys_instance.converter, converter_properties
-            )
-
-            clock_properties = system_config.get("clock_properties", {})
-            _apply_config_recursively(sys_instance.clock, clock_properties)
-
-            fpga_properties = system_config.get("fpga_properties", {})
-            _apply_config_recursively(sys_instance.fpga, fpga_properties)
-
-            # Handle PLL configurations
-            for pll_cfg in pll_configurations:
-                pll_type = pll_cfg.get("type")
-                pll_name = pll_cfg.get("name")
-                pll_vcxo_config = pll_cfg.get("vcxo")
-                pll_vcxo_parsed = _parse_vcxo(pll_vcxo_config)
-                pll_properties = pll_cfg.get("pll_properties", {})
-                target_component_str = pll_cfg.get("target_component")
-
-                if pll_type == "inline":
-                    if pll_name.upper() not in _clock_registry:
-                        raise ValueError(
-                            f"PLL '{pll_name}' not found in clock registry."
-                        )
-
-                    target_component = None
-                    if target_component_str == "converter":
-                        target_component = sys_instance.converter
-                    elif target_component_str == "clock":
-                        target_component = sys_instance.clock
-                    elif target_component_str == "fpga":
-                        target_component = sys_instance.fpga
-                    else:
-                        raise ValueError(
-                            f"Invalid target_component for inline PLL: {target_component_str}"
-                        )
-
-                    # Add inline PLL
-                    sys_instance.add_pll_inline(
-                        pll_name, pll_vcxo_parsed, target_component
-                    )  # Pass simple name
-                    # Apply properties to the newly added PLL
-                    _apply_config_recursively(
-                        sys_instance.plls[-1], pll_properties
-                    )
-
-                elif pll_type == "sysref":
-                    if pll_name.upper() not in _clock_registry:
-                        raise ValueError(
-                            f"PLL '{pll_name}' not found in clock registry for sysref."
-                        )
-
-                    sys_instance.add_pll_sysref(
-                        pll_name, pll_vcxo_parsed, sys_instance.clock
-                    )  # Pass simple name
-                    # Apply properties to the newly added PLL
-                    _apply_config_recursively(
-                        sys_instance.plls[-1], pll_properties
-                    )
-                else:
-                    raise ValueError(
-                        f"Unsupported PLL configuration type: {pll_type}"
-                    )
-
-            # Solve the system
-            solution = sys_instance.solve(out_clock_constraints=constraints)
-
-            return {
-                "config": system_config,
-                "solution": solution,
-                "status": "solved",
-            }
-
-        except json.JSONDecodeError as e:
-            return {
-                "error": f"Invalid JSON string for system_config_json: {str(e)}",
-                "system_config_json": system_config_json,
-            }
-        except ValueError as e:
-            return {
-                "error": f"Configuration error: {str(e)}",
-                "system_config_json": system_config_json,
-            }
-        except Exception as e:
-            # Catch any other unexpected errors during solving
-            return {
-                "error": f"An unexpected error occurred during system solving: {str(e)}",
-                "system_config_json": system_config_json,
-            }
+        return _solve_system(system_config_json)
 
     return mcp_instance
 
@@ -474,10 +103,8 @@ def create_mcp_server() -> FastMCP:
     default=5000,
     help="The port to use if the transport is 'http'.",
 )
-def main(transport: str, port: int):
-    """
-    Starts the pyadi-jif MCP server.
-    """
+def main(transport: str, port: int) -> None:
+    """Start the pyadi-jif MCP server."""
     click.echo(f"Starting pyadi-jif MCP server with transport: {transport}")
     mcp = create_mcp_server()
     if transport == "http":

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -68,6 +68,7 @@ JESD204 is a high-speed serial interface standard used to connect data converter
 - Models for ADI converters (ADCs, DACs, MxFEs), clock chips (HMC7044, AD9523-1, AD9545), and FPGA transceivers (Xilinx, Intel)
 - Interactive web-based **JIF Tools Explorer** (`jiftools`) for graphical configuration and exploration
 - MCP server for AI assistant integration
+- JSON CLI (`jifagent`) for local coding agents and shell automation
 - Clock tree and system block diagram generation
 
 ## Quick Start
@@ -116,6 +117,7 @@ See the [Quick Start Guide](tools_quickstart.md) and [full tools documentation](
 install.md
 tools_quickstart.md
 tools.md
+local_agent_cli.md
 mcp_server.md
 flow.md
 jif_dt.md

--- a/doc/source/local_agent_cli.md
+++ b/doc/source/local_agent_cli.md
@@ -1,0 +1,92 @@
+# Local agent CLI
+
+`jifagent` exposes the same component discovery, JESD-mode query, and system-solving operations as the pyadi-jif MCP server without starting a server. It is intended for local coding agents, shell automation, and tools that communicate through JSON over standard input and output.
+
+## Installation
+
+Install pyadi-jif with at least one solver:
+
+```bash
+pip install "pyadi-jif[cplex]"
+```
+
+The CLI itself is part of the base package and does not require the `mcp` extra.
+
+## Agent protocol
+
+Discover the available operations:
+
+```bash
+jifagent --compact tools
+```
+
+Invoke any MCP-equivalent operation by name:
+
+```bash
+jifagent --compact call list_components \
+  --arguments '{"component_type":"converter"}'
+
+jifagent --compact call query_jesd_modes \
+  --arguments '{"component_name":"AD9081_RX","jesd_params_json":"{\"M\":4,\"L\":8,\"K\":32}"}'
+```
+
+For larger requests, pass a JSON object through standard input:
+
+```bash
+printf '%s' '{"component_type":"clock","component_name":"HMC7044"}' |
+  jifagent --compact call get_component_info --arguments-file -
+```
+
+Each successful invocation writes exactly one JSON document to standard output and exits with status `0`. Operation errors are also returned as one JSON document, with an `error` field, and exit with status `1`. Solver diagnostics are directed to standard error so standard output remains machine-readable.
+
+## Convenience commands
+
+The common operations also have direct commands:
+
+```bash
+jifagent --compact components converter
+jifagent --compact info clock HMC7044
+jifagent --compact jesd-modes AD9081_RX --params '{"M":4,"L":8}'
+```
+
+Use `--pretty` instead of `--compact` for formatted output.
+
+## Solve a system
+
+Save an MCP-compatible system request as `system.json`:
+
+```json
+{
+  "conv": "AD9680",
+  "clk": "AD9523_1",
+  "fpga": "XILINX",
+  "vcxo": {"type": "fixed", "value": 125000000},
+  "solver": "CPLEX",
+  "converter_properties": {
+    "sample_clock": 1000000000,
+    "decimation": 1,
+    "L": 4,
+    "M": 2,
+    "N": 14,
+    "Np": 16,
+    "K": 32,
+    "F": 1
+  },
+  "fpga_properties": {
+    "ref_clock_min": 60000000,
+    "ref_clock_max": 670000000,
+    "out_clk_select": "XCVR_REFCLK"
+  }
+}
+```
+
+Then solve it from a file or standard input:
+
+```bash
+jifagent --compact solve system.json
+cat system.json | jifagent --compact solve -
+```
+
+The result contains `status`, the original `config`, and the solved `solution`. Set `"export_format": "adi.jif-dt"` in the request to include the versioned `adi.jif-dt` interoperability contract under the `contract` key.
+
+For the complete request schema and MCP transport setup, see [pyadi-jif MCP Server](mcp_server.md).

--- a/doc/source/mcp_server.md
+++ b/doc/source/mcp_server.md
@@ -5,13 +5,18 @@ interacting with pyadi-jif functionalities, including querying JESD modes and pe
 system-level solving. This server leverages the `fastmcp` library to expose its capabilities
 as discoverable tools, making it accessible to AI assistants and other automated systems.
 
+Local agents that do not need an MCP transport can call the same operations through the
+JSON-only [`jifagent` command-line interface](local_agent_cli.md).
+
 ## Installation
 
-Install pyadi-jif with the `mcp` optional extras:
+Install pyadi-jif with the `mcp` extra and at least one solver extra:
 
 ```bash
-pip install "pyadi-jif[mcp]"
+pip install "pyadi-jif[mcp,cplex]"
 ```
+
+Use `pyadi-jif[mcp,gekko]` instead to run with GEKKO.
 
 ## Starting the Server
 
@@ -64,7 +69,7 @@ list_components(component_type: str) -> dict
 
 | Parameter        | Type | Description                                      |
 |------------------|------|--------------------------------------------------|
-| `component_type` | str  | One of `"converter"`, `"clock"`, or `"fpga"`.   |
+| `component_type` | str  | One of `"converter"`, `"clock"`, `"fpga"`, or `"pll"`. |
 
 **Returns** a dict with a `"components"` key containing a list of component name strings.
 
@@ -80,7 +85,7 @@ get_component_info(component_type: str, component_name: str) -> dict
 
 | Parameter        | Type | Description                                                         |
 |------------------|------|---------------------------------------------------------------------|
-| `component_type` | str  | One of `"converter"`, `"clock"`, or `"fpga"`.                      |
+| `component_type` | str  | One of `"converter"`, `"clock"`, `"fpga"`, or `"pll"`.           |
 | `component_name` | str  | Component name as returned by `list_components` (e.g. `"AD9081_RX"`). |
 
 **Returns** a dict with keys `name`, `docstring`, `constructor_signature`, and `properties`.
@@ -147,7 +152,6 @@ solve_system(system_config_json: str) -> dict
     {
       "type": "inline",
       "name": "ADF4371",
-      "vcxo": { "type": "fixed", "value": 122880000 },
       "target_component": "converter",
       "pll_properties": {
         "r_divider": 1,
@@ -172,8 +176,9 @@ solve_system(system_config_json: str) -> dict
 | `converter_properties` | no       | Attributes to set on the converter instance.                                   |
 | `clock_properties`     | no       | Attributes to set on the clock instance.                                       |
 | `fpga_properties`      | no       | Attributes to set on the FPGA instance.                                        |
-| `pll_configurations`   | no       | List of inline or sysref PLL configs. Each entry has `type`, `name`, `vcxo`, `target_component`, and `pll_properties`. |
+| `pll_configurations`   | no       | List of inline or sysref PLL configs. Inline PLLs use `target_component: "converter"`; references come from the system clock. |
 | `constraints`          | no       | Output clock constraints dict passed to `sys.solve()`.                        |
+| `export_format`        | no       | Set to `"adi.jif-dt"` to include a versioned `contract` in the response.      |
 
 ## Python Client Example
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 ]
 
 dependencies = [
+    "click>=8.1.7",
     "numpy",
     "openpyxl>=3.1.3",
     "pandas>=1.1.5",
@@ -49,6 +50,7 @@ mcp = ["fastmcp", "pytest-asyncio", "inline-snapshot"]
 
 
 [project.scripts]
+jifagent = "adijif.cli:main"
 jiftools = "adijif.tools.explorer.cli:run_streamlit"
 jifmcp = "adijif.mcp_server:main"
 

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -1,0 +1,231 @@
+"""Tests for the JSON local-agent CLI."""
+
+import json
+from types import SimpleNamespace
+
+from click.testing import CliRunner
+
+import adijif.agent_api as agent_api
+from adijif.cli import main
+
+
+def _json(result):
+    assert result.output
+    return json.loads(result.output)
+
+
+def test_tools_describes_mcp_equivalent_operations():
+    result = CliRunner().invoke(main, ["--compact", "tools"])
+
+    assert result.exit_code == 0
+    tools = _json(result)["tools"]
+    assert [tool["name"] for tool in tools] == [
+        "list_components",
+        "query_jesd_modes",
+        "get_component_info",
+        "solve_system",
+    ]
+    assert tools[0]["input_schema"] == {
+        "additionalProperties": False,
+        "properties": {"component_type": {"type": "string"}},
+        "required": ["component_type"],
+        "type": "object",
+    }
+
+
+def test_components_outputs_json_only():
+    result = CliRunner().invoke(main, ["--compact", "components", "converter"])
+
+    assert result.exit_code == 0
+    assert "AD9680" in _json(result)["components"]
+
+
+def test_info_outputs_component_contract():
+    result = CliRunner().invoke(
+        main, ["--compact", "info", "clock", "HMC7044"]
+    )
+
+    assert result.exit_code == 0
+    payload = _json(result)
+    assert payload["name"] == "hmc7044"
+    assert "d" in payload["properties"]
+
+
+def test_jesd_modes_accepts_stdin_json():
+    result = CliRunner().invoke(
+        main,
+        ["--compact", "jesd-modes", "AD9081_RX", "--params-file", "-"],
+        input='{"M": 4, "L": 8, "K": 32}',
+    )
+
+    assert result.exit_code == 0
+    payload = _json(result)
+    assert payload["query_params"] == {"M": 4, "L": 8, "K": 32}
+    assert payload["jesd_modes"]
+
+
+def test_generic_call_accepts_mcp_tool_name_and_arguments():
+    result = CliRunner().invoke(
+        main,
+        [
+            "--compact",
+            "call",
+            "list_components",
+            "--arguments",
+            '{"component_type": "pll"}',
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "ADF4030" in _json(result)["components"]
+
+
+def test_operation_error_is_json_and_nonzero():
+    result = CliRunner().invoke(
+        main, ["--compact", "components", "not-a-component-type"]
+    )
+
+    assert result.exit_code == 1
+    assert "Invalid component_type" in _json(result)["error"]
+
+
+def test_solve_reads_stdin_and_returns_json_error():
+    result = CliRunner().invoke(
+        main,
+        ["--compact", "solve", "-"],
+        input='{"conv": "AD9680"}',
+    )
+
+    assert result.exit_code == 1
+    assert "must specify 'conv', 'clk', and 'fpga'" in _json(result)["error"]
+
+
+def test_call_rejects_non_object_arguments():
+    result = CliRunner().invoke(
+        main,
+        ["--compact", "call", "list_components", "--arguments", "[]"],
+    )
+
+    assert result.exit_code == 1
+    assert "arguments must be a JSON object" in _json(result)["error"]
+
+
+def test_call_rejects_wrong_argument_types_as_json():
+    result = CliRunner().invoke(
+        main,
+        [
+            "--compact",
+            "call",
+            "list_components",
+            "--arguments",
+            '{"component_type": 1}',
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert _json(result)["error"] == "component_type must be a string"
+
+
+def test_call_input_errors_are_json(tmp_path):
+    missing = tmp_path / "missing.json"
+    result = CliRunner().invoke(
+        main,
+        [
+            "--compact",
+            "call",
+            "list_components",
+            "--arguments-file",
+            str(missing),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Invalid arguments JSON" in _json(result)["error"]
+
+
+def test_solve_wires_supported_pll_topologies(monkeypatch):
+    created = []
+
+    class FakeSystem:
+        def __init__(self):
+            self.converter = SimpleNamespace(name="AD9680")
+            self.clock = SimpleNamespace(name="AD9523_1")
+            self.fpga = SimpleNamespace(name="XILINX")
+            self.plls = []
+            self._plls_sysref = []
+            self.calls = []
+
+        def add_pll_inline(self, name, clock, converter):
+            self.calls.append(("inline", name, clock, converter))
+            self.plls.append(SimpleNamespace(r_divider=0))
+
+        def add_pll_sysref(self, name, clock, converter, fpga):
+            self.calls.append(("sysref", name, clock, converter, fpga))
+            self._plls_sysref.append(SimpleNamespace(r_divider=0))
+
+        def solve(self, out_clock_constraints):
+            return {"constraints": out_clock_constraints}
+
+    def factory(**kwargs):
+        instance = FakeSystem()
+        created.append(instance)
+        return instance
+
+    monkeypatch.setattr(agent_api, "_system", factory)
+    config = {
+        "conv": "AD9680",
+        "clk": "AD9523_1",
+        "fpga": "XILINX",
+        "pll_configurations": [
+            {
+                "type": "inline",
+                "name": "ADF4382",
+                "target_component": "converter",
+                "pll_properties": {"r_divider": 2},
+            },
+            {
+                "type": "sysref",
+                "name": "ADF4030",
+                "pll_properties": {"r_divider": 3},
+            },
+        ],
+    }
+
+    result = agent_api.solve_system(json.dumps(config))
+
+    assert result["status"] == "solved"
+    system = created[0]
+    assert system.calls[0] == (
+        "inline",
+        "ADF4382",
+        system.clock,
+        system.converter,
+    )
+    assert system.calls[1] == (
+        "sysref",
+        "ADF4030",
+        system.clock,
+        system.converter,
+        system.fpga,
+    )
+    assert system.plls[0].r_divider == 2
+    assert system._plls_sysref[0].r_divider == 3
+
+
+def test_solve_rejects_obsolete_per_pll_vcxo():
+    config = {
+        "conv": "AD9680",
+        "clk": "AD9523_1",
+        "fpga": "XILINX",
+        "pll_configurations": [
+            {
+                "type": "inline",
+                "name": "ADF4382",
+                "vcxo": {"type": "fixed", "value": 125_000_000},
+            }
+        ],
+    }
+
+    result = agent_api.solve_system(json.dumps(config))
+
+    assert "Per-PLL 'vcxo' is not supported" in result["error"]

--- a/tests/test_mcp_server_coverage.py
+++ b/tests/test_mcp_server_coverage.py
@@ -60,18 +60,40 @@ def test_mcp_apply_config_recursively():
             self.top = 0
 
     o = Obj()
-    config = {"top": 1, "sub": {"val": 2}, "new_attr": 3}
+    config = {"top": 1, "sub": {"val": 2}}
     _apply_config_recursively(o, config)
 
     assert o.top == 1
     assert o.sub.val == 2
-    assert o.new_attr == 3
+
+
+@pytest.mark.parametrize("key", ["new_attr", "_model"])
+def test_mcp_apply_config_rejects_unknown_or_private_attributes(key):
+    """Agent configuration cannot mutate internals or invent attributes."""
+
+    class Obj:
+        top = 0
+
+    with pytest.raises(ValueError, match="configuration attribute"):
+        _apply_config_recursively(Obj(), {key: 1})
 
 
 async def _get_mcp_tool_fn(mcp, name):
     """Helper to get a tool function from FastMCP instance."""
     tool = await mcp.get_tool(name)
     return tool.fn
+
+
+@pytest.mark.asyncio
+async def test_mcp_tools_keep_transport_visible_descriptions():
+    """MCP discovery includes enough schema guidance for an agent."""
+    mcp = create_mcp_server()
+    solve_tool = await mcp.get_tool("solve_system")
+    list_tool = await mcp.get_tool("list_components")
+
+    assert "converter_properties" in (solve_tool.description or "")
+    assert "adi.jif-dt" in (solve_tool.description or "")
+    assert "converter" in (list_tool.description or "")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add a `jifagent` JSON CLI for local coding agents and shell automation
- expose MCP-equivalent operation discovery and generic calls, plus direct convenience commands
- move component discovery, JESD queries, and system solving into one transport-neutral API shared by MCP and CLI
- support stdin/file inputs, deterministic JSON stdout, nonzero error exits, PLL discovery, and optional `adi.jif-dt` contract output
- retain rich transport-visible MCP tool descriptions and document runnable local-agent workflows
- reject unknown/private component attributes and normalize malformed input/file failures into JSON errors
- align PLL requests with current system topology: system-clock references, converter inline target, and explicit rejection of obsolete per-PLL VCXO fields

## Verification

- focused CLI and MCP tests: 48 passed, 1 skipped
- full non-browser suite: 825 passed, 11 skipped, 5 xfailed
- `nox -s ty lint`: passed
- strict Sphinx docs: passed
- real installed CLI CPLEX solve: passed with JSON-only stdout
- real `adi.jif-dt` contract solve/export: passed
- clean built-wheel install without MCP extra and `jifagent` invocation: passed
- old/new MCP component inventory comparison: no removed or added existing converter, clock, or FPGA models
- `git diff --check`: passed

## Review hardening

- successful inline/sysref PLL wiring and property regressions
- malformed argument-type and missing-file JSON contract regressions
- private/unknown attribute mutation regressions
- MCP discovery-description regression coverage