### PR TITLE
Correct AD9144 dual-link JESD modes

### DIFF
--- a/adijif/converters/ad9144.py
+++ b/adijif/converters/ad9144.py
@@ -55,23 +55,23 @@ quick_configuration_modes = {
     **quick_configuration_modes,
     **{
         str(4) + "-DL": _convert_to_config(
-            DualLink=False, M=2, L=4, S=1, F=1, N=16, Np=16
+            DualLink=True, M=2, L=4, S=1, F=1, N=16, Np=16
         ),
         str(5) + "-DL": _convert_to_config(
-            DualLink=False, M=2, L=4, S=2, F=2, N=16, Np=16
+            DualLink=True, M=2, L=4, S=2, F=2, N=16, Np=16
         ),
         str(6) + "-DL": _convert_to_config(
-            DualLink=False, M=2, L=2, S=1, F=2, N=16, Np=16
+            DualLink=True, M=2, L=2, S=1, F=2, N=16, Np=16
         ),
         str(7) + "-DL": _convert_to_config(
-            DualLink=False, M=2, L=1, S=1, F=4, N=16, Np=16
+            DualLink=True, M=2, L=1, S=1, F=4, N=16, Np=16
         ),
         # 8 is missing in datasheet
         str(9) + "-DL": _convert_to_config(
-            DualLink=False, M=1, L=2, S=1, F=1, N=16, Np=16
+            DualLink=True, M=1, L=2, S=1, F=1, N=16, Np=16
         ),
         str(10) + "-DL": _convert_to_config(
-            DualLink=False, M=1, L=1, S=1, F=2, N=16, Np=16
+            DualLink=True, M=1, L=1, S=1, F=2, N=16, Np=16
         ),
     },
 }

--- a/tests/test_ad9144_modes.py
+++ b/tests/test_ad9144_modes.py
@@ -1,0 +1,28 @@
+"""Regression tests for AD9144 JESD quick-configuration metadata."""
+
+import pytest
+
+import adijif
+
+DUAL_LINK_MODES = ("4-DL", "5-DL", "6-DL", "7-DL", "9-DL", "10-DL")
+SINGLE_LINK_MODES = ("0", "1", "2", "3", "4", "5", "6", "7", "9", "10")
+
+
+@pytest.mark.parametrize("mode", DUAL_LINK_MODES)
+def test_ad9144_dual_link_modes_enable_dual_link(mode):
+    converter = adijif.ad9144()
+
+    converter.set_quick_configuration_mode(mode)
+
+    assert converter.DualLink is True
+    assert converter.quick_configuration_modes["jesd204b"][mode]["DualLink"] is True
+
+
+@pytest.mark.parametrize("mode", SINGLE_LINK_MODES)
+def test_ad9144_single_link_modes_disable_dual_link(mode):
+    converter = adijif.ad9144()
+
+    converter.set_quick_configuration_mode(mode)
+
+    assert converter.DualLink is False
+    assert converter.quick_configuration_modes["jesd204b"][mode]["DualLink"] is False


### PR DESCRIPTION
## Summary

- mark AD9144 quick-configuration modes `4-DL`, `5-DL`, `6-DL`, `7-DL`, `9-DL`, and `10-DL` as dual-link
- add parameterized regressions covering every AD9144 dual-link and single-link mode
- verify selecting each mode updates both the mode-table metadata and converter state

## Verification

- focused AD9144/DAQ2/drawing/cache suite: 54 passed, 1 skipped, 1 xfailed
- full non-browser suite: 841 passed, 11 skipped, 5 xfailed
- `nox -s ty lint`: passed
- `git diff --check`: passed