### PR TITLE
Validate AD9528 SYSREF divider range

### DIFF
--- a/adijif/clocks/ad9528.py
+++ b/adijif/clocks/ad9528.py
@@ -125,7 +125,7 @@ class ad9528(ad9528_bf):
             value (int, list[int]): Allowable values for divider
 
         """
-        self._check_in_range(value, self.d_available, "k")
+        self._check_in_range(value, self.k_available, "k")
         self._k = self._own_selection(value)
 
     @property

--- a/tests/test_clocks_more_coverage.py
+++ b/tests/test_clocks_more_coverage.py
@@ -1,5 +1,7 @@
 """Additional tests for AD9523, AD9528, and AD9545 to improve coverage."""
 
+import pytest
+
 import adijif
 
 
@@ -37,6 +39,24 @@ def test_ad9528_solve_various_dividers():
         10,
         12,
     ]  # Example values
+
+
+@pytest.mark.parametrize("divider", [0, 1024, 65535])
+def test_ad9528_accepts_full_sysref_divider_range(divider):
+    """AD9528 SYSREF divider validation uses its 16-bit capability range."""
+    clk = adijif.ad9528()
+
+    clk.k = divider
+
+    assert clk.k == divider
+
+
+@pytest.mark.parametrize("divider", [-1, 65536])
+def test_ad9528_rejects_sysref_dividers_outside_capability_range(divider):
+    clk = adijif.ad9528()
+
+    with pytest.raises(Exception, match="invalid for k"):
+        clk.k = divider
 
 
 def test_ad9545_solve_smoke():


### PR DESCRIPTION
## Summary

- validate AD9528 SYSREF divider `k` against its documented 16-bit capability range instead of the unrelated output-divider range
- cover valid boundaries and representative values above 1023
- retain rejection coverage below 0 and above 65535

## Verification

- focused AD9528 and clock ownership suite: 37 passed
- full non-browser suite: 846 passed, 11 skipped, 5 xfailed
- `nox -s ty lint`: passed
- `git diff --check`: passed