### PR TITLE
Fix package version synchronization

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -18,7 +18,7 @@ project = 'pyadi-jif'
 year = datetime.datetime.now().year
 copyright = f'2020-{year}, Analog Devices Inc.'
 author = 'Travis F. Collins, PhD'
-release = 'v0.1.4'
+release = 'v0.1.7'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/doc/source/jif_dt.md
+++ b/doc/source/jif_dt.md
@@ -65,7 +65,7 @@ The output begins with:
   ],
   "producer": {
     "name": "pyadi-jif",
-    "version": "0.1.6"
+    "version": "0.1.7"
   },
   "schema": "adi.jif-dt",
   "version": "1.0"

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,7 @@
 # flake8: noqa
 import tempfile
 from datetime import datetime
+from pathlib import Path
 
 import nox
 from nox.sessions import Session
@@ -17,9 +18,35 @@ main_python = "3.10"
 multi_python_versions_support = ["3.10", "3.11", "3.12", "3.13"]
 package = "adijif"
 
+VERSION_FILES = {
+    Path("pyproject.toml"): 'version = "{version}"',
+    Path("adijif/__init__.py"): '__version__ = "{version}"',
+    Path("setup.cfg"): "current_version = {version}",
+    Path("doc/source/conf.py"): "release = 'v{version}'",
+    Path("doc/source/jif_dt.md"): (
+        '"producer": {{\n    "name": "pyadi-jif",\n    "version": "{version}"'
+    ),
+}
+
 
 def install_with_constraints(session, *args, **kwargs):
     session.install(*args, **kwargs)
+
+
+def update_version(old_version: str, new_version: str) -> None:
+    """Update every package-version surface, refusing partial replacements."""
+    replacements = {}
+    for path, template in VERSION_FILES.items():
+        content = path.read_text()
+        old = template.format(version=old_version)
+        new = template.format(version=new_version)
+        if content.count(old) != 1:
+            raise RuntimeError(
+                f"Expected exactly one {old_version} version in {path}"
+            )
+        replacements[path] = content.replace(old, new, 1)
+    for path, content in replacements.items():
+        path.write_text(content)
 
 
 @nox.session(python=main_python)
@@ -262,28 +289,26 @@ def docs(session: Session) -> None:
 def dev_release(session: Session) -> None:
     """Generate development release."""
     install_with_constraints(session, "numpy")
-    out_lines = []
-    org_lines = []
-    with open("pyproject.toml", "r") as f:
-        lines = f.readlines()
-        org_lines = lines
-        for line in lines:
-            if "version" in line:
-                current_version = line.split("=")[1].strip().replace('"', "")
-                print(f"Current version: {current_version}")
-                now = datetime.now().strftime("%Y%m%d%H%M%S")
-                line = f'version = "{current_version}.dev.{now}"\n'
-            out_lines.append(line)
+    import re
 
-    with open("pyproject.toml", "w") as f:
-        f.writelines(out_lines)
+    toml_content = Path("pyproject.toml").read_text()
+    match = re.search(
+        r'^version = "(\d+\.\d+\.\d+)"', toml_content, re.MULTILINE
+    )
+    if not match:
+        session.error("Could not find version in pyproject.toml")
+        return
+    current_version = match.group(1)
+    now = datetime.now().strftime("%Y%m%d%H%M%S")
+    dev_version = f"{current_version}.dev{now}"
+    print(f"Development version: {dev_version}")
+    update_version(current_version, dev_version)
 
     try:
         session.run("uv", "build")
 
     finally:
-        with open("pyproject.toml", "w") as f:
-            f.writelines(org_lines)
+        update_version(dev_version, current_version)
 
 
 @nox.session(python=main_python)
@@ -331,34 +356,7 @@ def create_release(session: Session) -> None:
     new_version = f"{major}.{minor}.{patch}"
     print(f"Bumping {bump_type}: {old_version} -> {new_version}")
 
-    with open("pyproject.toml", "w") as f:
-        f.write(
-            toml_content.replace(
-                f'version = "{old_version}"', f'version = "{new_version}"', 1
-            )
-        )
-
-    with open("adijif/__init__.py") as f:
-        init_content = f.read()
-    with open("adijif/__init__.py", "w") as f:
-        f.write(
-            init_content.replace(
-                f'__version__ = "{old_version}"',
-                f'__version__ = "{new_version}"',
-                1,
-            )
-        )
-
-    with open("setup.cfg") as f:
-        cfg_content = f.read()
-    with open("setup.cfg", "w") as f:
-        f.write(
-            cfg_content.replace(
-                f"current_version = {old_version}",
-                f"current_version = {new_version}",
-                1,
-            )
-        )
+    update_version(old_version, new_version)
 
     tag = f"v{new_version}"
     session.run(
@@ -367,6 +365,8 @@ def create_release(session: Session) -> None:
         "pyproject.toml",
         "adijif/__init__.py",
         "setup.cfg",
+        "doc/source/conf.py",
+        "doc/source/jif_dt.md",
         external=True,
     )
     session.run(

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,8 +8,16 @@ search = version = "{current_version}"
 replace = version = "{new_version}"
 
 [bumpversion:file:adijif/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
+[bumpversion:file:doc/source/conf.py]
+search = release = 'v{current_version}'
+replace = release = 'v{new_version}'
+
+[bumpversion:file:doc/source/jif_dt.md]
+search = "version": "{current_version}"
+replace = "version": "{new_version}"
 
 [bdist_wheel]
 universal = 1

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,43 @@
+"""Regression tests for synchronized package-version surfaces."""
+
+import configparser
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+
+
+def extract(pattern: str, path: Path) -> str:
+    """Extract one version and fail clearly when its surface disappears."""
+    match = re.search(pattern, path.read_text(), re.MULTILINE)
+    assert match, f"Could not find a managed version in {path}"
+    return match.group(1)
+
+
+def test_package_version_surfaces_are_synchronized():
+    """Code, packaging, release tooling, and docs expose one version."""
+    project_version = extract(r'^version = "([^"]+)"$', ROOT / "pyproject.toml")
+    code_version = extract(
+        r'^__version__ = "([^"]+)"$', ROOT / "adijif/__init__.py"
+    )
+
+    config = configparser.ConfigParser()
+    config.read(ROOT / "setup.cfg")
+    tool_version = config["bumpversion"]["current_version"]
+
+    sphinx_release = extract(
+        r"^release = 'v([^']+)'$",
+        ROOT / "doc/source/conf.py",
+    )
+    documented_version = extract(
+        r'"producer": \{\s*"name": "pyadi-jif",\s*"version": "([^"]+)"',
+        ROOT / "doc/source/jif_dt.md",
+    )
+
+    assert {
+        project_version,
+        code_version,
+        tool_version,
+        sphinx_release,
+        documented_version,
+    } == {project_version}


### PR DESCRIPTION
## Summary
- synchronize the current `0.1.7` package version across code, Sphinx metadata, and the documented JIF-DT producer output
- make both `bump2version` and Nox release paths update every managed version surface
- make development builds use canonical PEP 440 versions and restore all source surfaces after building
- add a regression test that rejects drift between packaging, runtime code, release tooling, and docs

## Verification
- `nox -s tests-3.10`: 863 passed, 11 skipped, 5 xfailed
- `nox -s lint`: passed
- `nox -s docs`: warning-strict Sphinx build passed
- real disposable `bump2version --no-commit --no-tag patch`: all five surfaces advanced to `0.1.8`
- real disposable `nox -s dev_release`: wheel runtime and metadata matched at `0.1.7.dev<timestamp>` and all source surfaces restored to `0.1.7`
