### PR TITLE
Fix PyPI README logo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A framework to simplify the use of JESD204 with Analog Devices, Inc. data conver
 **New:** Try the interactive web-based [JIF Tools Explorer](#jif-tools-explorer) for a graphical interface!
 
 <p align="center">
-<img src="doc/source/imgs/PyADI-JIF_logo.png" width="500" alt="PyADI-JIF Logo"> </br>
+<img src="https://raw.githubusercontent.com/analogdevicesinc/pyadi-jif/main/doc/source/imgs/PyADI-JIF_logo.png" width="500" alt="PyADI-JIF Logo"> <br>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

- replace the repository-relative README logo path with an absolute raw GitHub URL
- use valid `<br>` markup after the logo
- ensure the logo resolves when PyPI renders the README from package metadata

## Verification

- logo URL returns `200 image/png`
- `readme-renderer[md]` output contains the absolute logo URL
- built wheel metadata contains the absolute URL and no relative logo path
- `uv build` succeeded
- `twine check` passed for wheel and source distribution
- `git diff --check` passed