### PR TITLE
Add Xilinx xgt_wizard export for HDL repo integration

### DIFF
--- a/adijif/agent_api.py
+++ b/adijif/agent_api.py
@@ -173,130 +173,167 @@ def get_component_info(component_type: str, component_name: str) -> AgentResult:
     return info
 
 
-def solve_system(system_config_json: str) -> AgentResult:
-    """Solve a system from the MCP-compatible JSON configuration."""
+def _parse_system_config(system_config_json: str) -> Dict[str, Any]:
+    """Parse and validate the JSON system configuration payload.
+
+    Args:
+        system_config_json: JSON object string describing the system.
+
+    Returns:
+        Parsed configuration dictionary.
+
+    Raises:
+        ValueError: If the payload is not a string, valid JSON, or an
+            object.
+    """
     if not isinstance(system_config_json, str):
-        return {"error": "system_config_json must be a string"}
+        raise ValueError("system_config_json must be a string")
     try:
         system_config = json.loads(system_config_json)
     except json.JSONDecodeError as exc:
-        return {
-            "error": f"Invalid JSON string for system_config_json: {exc}",
-            "system_config_json": system_config_json,
-        }
+        raise ValueError(
+            f"Invalid JSON string for system_config_json: {exc}"
+        ) from exc
     if not isinstance(system_config, dict):
+        raise ValueError(
+            "Configuration error: system configuration must be an object"
+        )
+    return system_config
+
+
+def _solve_from_config(system_config: Dict[str, Any]) -> tuple:
+    """Build and solve a system from a parsed configuration.
+
+    Args:
+        system_config: Parsed system configuration dictionary.
+
+    Returns:
+        Tuple of the solved system instance and its solution dictionary.
+
+    Raises:
+        ValueError: On unknown components or invalid configuration values.
+    """
+    conv_name = system_config.get("conv")
+    clk_name = system_config.get("clk")
+    fpga_name = system_config.get("fpga")
+    if not conv_name or not clk_name or not fpga_name:
+        raise ValueError(
+            "System configuration must specify 'conv', 'clk', and 'fpga'."
+        )
+
+    try:
+        get_component_class("converter", conv_name)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"Converter '{conv_name}' not found in registry."
+        ) from exc
+    try:
+        get_component_class("clock", clk_name)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Clock '{clk_name}' not found in registry.") from exc
+    try:
+        get_component_class("fpga", fpga_name)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"FPGA '{fpga_name}' not found in registry.") from exc
+
+    vcxo_config = system_config.get(
+        "vcxo", {"type": "fixed", "value": 100_000_000}
+    )
+    solver = system_config.get("solver", "CPLEX")
+    sys_instance = _system(
+        conv=conv_name,
+        clk=clk_name,
+        fpga=fpga_name,
+        vcxo=_parse_vcxo(vcxo_config),
+        solver=solver,
+    )
+
+    _apply_config_recursively(
+        sys_instance.converter, system_config.get("converter_properties", {})
+    )
+    _apply_config_recursively(
+        sys_instance.clock, system_config.get("clock_properties", {})
+    )
+    _apply_config_recursively(
+        sys_instance.fpga, system_config.get("fpga_properties", {})
+    )
+
+    for pll_config in system_config.get("pll_configurations", []):
+        if not isinstance(pll_config, dict):
+            raise ValueError("Each PLL configuration must be an object")
+        pll_type = pll_config.get("type")
+        pll_name = pll_config.get("name")
+        pll_properties = pll_config.get("pll_properties", {})
+        if not isinstance(pll_name, str):
+            raise ValueError("PLL configuration requires a string 'name'")
+        if not isinstance(pll_properties, dict):
+            raise ValueError("PLL 'pll_properties' must be an object")
+
+        if pll_type == "inline":
+            target = pll_config.get("target_component", "converter")
+            if target != "converter":
+                raise ValueError(
+                    f"Invalid target_component for inline PLL: {target}"
+                )
+            try:
+                get_component_class("pll", pll_name)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"PLL '{pll_name}' not found in clock registry."
+                ) from exc
+            if "vcxo" in pll_config:
+                raise ValueError(
+                    "Per-PLL 'vcxo' is not supported; PLL references are "
+                    "wired from the system clock"
+                )
+            sys_instance.add_pll_inline(
+                pll_name, sys_instance.clock, sys_instance.converter
+            )
+            _apply_config_recursively(sys_instance.plls[-1], pll_properties)
+        elif pll_type == "sysref":
+            try:
+                get_component_class("pll", pll_name)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"PLL '{pll_name}' not found in clock registry for sysref."
+                ) from exc
+            if "vcxo" in pll_config:
+                raise ValueError(
+                    "Per-PLL 'vcxo' is not supported; PLL references are "
+                    "wired from the system clock"
+                )
+            sys_instance.add_pll_sysref(
+                pll_name,
+                sys_instance.clock,
+                sys_instance.converter,
+                sys_instance.fpga,
+            )
+            _apply_config_recursively(
+                sys_instance._plls_sysref[-1], pll_properties
+            )
+        else:
+            raise ValueError(
+                f"Unsupported PLL configuration type: {pll_type}"
+            )
+
+    solution = sys_instance.solve(
+        out_clock_constraints=system_config.get("constraints", {})
+    )
+    return sys_instance, solution
+
+
+def solve_system(system_config_json: str) -> AgentResult:
+    """Solve a system from the MCP-compatible JSON configuration."""
+    try:
+        system_config = _parse_system_config(system_config_json)
+    except ValueError as exc:
         return {
-            "error": "Configuration error: system configuration must be an object",
+            "error": str(exc),
             "system_config_json": system_config_json,
         }
 
     try:
-        conv_name = system_config.get("conv")
-        clk_name = system_config.get("clk")
-        fpga_name = system_config.get("fpga")
-        if not conv_name or not clk_name or not fpga_name:
-            raise ValueError(
-                "System configuration must specify 'conv', 'clk', and 'fpga'."
-            )
-
-        try:
-            get_component_class("converter", conv_name)
-        except (TypeError, ValueError) as exc:
-            raise ValueError(
-                f"Converter '{conv_name}' not found in registry."
-            ) from exc
-        try:
-            get_component_class("clock", clk_name)
-        except (TypeError, ValueError) as exc:
-            raise ValueError(f"Clock '{clk_name}' not found in registry.") from exc
-        try:
-            get_component_class("fpga", fpga_name)
-        except (TypeError, ValueError) as exc:
-            raise ValueError(f"FPGA '{fpga_name}' not found in registry.") from exc
-
-        vcxo_config = system_config.get(
-            "vcxo", {"type": "fixed", "value": 100_000_000}
-        )
-        solver = system_config.get("solver", "CPLEX")
-        sys_instance = _system(
-            conv=conv_name,
-            clk=clk_name,
-            fpga=fpga_name,
-            vcxo=_parse_vcxo(vcxo_config),
-            solver=solver,
-        )
-
-        _apply_config_recursively(
-            sys_instance.converter, system_config.get("converter_properties", {})
-        )
-        _apply_config_recursively(
-            sys_instance.clock, system_config.get("clock_properties", {})
-        )
-        _apply_config_recursively(
-            sys_instance.fpga, system_config.get("fpga_properties", {})
-        )
-
-        for pll_config in system_config.get("pll_configurations", []):
-            if not isinstance(pll_config, dict):
-                raise ValueError("Each PLL configuration must be an object")
-            pll_type = pll_config.get("type")
-            pll_name = pll_config.get("name")
-            pll_properties = pll_config.get("pll_properties", {})
-            if not isinstance(pll_name, str):
-                raise ValueError("PLL configuration requires a string 'name'")
-            if not isinstance(pll_properties, dict):
-                raise ValueError("PLL 'pll_properties' must be an object")
-
-            if pll_type == "inline":
-                target = pll_config.get("target_component", "converter")
-                if target != "converter":
-                    raise ValueError(
-                        f"Invalid target_component for inline PLL: {target}"
-                    )
-                try:
-                    get_component_class("pll", pll_name)
-                except (TypeError, ValueError) as exc:
-                    raise ValueError(
-                        f"PLL '{pll_name}' not found in clock registry."
-                    ) from exc
-                if "vcxo" in pll_config:
-                    raise ValueError(
-                        "Per-PLL 'vcxo' is not supported; PLL references are "
-                        "wired from the system clock"
-                    )
-                sys_instance.add_pll_inline(
-                    pll_name, sys_instance.clock, sys_instance.converter
-                )
-                _apply_config_recursively(sys_instance.plls[-1], pll_properties)
-            elif pll_type == "sysref":
-                try:
-                    get_component_class("pll", pll_name)
-                except (TypeError, ValueError) as exc:
-                    raise ValueError(
-                        f"PLL '{pll_name}' not found in clock registry for sysref."
-                    ) from exc
-                if "vcxo" in pll_config:
-                    raise ValueError(
-                        "Per-PLL 'vcxo' is not supported; PLL references are "
-                        "wired from the system clock"
-                    )
-                sys_instance.add_pll_sysref(
-                    pll_name,
-                    sys_instance.clock,
-                    sys_instance.converter,
-                    sys_instance.fpga,
-                )
-                _apply_config_recursively(
-                    sys_instance._plls_sysref[-1], pll_properties
-                )
-            else:
-                raise ValueError(
-                    f"Unsupported PLL configuration type: {pll_type}"
-                )
-
-        solution = sys_instance.solve(
-            out_clock_constraints=system_config.get("constraints", {})
-        )
+        sys_instance, solution = _solve_from_config(system_config)
         result: AgentResult = {
             "config": system_config,
             "solution": solution,
@@ -320,11 +357,61 @@ def solve_system(system_config_json: str) -> AgentResult:
         }
 
 
+def export_xgt_wizard(
+    system_config_json: str, hdl_project: str = ""
+) -> AgentResult:
+    """Solve a system and export HDL repo xgt_wizard build parameters.
+
+    Args:
+        system_config_json: Same JSON configuration as ``solve_system``.
+        hdl_project: Optional HDL project path relative to ``projects/``
+            (e.g. ``"ad9081_fmca_ebz/zcu102"``). When given, the result
+            also contains a full ``make_command``.
+
+    Returns:
+        Dictionary with the xgt_wizard ``config``, ``make_args``, ``tcl``,
+        optional ``make_command``, and ``status`` — or an ``error`` entry.
+    """
+    from adijif.fpgas.xilinx.xgt_wizard import XgtWizardConfig
+
+    try:
+        system_config = _parse_system_config(system_config_json)
+    except ValueError as exc:
+        return {
+            "error": str(exc),
+            "system_config_json": system_config_json,
+        }
+
+    try:
+        sys_instance, solution = _solve_from_config(system_config)
+        wizard = XgtWizardConfig.from_system_solution(sys_instance, solution)
+        result: AgentResult = {
+            "config": wizard.to_dict(),
+            "make_args": wizard.to_make_args(),
+            "tcl": wizard.to_tcl(),
+            "status": "ok",
+        }
+        if hdl_project:
+            result["make_command"] = wizard.to_make_command(hdl_project)
+        return result
+    except (TypeError, ValueError) as exc:
+        return {
+            "error": f"Configuration error: {exc}",
+            "system_config_json": system_config_json,
+        }
+    except Exception as exc:
+        return {
+            "error": f"An unexpected error occurred during system solving: {exc}",
+            "system_config_json": system_config_json,
+        }
+
+
 AGENT_OPERATIONS: Dict[str, AgentOperation] = {
     "list_components": list_components,
     "query_jesd_modes": query_jesd_modes,
     "get_component_info": get_component_info,
     "solve_system": solve_system,
+    "export_xgt_wizard": export_xgt_wizard,
 }
 
 

--- a/adijif/fpgas/xilinx/xgt_wizard.py
+++ b/adijif/fpgas/xilinx/xgt_wizard.py
@@ -1,0 +1,325 @@
+"""Export solved configs to the ADI HDL repo xgt_wizard (adi_xcvr) flow.
+
+The HDL repo's ``adi_xcvr_project`` proc consumes a flat parameter list
+(``LANE_RATE``/``REF_CLK``/``PLL_TYPE``/``JESD_MODE`` plus ``XCVR_RX_*``
+overrides). This module maps a solved pyadi-jif system onto that contract
+and renders it as a make command, a sourceable tcl snippet, or JSON.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+
+def _fmt(value: float) -> str:
+    """Format a rate for the HDL parameter list (e.g. ``10``, ``245.76``).
+
+    Rounds to 6 decimals to absorb solver float noise, then strips
+    trailing zeros and any dangling decimal point.
+
+    Args:
+        value: Rate in Gbps or MHz.
+
+    Returns:
+        Compact decimal string.
+    """
+    return f"{round(value, 6):.6f}".rstrip("0").rstrip(".")
+
+_PLL_TYPES = ("CPLL", "QPLL0", "QPLL1")
+_PLL_NAME_MAP = {"cpll": "CPLL", "qpll": "QPLL0", "qpll1": "QPLL1"}
+_JESD_MODE_MAP = {"jesd204b": "8B10B", "jesd204c": "64B66B"}
+
+
+@dataclass(frozen=True)
+class XgtWizardLink:
+    """Solved transceiver settings for one JESD link direction."""
+
+    lane_rate_gbps: float
+    ref_clk_mhz: float
+    pll_type: str
+    num_lanes: int
+
+    def __post_init__(self) -> None:
+        """Validate rates, PLL naming, and lane count.
+
+        Raises:
+            ValueError: If a rate is not positive, ``pll_type`` is not one
+                of CPLL/QPLL0/QPLL1, or ``num_lanes`` is not >= 1.
+        """
+        if self.lane_rate_gbps <= 0 or self.ref_clk_mhz <= 0:
+            raise ValueError("lane_rate_gbps and ref_clk_mhz must be positive")
+        if self.pll_type not in _PLL_TYPES:
+            raise ValueError(
+                f"pll_type must be one of {_PLL_TYPES}, got {self.pll_type}"
+            )
+        if type(self.num_lanes) is not int or self.num_lanes < 1:
+            raise ValueError("num_lanes must be a positive integer")
+
+
+@dataclass(frozen=True)
+class XgtWizardConfig:
+    """Parameters for the HDL repo ``adi_xcvr_project`` xgt_wizard flow."""
+
+    jesd_mode: str
+    tx: Optional[XgtWizardLink]
+    rx: Optional[XgtWizardLink]
+    transceiver_type: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        """Validate the JESD mode and require at least one direction.
+
+        Raises:
+            ValueError: If ``jesd_mode`` is not ``8B10B``/``64B66B`` or
+                both ``tx`` and ``rx`` are ``None``.
+        """
+        if self.jesd_mode not in _JESD_MODE_MAP.values():
+            raise ValueError(
+                "jesd_mode must be '8B10B' or '64B66B', got "
+                f"{self.jesd_mode}"
+            )
+        if self.tx is None and self.rx is None:
+            raise ValueError("at least one of tx or rx must be set")
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a detached JSON-compatible snapshot.
+
+        Returns:
+            Nested plain dictionary of all fields.
+        """
+        return asdict(self)
+
+    def to_json(self, *, indent: int = 2) -> str:
+        """Serialize the config deterministically.
+
+        Args:
+            indent: JSON indentation width.
+
+        Returns:
+            JSON document with sorted keys and a trailing newline.
+        """
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=True) + "\n"
+
+    def _project_params(self) -> List[Tuple[str, str]]:
+        """Build the ordered ``adi_xcvr_project`` parameter pairs.
+
+        The primary direction is TX when both directions exist, otherwise
+        whichever exists. ``XCVR_RX_*`` overrides are emitted individually
+        and only where the RX value differs from the primary.
+
+        Returns:
+            Ordered list of ``(key, value)`` string pairs.
+        """
+        primary = self.tx if self.tx is not None else self.rx
+        params = [
+            ("LANE_RATE", _fmt(primary.lane_rate_gbps)),
+            ("REF_CLK", _fmt(primary.ref_clk_mhz)),
+            ("PLL_TYPE", primary.pll_type),
+            ("JESD_MODE", self.jesd_mode),
+        ]
+        if self.tx is not None and self.rx is not None:
+            overrides = (
+                ("XCVR_RX_LANE_RATE", "lane_rate_gbps", _fmt),
+                ("XCVR_RX_REF_CLK", "ref_clk_mhz", _fmt),
+                ("XCVR_RX_PLL_TYPE", "pll_type", str),
+            )
+            for key, attr, render in overrides:
+                rx_value = getattr(self.rx, attr)
+                if rx_value != getattr(self.tx, attr):
+                    params.append((key, render(rx_value)))
+        return params
+
+    def to_make_args(self) -> str:
+        """Render the make-level ``KEY=value`` parameter overrides.
+
+        Returns:
+            Space-separated ``KEY=value`` string for an HDL project make.
+        """
+        return " ".join(f"{k}={v}" for k, v in self._project_params())
+
+    def to_make_command(self, project: str) -> str:
+        """Render a full make invocation for an HDL project.
+
+        Args:
+            project: HDL project path relative to ``projects/``, e.g.
+                ``"ad9081_fmca_ebz/zcu102"``.
+
+        Returns:
+            Complete ``make -C projects/<project> ...`` command line.
+        """
+        return f"make -C projects/{project} {self.to_make_args()}"
+
+    def to_tcl(self) -> str:
+        """Render a sourceable tcl snippet with the wizard parameters.
+
+        Defines ``adi_xcvr_project_args`` for ``adi_xcvr_project`` in
+        ``system_project.tcl`` and ``adi_xcvr_parameters_args`` (lane
+        counts) for ``adi_xcvr_parameters`` in the block design tcl.
+
+        Returns:
+            Tcl source text.
+        """
+        import adijif
+
+        lane_counts = []
+        if self.rx is not None:
+            lane_counts.append(("RX_NUM_OF_LANES", str(self.rx.num_lanes)))
+        if self.tx is not None:
+            lane_counts.append(("TX_NUM_OF_LANES", str(self.tx.num_lanes)))
+
+        lines = [f"# Generated by pyadi-jif {adijif.__version__}"]
+        for var, pairs in (
+            ("adi_xcvr_project_args", self._project_params()),
+            ("adi_xcvr_parameters_args", lane_counts),
+        ):
+            lines.append(f"set {var} [list \\")
+            lines.extend(f"  {k} {v} \\" for k, v in pairs)
+            lines.append("]")
+        return "\n".join(lines) + "\n"
+
+    @classmethod
+    def from_system_solution(
+        cls, system: Any, solution: Dict[str, Any]
+    ) -> "XgtWizardConfig":
+        """Map a solved single-converter system onto the xgt_wizard contract.
+
+        Args:
+            system: Solved :class:`adijif.system.system` instance. The FPGA
+                must have been configured via ``setup_by_dev_kit_name`` so
+                ``fpga.name`` matches the solution clock names.
+            solution: Result of :meth:`adijif.system.system.solve`.
+
+        Returns:
+            Frozen :class:`XgtWizardConfig` snapshot.
+
+        Raises:
+            ValueError: If the system has multiple converters, uses a PLL
+                the xgt_wizard flow does not support (Versal RPLL/LCPLL),
+                mixes JESD classes across directions, or a required ref
+                clock cannot be found in the solution.
+        """
+        converter = system.converter
+        if isinstance(converter, list):
+            raise ValueError(
+                "xgt_wizard export supports a single converter system"
+            )
+
+        nested = getattr(converter, "_nested", None)
+        if nested:
+            links = [(name, getattr(converter, name)) for name in nested]
+        else:
+            links = [(converter.name, converter)]
+
+        tx: Optional[XgtWizardLink] = None
+        rx: Optional[XgtWizardLink] = None
+        jesd_mode: Optional[str] = None
+        for name, child in links:
+            if f"fpga_{name}" not in solution:
+                continue
+            link, mode, direction = _extract_link(
+                system, solution, name, child
+            )
+            if jesd_mode is None:
+                jesd_mode = mode
+            elif jesd_mode != mode:
+                raise ValueError(
+                    "jesd_class differs between directions; xgt_wizard "
+                    "supports a single JESD_MODE"
+                )
+            if direction == "tx":
+                tx = link
+            else:
+                rx = link
+
+        if jesd_mode is None:
+            raise ValueError("solution contains no fpga_* link sections")
+        return cls(
+            jesd_mode=jesd_mode,
+            tx=tx,
+            rx=rx,
+            transceiver_type=getattr(system.fpga, "transceiver_type", None),
+        )
+
+
+def _extract_link(
+    system: Any, solution: Dict[str, Any], name: str, child: Any
+) -> Tuple[XgtWizardLink, str, str]:
+    """Build one direction's link parameters from the solution.
+
+    Args:
+        system: Solved system instance.
+        solution: Full solve result.
+        name: Link name used in ``fpga_{name}``/``jesd_{name}`` keys.
+        child: Converter object for this link (for ``converter_type``).
+
+    Returns:
+        Tuple of the link, the JESD mode string, and ``"tx"`` or ``"rx"``.
+
+    Raises:
+        ValueError: On unsupported PLL types, unknown ``jesd_class`` or
+            converter type, or a missing FPGA ref clock.
+    """
+    fpga_cfg = solution[f"fpga_{name}"]
+    jesd = solution[f"jesd_{name}"]
+
+    pll = _PLL_NAME_MAP.get(fpga_cfg["type"])
+    if pll is None:
+        raise ValueError(
+            f"xgt_wizard flow does not support PLL type "
+            f"'{fpga_cfg['type']}' (Versal is unsupported)"
+        )
+
+    jesd_class = jesd["jesd_class"].lower()
+    mode = _JESD_MODE_MAP.get(jesd_class)
+    if mode is None:
+        raise ValueError(f"unknown jesd_class: {jesd_class}")
+
+    converter_type = child.converter_type.lower()
+    if converter_type == "adc":
+        direction = "rx"
+    elif converter_type == "dac":
+        direction = "tx"
+    else:
+        raise ValueError(f"unsupported converter type: {converter_type}")
+
+    link = XgtWizardLink(
+        lane_rate_gbps=jesd["bit_clock"] / 1e9,
+        ref_clk_mhz=_find_ref_clk(system, solution, name) / 1e6,
+        pll_type=pll,
+        num_lanes=int(jesd["L"]),
+    )
+    return link, mode, direction
+
+
+def _find_ref_clk(
+    system: Any, solution: Dict[str, Any], name: str
+) -> float:
+    """Locate the FPGA reference clock rate for one link.
+
+    Args:
+        system: Solved system instance (``fpga.name`` prefixes the clock).
+        solution: Full solve result.
+        name: Link name (``{fpga.name}_{name}_ref_clk`` is expected).
+
+    Returns:
+        Reference clock rate in Hz.
+
+    Raises:
+        ValueError: If no matching output clock exists. Ensure the FPGA was
+            configured with ``setup_by_dev_kit_name`` so its name matches.
+    """
+    clocks = solution["clock"]["output_clocks"]
+    fpga_name = getattr(system.fpga, "name", "")
+    key = f"{fpga_name}_{name}_ref_clk"
+    if key in clocks:
+        return clocks[key]["rate"]
+    suffix = f"_{name}_ref_clk"
+    matches = [k for k in clocks if k.endswith(suffix)]
+    if len(matches) == 1:
+        return clocks[matches[0]]["rate"]
+    raise ValueError(
+        f"could not find FPGA ref clock '{key}' in output_clocks "
+        f"(available: {sorted(clocks)}); was the FPGA configured with "
+        "setup_by_dev_kit_name?"
+    )

--- a/adijif/mcp_server.py
+++ b/adijif/mcp_server.py
@@ -9,6 +9,7 @@ from fastmcp import FastMCP
 from adijif.agent_api import (
     _apply_config_recursively,
     _parse_vcxo,
+    export_xgt_wizard as _export_xgt_wizard,
     get_component_info as _get_component_info,
     list_components as _list_components,
     query_jesd_modes as _query_jesd_modes,
@@ -87,6 +88,28 @@ def create_mcp_server() -> FastMCP:
             ``contract``; otherwise an ``error`` string.
         """
         return _solve_system(system_config_json)
+
+    @mcp_instance.tool
+    def export_xgt_wizard(
+        system_config_json: str, hdl_project: str = ""
+    ) -> Dict[str, Any]:
+        """Solve a system and export HDL repo xgt_wizard build parameters.
+
+        Maps the solved transceiver configuration onto the ADI HDL repo's
+        ``adi_xcvr_project`` contract (``LANE_RATE``, ``REF_CLK``,
+        ``PLL_TYPE``, ``JESD_MODE``, and ``XCVR_RX_*`` overrides).
+
+        Args:
+            system_config_json: Same JSON configuration as ``solve_system``.
+            hdl_project: Optional HDL project path relative to
+                ``projects/`` (e.g. ``ad9081_fmca_ebz/zcu102``) to include
+                a full ``make_command``.
+
+        Returns:
+            ``status``, ``config``, ``make_args``, ``tcl``, and optionally
+            ``make_command`` on success; otherwise an ``error`` string.
+        """
+        return _export_xgt_wizard(system_config_json, hdl_project)
 
     return mcp_instance
 

--- a/adijif/system.py
+++ b/adijif/system.py
@@ -14,6 +14,7 @@ from typing import (
 )
 
 if TYPE_CHECKING:
+    from adijif.fpgas.xilinx.xgt_wizard import XgtWizardConfig
     from adijif.jif_dt import JifDtContract
 
 import numpy as np
@@ -426,23 +427,37 @@ class system(SystemPLL, system_draw):
 
     def export_config(
         self, *, format: str, solution: Optional[Dict] = None
-    ) -> "JifDtContract":
+    ) -> Union["JifDtContract", "XgtWizardConfig"]:
         """Export a solved system through a versioned interchange contract.
 
         Args:
-            format: Interchange format. Only ``"adi.jif-dt"`` is supported.
+            format: Interchange format. ``"adi.jif-dt"`` produces the
+                pyadi-dt handoff contract; ``"adi.xgt-wizard"`` produces
+                the ADI HDL repo xgt_wizard (adi_xcvr_project) parameters.
             solution: Existing :meth:`solve` result. When omitted, solve the
                 current system before exporting it.
 
         Returns:
-            Detached :class:`adijif.jif_dt.JifDtContract` snapshot.
+            Detached :class:`adijif.jif_dt.JifDtContract` or
+            :class:`adijif.fpgas.xilinx.xgt_wizard.XgtWizardConfig`
+            snapshot.
+
+        Raises:
+            ValueError: If ``format`` is not a supported export format.
         """
-        if format != "adi.jif-dt":
+        if format == "adi.jif-dt":
+            from adijif.jif_dt import JifDtContract
+
+            exporter = JifDtContract.from_system_solution
+        elif format == "adi.xgt-wizard":
+            from adijif.fpgas.xilinx.xgt_wizard import XgtWizardConfig
+
+            exporter = XgtWizardConfig.from_system_solution
+        else:
             raise ValueError(f"unsupported export format: {format}")
-        from adijif.jif_dt import JifDtContract
 
         solved = self.solve() if solution is None else solution
-        return JifDtContract.from_system_solution(self, solved)
+        return exporter(self, solved)
 
     def _apply_out_clock_constraints(
         self, clocks: ClocksBundle, out_clock_constraints: dict

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -136,6 +136,7 @@ mcp_server.md
 optimization.md
 finding_extreme_rates.md
 jif_dt.md
+xgt_wizard.md
 draw.md
 ```
 

--- a/doc/source/xgt_wizard.md
+++ b/doc/source/xgt_wizard.md
@@ -1,0 +1,73 @@
+# Export to the HDL repo xgt_wizard flow
+
+The [ADI HDL repository's xgt_wizard
+flow](https://analogdevicesinc.github.io/hdl/library/jesd204/xgt_wizard/index.html)
+automates Xilinx gigabit transceiver configuration. A project's
+`system_project.tcl` calls `adi_xcvr_project` with a flat parameter list
+(`LANE_RATE`, `REF_CLK`, `PLL_TYPE`, `JESD_MODE`, and optional `XCVR_RX_*`
+overrides), and the block design script passes lane counts through
+`adi_xcvr_parameters`. These parameters are also overridable at the make
+level, e.g. `make LANE_RATE=10 REF_CLK=250 PLL_TYPE=QPLL0`.
+
+pyadi-jif can map a solved system directly onto that contract with the
+`adi.xgt-wizard` export format, so no hand-edited tcl is needed:
+
+```python
+solution = system.solve()
+wizard = system.export_config(format="adi.xgt-wizard", solution=solution)
+print(wizard.to_make_command("ad9081_fmca_ebz/zcu102"))
+print(wizard.to_tcl())
+```
+
+Passing the existing `solution` avoids solving twice. If it is omitted,
+`export_config()` solves the current system first.
+
+## Solve and export an AD9081 + ZCU102 system
+
+The complete runnable example is checked by the normal example test suite:
+
+```{literalinclude} ../../examples/ad9081_zcu102_xgt_wizard.py
+:language: python
+:caption: examples/ad9081_zcu102_xgt_wizard.py
+```
+
+## What the exporter emits
+
+Three renderings of the same frozen `XgtWizardConfig` snapshot:
+
+- `to_make_command(project)` / `to_make_args()` — the exact make
+  invocation for an HDL project, e.g.
+  `make -C projects/ad9081_fmca_ebz/zcu102 LANE_RATE=23.925 REF_CLK=362.5
+  PLL_TYPE=QPLL1 JESD_MODE=64B66B XCVR_RX_LANE_RATE=11.9625`
+- `to_tcl()` — a sourceable snippet defining `adi_xcvr_project_args`
+  (for `adi_xcvr_project` in `system_project.tcl`) and
+  `adi_xcvr_parameters_args` (RX/TX lane counts for
+  `adi_xcvr_parameters` in the block design script)
+- `to_dict()` / `to_json()` — a structured snapshot for other tooling
+
+### Primary direction and RX overrides
+
+When both directions exist, TX is the primary direction: its lane rate,
+reference clock, and PLL fill `LANE_RATE`, `REF_CLK`, and `PLL_TYPE`.
+Each `XCVR_RX_*` override is emitted individually and only where the RX
+value differs from TX. Single-direction systems emit no overrides.
+
+## Supported scope
+
+- 7-series and UltraScale+ transceivers using `CPLL`, `QPLL0` (solver
+  type `qpll`), or `QPLL1`. Versal (`RPLL`/`LCPLL`) is rejected because
+  the xgt_wizard flow does not cover it.
+- The FPGA must be configured with `setup_by_dev_kit_name()` so the
+  solved clock names (`<carrier>_<link>_ref_clk`) can be located.
+- Note: the `ad9081_fmca_ebz/zcu102` HDL project has not yet adopted the
+  xgt_wizard flow (`daq2`, `daq3`, and `adrv9371x` carriers have). The
+  generated tcl variables are exactly what such a conversion sources.
+
+## Agent and MCP access
+
+The same export is available as the `export_xgt_wizard` operation for the
+`jifagent` CLI (`jifagent call export_xgt_wizard ...`) and the `jifmcp`
+MCP server. It accepts the same JSON system configuration as
+`solve_system` plus an optional `hdl_project` string, and returns the
+structured config, `make_args`, `tcl`, and (when `hdl_project` is given)
+`make_command`.

--- a/examples/ad9081_zcu102_xgt_wizard.py
+++ b/examples/ad9081_zcu102_xgt_wizard.py
@@ -1,0 +1,37 @@
+# Generate HDL repo xgt_wizard (adi_xcvr_project) parameters for
+# AD9081+ZCU102 from a solved configuration
+
+import adijif
+
+vcxo = 100e6
+cddc = 6
+fddc = 4
+
+sys = adijif.system("ad9081", "hmc7044", "xilinx", vcxo, solver="CPLEX")
+sys.fpga.setup_by_dev_kit_name("zcu102")
+sys.fpga.ref_clock_constraint = "Unconstrained"
+sys.fpga.sys_clk_select = "XCVR_QPLL0"  # Use faster QPLL
+sys.converter.clocking_option = "integrated_pll"
+sys.fpga.out_clk_select = "XCVR_PROGDIV_CLK"
+sys.converter.adc.sample_clock = 2900000000 / (cddc * fddc)
+sys.converter.dac.sample_clock = 5800000000 / (cddc * fddc)
+
+sys.converter.adc.datapath.cddc_decimations = [cddc] * 4
+sys.converter.adc.datapath.fddc_decimations = [fddc] * 8
+sys.converter.adc.datapath.fddc_enabled = [True] * 8
+sys.converter.dac.datapath.cduc_interpolation = cddc
+sys.converter.dac.datapath.fduc_interpolation = fddc
+sys.converter.dac.datapath.fduc_enabled = [True] * 8
+
+sys.converter.dac.set_quick_configuration_mode("0", "jesd204c")
+sys.converter.adc.set_quick_configuration_mode("1.0", "jesd204c")
+
+cfg = sys.solve()
+
+wiz = sys.export_config(format="adi.xgt-wizard", solution=cfg)
+
+print("# Build command for the ADI HDL repo:")
+print(wiz.to_make_command("ad9081_fmca_ebz/zcu102"))
+print()
+print("# Sourceable tcl for system_project.tcl / block design:")
+print(wiz.to_tcl())

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -24,6 +24,7 @@ def test_tools_describes_mcp_equivalent_operations():
         "query_jesd_modes",
         "get_component_info",
         "solve_system",
+        "export_xgt_wizard",
     ]
     assert tools[0]["input_schema"] == {
         "additionalProperties": False,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -35,6 +35,7 @@ async def test_list_tools(mcp_client: Client):
     tool_names = sorted([tool.name for tool in tools])  # Fixed: use tool.name
     assert tool_names == snapshot(
         [
+            "export_xgt_wizard",
             "get_component_info",
             "list_components",
             "query_jesd_modes",
@@ -404,3 +405,15 @@ async def test_solve_system_with_gekko_solver(mcp_client: Client):
     )
     assert "error" not in result.data
     assert result.data["status"] == "solved"
+
+
+@pytest.mark.asyncio
+async def test_export_xgt_wizard_invalid_json(mcp_client: Client):
+    """
+    Tests the 'export_xgt_wizard' tool with malformed JSON.
+    """
+    result = await mcp_client.call_tool(
+        "export_xgt_wizard", {"system_config_json": "{'conv':"}
+    )
+    assert "error" in result.data
+    assert "Invalid JSON string" in result.data["error"]

--- a/tests/test_xgt_wizard.py
+++ b/tests/test_xgt_wizard.py
@@ -1,0 +1,333 @@
+"""Tests for the Xilinx xgt_wizard (adi_xcvr_project) export."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+
+from adijif.fpgas.xilinx.xgt_wizard import XgtWizardConfig, XgtWizardLink
+from adijif.system import system as System
+
+
+def _fake_ad9081_zcu102():
+    """AD9081+ZCU102-shaped fake system and solution (real solve numbers)."""
+    converter = SimpleNamespace(
+        name="ad9081",
+        _nested=["adc", "dac"],
+        adc=SimpleNamespace(converter_type="adc"),
+        dac=SimpleNamespace(converter_type="dac"),
+    )
+    system = SimpleNamespace(
+        converter=converter,
+        fpga=SimpleNamespace(name="zcu102", transceiver_type="GTHE4"),
+    )
+    solution = {
+        "fpga_adc": {"type": "qpll1", "sys_clk_select": "XCVR_QPLL1"},
+        "jesd_adc": {
+            "bit_clock": 11_962_500_000.0,
+            "jesd_class": "jesd204c",
+            "L": 1,
+        },
+        "fpga_dac": {"type": "qpll", "sys_clk_select": "XCVR_QPLL0"},
+        "jesd_dac": {
+            "bit_clock": 23_925_000_000.0,
+            "jesd_class": "jesd204c",
+            "L": 4,
+        },
+        "clock": {
+            "output_clocks": {
+                "ad9081_ref_clk": {"rate": 580_000_000.0, "divider": 5},
+                "zcu102_adc_ref_clk": {"rate": 362_500_000.0, "divider": 8},
+                "zcu102_adc_device_clk": {
+                    "rate": 120_833_333.33,
+                    "divider": 24,
+                },
+                "zcu102_dac_ref_clk": {"rate": 362_500_000.0, "divider": 8},
+                "zcu102_dac_device_clk": {
+                    "rate": 241_666_666.67,
+                    "divider": 12,
+                },
+            }
+        },
+    }
+    return system, solution
+
+
+def _fake_ad9680_zc706():
+    """Flat single-direction (ADC only) fake system and solution."""
+    converter = SimpleNamespace(
+        name="AD9680", converter_type="adc", _nested=None
+    )
+    system = SimpleNamespace(
+        converter=converter,
+        fpga=SimpleNamespace(name="zc706", transceiver_type="GTXE2"),
+    )
+    solution = {
+        "fpga_AD9680": {"type": "qpll", "sys_clk_select": "XCVR_QPLL0"},
+        "jesd_AD9680": {
+            "bit_clock": 10_000_000_000.0,
+            "jesd_class": "jesd204b",
+            "L": 4,
+        },
+        "clock": {
+            "output_clocks": {
+                "AD9680_ref_clk": {"rate": 1_000_000_000.0, "divider": 3},
+                "zc706_AD9680_ref_clk": {
+                    "rate": 250_000_000.0,
+                    "divider": 12,
+                },
+                "zc706_AD9680_device_clk": {
+                    "rate": 250_000_000.0,
+                    "divider": 12,
+                },
+            }
+        },
+    }
+    return system, solution
+
+
+def test_nested_rxtx_mapping_extracts_both_directions():
+    system, solution = _fake_ad9081_zcu102()
+    cfg = XgtWizardConfig.from_system_solution(system, solution)
+
+    assert cfg.jesd_mode == "64B66B"
+    assert cfg.transceiver_type == "GTHE4"
+    assert cfg.rx == XgtWizardLink(
+        lane_rate_gbps=11.9625,
+        ref_clk_mhz=362.5,
+        pll_type="QPLL1",
+        num_lanes=1,
+    )
+    assert cfg.tx == XgtWizardLink(
+        lane_rate_gbps=23.925,
+        ref_clk_mhz=362.5,
+        pll_type="QPLL0",
+        num_lanes=4,
+    )
+
+
+def test_flat_single_direction_mapping_has_no_tx():
+    system, solution = _fake_ad9680_zc706()
+    cfg = XgtWizardConfig.from_system_solution(system, solution)
+
+    assert cfg.jesd_mode == "8B10B"
+    assert cfg.tx is None
+    assert cfg.rx == XgtWizardLink(
+        lane_rate_gbps=10.0,
+        ref_clk_mhz=250.0,
+        pll_type="QPLL0",
+        num_lanes=4,
+    )
+
+
+def test_cpll_maps_and_versal_plls_are_rejected():
+    system, solution = _fake_ad9680_zc706()
+    solution["fpga_AD9680"]["type"] = "cpll"
+    cfg = XgtWizardConfig.from_system_solution(system, solution)
+    assert cfg.rx.pll_type == "CPLL"
+
+    for pll in ("rpll", "lcpll"):
+        bad = deepcopy(solution)
+        bad["fpga_AD9680"]["type"] = pll
+        with pytest.raises(ValueError, match="not support"):
+            XgtWizardConfig.from_system_solution(system, bad)
+
+
+def test_jesd_class_mismatch_and_unknown_class_raise():
+    system, solution = _fake_ad9081_zcu102()
+    solution["jesd_adc"]["jesd_class"] = "jesd204b"
+    with pytest.raises(ValueError, match="jesd_class"):
+        XgtWizardConfig.from_system_solution(system, solution)
+
+    system2, solution2 = _fake_ad9680_zc706()
+    solution2["jesd_AD9680"]["jesd_class"] = "jesd204z"
+    with pytest.raises(ValueError, match="jesd_class"):
+        XgtWizardConfig.from_system_solution(system2, solution2)
+
+
+def test_multi_converter_systems_are_rejected():
+    system, solution = _fake_ad9680_zc706()
+    system.converter = [system.converter]
+    with pytest.raises(ValueError, match="single converter"):
+        XgtWizardConfig.from_system_solution(system, solution)
+
+
+def test_missing_ref_clk_raises_and_suffix_fallback_works():
+    system, solution = _fake_ad9680_zc706()
+    clocks = solution["clock"]["output_clocks"]
+    clocks["ZC706_AD9680_ref_clk"] = clocks.pop("zc706_AD9680_ref_clk")
+    cfg = XgtWizardConfig.from_system_solution(system, solution)
+    assert cfg.rx.ref_clk_mhz == 250.0
+
+    del solution["clock"]["output_clocks"]["ZC706_AD9680_ref_clk"]
+    with pytest.raises(ValueError, match="AD9680_ref_clk"):
+        XgtWizardConfig.from_system_solution(system, solution)
+
+
+def test_link_and_config_validation():
+    with pytest.raises(ValueError, match="pll_type"):
+        XgtWizardLink(
+            lane_rate_gbps=10.0, ref_clk_mhz=250.0, pll_type="QPLL9",
+            num_lanes=4,
+        )
+    with pytest.raises(ValueError, match="num_lanes"):
+        XgtWizardLink(
+            lane_rate_gbps=10.0, ref_clk_mhz=250.0, pll_type="CPLL",
+            num_lanes=0,
+        )
+    with pytest.raises(ValueError, match="positive"):
+        XgtWizardLink(
+            lane_rate_gbps=-1.0, ref_clk_mhz=250.0, pll_type="CPLL",
+            num_lanes=4,
+        )
+    with pytest.raises(ValueError, match="jesd_mode"):
+        XgtWizardConfig(jesd_mode="8b10b", tx=None, rx=None)
+    with pytest.raises(ValueError, match="tx or rx"):
+        XgtWizardConfig(jesd_mode="8B10B", tx=None, rx=None)
+
+
+def test_number_formatting_strips_trailing_zeros_and_noise():
+    from adijif.fpgas.xilinx.xgt_wizard import _fmt
+
+    assert _fmt(10.0) == "10"
+    assert _fmt(245.76) == "245.76"
+    assert _fmt(11.9625) == "11.9625"
+    assert _fmt(362.5) == "362.5"
+    assert _fmt(11.962500000001) == "11.9625"
+
+
+def test_make_renderers_emit_tx_primary_with_rx_overrides():
+    system, solution = _fake_ad9081_zcu102()
+    cfg = XgtWizardConfig.from_system_solution(system, solution)
+
+    assert cfg.to_make_args() == (
+        "LANE_RATE=23.925 REF_CLK=362.5 PLL_TYPE=QPLL0 JESD_MODE=64B66B "
+        "XCVR_RX_LANE_RATE=11.9625 XCVR_RX_PLL_TYPE=QPLL1"
+    )
+    assert cfg.to_make_command("ad9081_fmca_ebz/zcu102") == (
+        "make -C projects/ad9081_fmca_ebz/zcu102 "
+        "LANE_RATE=23.925 REF_CLK=362.5 PLL_TYPE=QPLL0 JESD_MODE=64B66B "
+        "XCVR_RX_LANE_RATE=11.9625 XCVR_RX_PLL_TYPE=QPLL1"
+    )
+
+
+def test_make_args_single_direction_has_no_overrides():
+    system, solution = _fake_ad9680_zc706()
+    cfg = XgtWizardConfig.from_system_solution(system, solution)
+    assert cfg.to_make_args() == (
+        "LANE_RATE=10 REF_CLK=250 PLL_TYPE=QPLL0 JESD_MODE=8B10B"
+    )
+
+
+def test_make_args_omits_overrides_matching_tx():
+    rx = XgtWizardLink(
+        lane_rate_gbps=10.0, ref_clk_mhz=250.0, pll_type="QPLL0", num_lanes=2
+    )
+    tx = XgtWizardLink(
+        lane_rate_gbps=10.0, ref_clk_mhz=250.0, pll_type="QPLL0", num_lanes=4
+    )
+    cfg = XgtWizardConfig(jesd_mode="8B10B", tx=tx, rx=rx)
+    assert cfg.to_make_args() == (
+        "LANE_RATE=10 REF_CLK=250 PLL_TYPE=QPLL0 JESD_MODE=8B10B"
+    )
+
+
+def test_tcl_renderer_defines_sourceable_variables():
+    system, solution = _fake_ad9081_zcu102()
+    cfg = XgtWizardConfig.from_system_solution(system, solution)
+    tcl = cfg.to_tcl()
+
+    assert tcl.startswith("# Generated by pyadi-jif")
+    assert (
+        "set adi_xcvr_project_args [list \\\n"
+        "  LANE_RATE 23.925 \\\n"
+        "  REF_CLK 362.5 \\\n"
+        "  PLL_TYPE QPLL0 \\\n"
+        "  JESD_MODE 64B66B \\\n"
+        "  XCVR_RX_LANE_RATE 11.9625 \\\n"
+        "  XCVR_RX_PLL_TYPE QPLL1 \\\n"
+        "]\n"
+    ) in tcl
+    assert (
+        "set adi_xcvr_parameters_args [list \\\n"
+        "  RX_NUM_OF_LANES 1 \\\n"
+        "  TX_NUM_OF_LANES 4 \\\n"
+        "]\n"
+    ) in tcl
+
+
+def test_tcl_renderer_single_direction_lane_counts():
+    system, solution = _fake_ad9680_zc706()
+    cfg = XgtWizardConfig.from_system_solution(system, solution)
+    tcl = cfg.to_tcl()
+    assert "RX_NUM_OF_LANES 4" in tcl
+    assert "TX_NUM_OF_LANES" not in tcl
+    assert "XCVR_RX_" not in tcl
+
+
+def test_to_json_round_trips():
+    system, solution = _fake_ad9081_zcu102()
+    cfg = XgtWizardConfig.from_system_solution(system, solution)
+    payload = json.loads(cfg.to_json())
+    assert payload == cfg.to_dict()
+    assert payload["rx"]["pll_type"] == "QPLL1"
+
+
+def test_export_config_dispatches_xgt_wizard_format():
+    fake_system, solution = _fake_ad9081_zcu102()
+    sys_obj = object.__new__(System)
+    sys_obj.converter = fake_system.converter
+    sys_obj.fpga = fake_system.fpga
+
+    cfg = sys_obj.export_config(format="adi.xgt-wizard", solution=solution)
+    assert isinstance(cfg, XgtWizardConfig)
+    assert cfg.tx.pll_type == "QPLL0"
+
+    with pytest.raises(ValueError, match="unsupported export format"):
+        sys_obj.export_config(format="raw-dict", solution=solution)
+
+
+def test_agent_export_xgt_wizard_operation(monkeypatch):
+    import adijif.agent_api as agent_api
+
+    fake_system, solution = _fake_ad9680_zc706()
+
+    class FakeSystem:
+        converter = fake_system.converter
+        fpga = fake_system.fpga
+        clock = SimpleNamespace(name="HMC7044")
+
+        def solve(self, out_clock_constraints):
+            return solution
+
+    monkeypatch.setattr(agent_api, "_system", lambda **kwargs: FakeSystem())
+    config = {"conv": "AD9680", "clk": "HMC7044", "fpga": "XILINX"}
+
+    result = agent_api.export_xgt_wizard(json.dumps(config))
+    assert result["status"] == "ok"
+    assert result["config"]["rx"]["pll_type"] == "QPLL0"
+    assert result["make_args"] == (
+        "LANE_RATE=10 REF_CLK=250 PLL_TYPE=QPLL0 JESD_MODE=8B10B"
+    )
+    assert "make_command" not in result
+    assert "set adi_xcvr_project_args" in result["tcl"]
+
+    with_project = agent_api.export_xgt_wizard(
+        json.dumps(config), hdl_project="daq2/zc706"
+    )
+    assert with_project["make_command"].startswith(
+        "make -C projects/daq2/zc706 "
+    )
+
+    assert "export_xgt_wizard" in agent_api.AGENT_OPERATIONS
+
+
+def test_agent_export_xgt_wizard_error_paths():
+    import adijif.agent_api as agent_api
+
+    assert "error" in agent_api.export_xgt_wizard("not json")
+    assert "must specify" in agent_api.export_xgt_wizard("{}")["error"]
+    assert "error" in agent_api.export_xgt_wizard(123)


### PR DESCRIPTION
## Summary

Adds an `adi.xgt-wizard` export that maps a solved pyadi-jif system onto the [ADI HDL repo xgt_wizard flow](https://analogdevicesinc.github.io/hdl/library/jesd204/xgt_wizard/index.html) (`adi_xcvr_project` / `adi_xcvr_parameters`), eliminating hand-edited tcl. First target: AD9081 + ZCU102.

## What it does

`XgtWizardConfig.from_system_solution()` (new `adijif/fpgas/xilinx/xgt_wizard.py`) joins the solved `fpga_*` (PLL type), `jesd_*` (lane rate, `jesd_class`, `L`), and `clock.output_clocks` (FPGA ref clk) sections into the `adi_xcvr_project` parameter set:

- `LANE_RATE` [Gbps], `REF_CLK` [MHz], `PLL_TYPE` (`CPLL`/`QPLL0`/`QPLL1`), `JESD_MODE` (`8B10B`/`64B66B`)
- TX is primary when both directions exist; `XCVR_RX_LANE_RATE`/`XCVR_RX_REF_CLK`/`XCVR_RX_PLL_TYPE` are emitted only where RX differs
- RX/TX lane counts for `adi_xcvr_parameters`
- Versal (RPLL/LCPLL) is rejected — the xgt_wizard flow does not cover it

Three renderers: `to_make_command("ad9081_fmca_ebz/zcu102")` / `to_make_args()`, `to_tcl()` (sourceable `adi_xcvr_project_args` + `adi_xcvr_parameters_args` variables), and `to_dict()`/`to_json()`.

Example output from the AD9081+ZCU102 example:

```
make -C projects/ad9081_fmca_ebz/zcu102 LANE_RATE=23.925 REF_CLK=362.5 PLL_TYPE=QPLL1 JESD_MODE=64B66B XCVR_RX_LANE_RATE=11.9625
```

## Surfaces

- `system.export_config(format="adi.xgt-wizard")` (alongside `adi.jif-dt`)
- New `export_xgt_wizard` agent operation, available via `jifagent call` and as a `jifmcp` MCP tool (same JSON config as `solve_system`, optional `hdl_project`)
- Runnable example `examples/ad9081_zcu102_xgt_wizard.py` (executed by the example test suite as a real-solver integration test)
- Feature documentation in `doc/source/xgt_wizard.md`

Parameter names and semantics were verified against `adi_xcvr_project` in the hdl repo (`projects/scripts/adi_project_xilinx.tcl`) and the daq2/zcu102 project. Note `ad9081_fmca_ebz/zcu102` has not yet adopted the xgt_wizard flow; the generated tcl variables are exactly what that conversion would source.

## Testing

- 17 new unit tests (`tests/test_xgt_wizard.py`, fake-system pattern, no solver) + MCP tool tests; new module at 97% coverage
- `solve_system` internals were extracted into `_parse_system_config`/`_solve_from_config` mechanically; existing agent/MCP tests unchanged and green
- Full suite: 905 passed; remaining failures are pre-existing/environmental (drawing-theme test fails identically on a clean tree; Streamlit e2e tests pass in isolation)