### PR TITLE
Hardware + Vivado build tests for the xgt_wizard export (AD9081+ZCU102)

### DIFF
--- a/.github/hw-nodes.json
+++ b/.github/hw-nodes.json
@@ -1,0 +1,35 @@
+[
+  {
+    "place": "nemo",
+    "runner_label": "hw-nemo",
+    "env_remote": "tests/hardware/env/nemo.yaml",
+    "tests": ["tests/hardware/test_hw_nemo_adrv9009.py"],
+    "extra_pytest_args": ["--run-hardware"],
+    "xilinx_board": "zynq",
+    "carrier": "zc706",
+    "board": "adrv9009",
+    "legs": ["coord"]
+  },
+  {
+    "place": "nuc",
+    "runner_label": "hw-nuc",
+    "env_remote": "tests/hardware/env/nuc.yaml",
+    "tests": ["tests/hardware/test_hw_nuc_fmcdaq3.py"],
+    "extra_pytest_args": ["--run-hardware"],
+    "xilinx_board": "microblaze",
+    "carrier": "vcu118",
+    "board": "fmcdaq3",
+    "legs": ["coord"]
+  },
+  {
+    "place": "bq",
+    "runner_label": "hw-bq",
+    "env_remote": "tests/hardware/env/bq.yaml",
+    "tests": ["tests/hardware/test_hw_bq_adrv9371.py"],
+    "extra_pytest_args": ["--run-hardware"],
+    "xilinx_board": "zynq",
+    "carrier": "zc706",
+    "board": "adrv9371",
+    "legs": ["coord"]
+  }
+]

--- a/.github/hw-nodes.json
+++ b/.github/hw-nodes.json
@@ -1,5 +1,19 @@
 [
   {
+    "place": "mini2",
+    "runner_label": "hw-bq",
+    "env_remote": "tests/hardware/env/mini2.yaml",
+    "tests": [
+      "tests/hardware/test_hw_mini2_ad9081.py",
+      "tests/hardware/test_hdl_xcvr_wizard_build.py"
+    ],
+    "extra_pytest_args": ["--run-hardware", "--run-hdl-build"],
+    "xilinx_board": "zynqmp",
+    "carrier": "zcu102",
+    "board": "ad9081",
+    "legs": ["coord"]
+  },
+  {
     "place": "nemo",
     "runner_label": "hw-nemo",
     "env_remote": "tests/hardware/env/nemo.yaml",

--- a/.github/workflows/hardware-tests.yml
+++ b/.github/workflows/hardware-tests.yml
@@ -1,0 +1,33 @@
+name: hardware-tests
+
+# Runs the pyadi-jif JESD hardware-validation tests on real ADI evaluation
+# boards in the lab. Each place in .github/hw-nodes.json fans out to its
+# self-hosted runner (hw-<place>), which acquires + boots the board via the
+# adi-labgrid-plugins strategy, then runs the per-board validation tests.
+#
+# Consumes the reusable hw-matrix workflow from adi-labgrid-plugins. The
+# coordinator defaults to vars.ADI_LG_COORDINATOR (10.0.0.41:20408).
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 7 * * *" # 07:00 UTC nightly
+
+permissions:
+  contents: read
+
+jobs:
+  hw:
+    uses: tfcollins/labgrid-plugins/.github/workflows/hw-matrix.yml@v1
+    with:
+      manifest_path: ".github/hw-nodes.json"
+      # CPLEX is required for the system-level solves; the hardware extra
+      # pulls in labgrid + paramiko for the DUT readers.
+      venv_install_cmd: >-
+        uv pip install --python "$VENV_DIR/bin/python" pytest
+        -e ".[cplex,hardware]"
+      pytest_cmd_template: >-
+        "$VENV_DIR/bin/pytest" -v $TESTS --run-hardware
+        --lg-coordinator "$LG_COORDINATOR" --junitxml="$JUNIT"
+      legs: "coord"
+    secrets: inherit

--- a/.github/workflows/hardware-tests.yml
+++ b/.github/workflows/hardware-tests.yml
@@ -26,8 +26,27 @@ jobs:
       venv_install_cmd: >-
         uv pip install --python "$VENV_DIR/bin/python" pytest
         -e ".[cplex,hardware]"
+      # Maintain a persistent ADI hdl checkout for the xcvr_wizard Vivado
+      # build test (mini2 leg, Vivado-capable hw-bq runner). HDL_DIR is
+      # exported to the pytest step via GITHUB_ENV; legs whose manifest
+      # entry doesn't list the hdl build test simply never use it.
+      pre_pytest_cmd: |
+        HDL_CACHE="$HOME/.cache/hw-ci/hdl"
+        if [ ! -d "$HDL_CACHE/.git" ]; then
+          git clone --depth 1 --branch main \
+            https://github.com/analogdevicesinc/hdl.git "$HDL_CACHE"
+        else
+          git -C "$HDL_CACHE" fetch --depth 1 origin main
+          git -C "$HDL_CACHE" reset --hard origin/main
+        fi
+        echo "HDL_DIR=$HDL_CACHE" >> "$GITHUB_ENV"
+      # --run-hdl-build only affects legs whose manifest lists the
+      # hdl_build-marked test file (mini2); it is inert elsewhere.
       pytest_cmd_template: >-
-        "$VENV_DIR/bin/pytest" -v $TESTS --run-hardware
+        "$VENV_DIR/bin/pytest" -v $TESTS --run-hardware --run-hdl-build
         --lg-coordinator "$LG_COORDINATOR" --junitxml="$JUNIT"
       legs: "coord"
+      # The mini2 leg runs board validation plus up to two GT wizard
+      # generations in Vivado.
+      timeout_minutes: 120
     secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+!tests/hardware/env/
 build/
 develop-eggs/
 dist/

--- a/adijif/__init__.py
+++ b/adijif/__init__.py
@@ -32,6 +32,7 @@ from adijif.converters.ad9152 import ad9152
 from adijif.converters.ad9371 import ad9371, ad9371_obs, ad9371_rx, ad9371_tx
 from adijif.converters.ad9680 import ad9680
 from adijif.converters.adrv9009 import adrv9009, adrv9009_rx, adrv9009_tx
+from adijif.converters.adrv9371 import adrv9371, adrv9371_rx, adrv9371_tx
 from adijif.fpgas.xilinx import xilinx
 from adijif.fpgas.xilinx.bf import xilinx_bf
 from adijif.jif_dt import (
@@ -69,6 +70,9 @@ AD9371_TX = ad9371_tx
 ADRV9009 = adrv9009
 ADRV9009_RX = adrv9009_rx
 ADRV9009_TX = adrv9009_tx
+ADRV9371 = adrv9371
+ADRV9371_RX = adrv9371_rx
+ADRV9371_TX = adrv9371_tx
 AD9523_1 = ad9523_1
 AD9528 = ad9528
 AD9545 = ad9545

--- a/adijif/converters/__init__.py
+++ b/adijif/converters/__init__.py
@@ -7,6 +7,8 @@ supported_parts = [
     "ad9371_tx",
     "adrv9009_rx",
     "adrv9009_tx",
+    "adrv9371_rx",
+    "adrv9371_tx",
     "ad9081_rx",
     "ad9081_tx",
     "ad9082_rx",

--- a/adijif/converters/adrv9371.py
+++ b/adijif/converters/adrv9371.py
@@ -1,0 +1,406 @@
+"""ADRV9371 (AD9371/AD9375 Mykonos) transceiver clocking model."""
+
+from abc import ABCMeta
+from typing import Any, Dict, List, Union
+
+import numpy as np
+
+from adijif.converters.adrv9009_bf import adrv9009_bf
+from adijif.converters.adrv9009_draw import adrv9009_rx_draw, adrv9009_tx_draw
+
+from ..solvers import (
+    GEKKO,
+    CpoModel,  # type: ignore # noqa: I202,BLK100
+    CpoSolveResult,
+)
+from .adc import adc
+from .adrv9371_util import (
+    _extra_jesd_check,
+    quick_configuration_modes_rx,  # type: ignore
+    quick_configuration_modes_tx,
+)
+from .converter import converter
+from .dac import dac
+
+# The AD9371 (Mykonos) is a JESD204B wideband transceiver. Its JESD clocking
+# follows the same relations as the ADRV9009 (Talise) family, so this model
+# reuses that structure while applying AD9371-specific rate limits (notably a
+# 6.144 Gbps maximum lane rate).
+
+
+class adrv9371_core(converter, metaclass=ABCMeta):
+    """ADRV9371 transceiver clocking model.
+
+    This model manages the JESD configuration and input clock constraints.
+    External LO constraints are not modeled.
+
+    Clocking: AD9371 uses onboard PLLs to generate the JESD clocks::
+
+        Lane Rate = I/Q Sample Rate * M * Np * (10 / 8) / L
+        Lane Rate = sample_clock * M * Np * (10 / 8) / L
+    """
+
+    device_clock_available = None  # FIXME
+    device_clock_ranges = None  # FIXME
+
+    name = "ADRV9371"
+
+    # JESD configurations
+    quick_configuration_modes = None  # FIXME
+    available_jesd_modes = ["jesd204b"]
+    M_available = [1, 2, 4]
+    L_available = [1, 2, 4]
+    N_available = [12, 16]
+    Np_available = [12, 16]
+    F_available = [1, 2, 3, 4, 8]
+    S_available = [1]
+    K_available = [*np.arange(1, 32 + 1)]
+    CS_available = [0]
+    CF_available = [0]
+
+    # Clock constraints
+    converter_clock_min = 25e6 * 8
+    converter_clock_max = 491.52e6 * 8
+
+    sample_clock_min = 25e6
+    sample_clock_max = 491520000
+
+    device_clock_min = 10e6
+    device_clock_max = 1e9
+
+    clocking_option_available = ["integrated_pll"]
+    _clocking_option = "integrated_pll"
+
+    # Divider ranges
+    input_clock_dividers_available = [1 / 2, 1, 2, 4, 8, 16]
+    input_clock_dividers_times2_available = [1, 2, 4, 8, 16, 32]
+
+    _lmfc_divisor_sysref_available = [*range(1, 20)]
+
+    # Unused
+    max_rx_sample_clock = 320e6
+    max_tx_sample_clock = 491.52e6
+    max_obs_sample_clock = 320e6
+
+    def _check_valid_internal_configuration(self) -> None:
+        # FIXME
+        pass
+
+    def get_required_clock_names(self) -> List[str]:
+        """Get list of strings of names of requested clocks.
+
+        This list of names is for the clocks defined by
+        get_required_clocks
+
+        Returns:
+            List[str]: List of strings of clock names mapped by get_required_clocks
+        """
+        return ["adrv9371_ref_clk", "adrv9371_sysref"]
+
+    def get_config(self, solution: CpoSolveResult = None) -> Dict:
+        """Extract configurations from solver results.
+
+        Collect internal converter configuration and output clock definitions
+        leading to connected devices (clock chips, FPGAs)
+
+        Args:
+            solution (CpoSolveResult): CPlex solution. Only needed for CPlex solver
+
+        Returns:
+            Dict: Dictionary of clocking rates and dividers for configuration
+        """
+        if solution:
+            self._solution = solution
+        return {}
+
+
+class adrv9371_clock_common(adrv9371_core, adrv9009_bf):
+    """ADRV9371 class managing common singleton (Rx,Tx) methods."""
+
+    def _check_valid_jesd_mode(self) -> None:
+        """Verify current JESD configuration for part is valid."""
+        _extra_jesd_check(self)
+        return super()._check_valid_jesd_mode()
+
+    def get_config(self, solution: CpoSolveResult = None) -> Dict:
+        """Extract configurations from solver results.
+
+        Collect internal converter configuration and output clock definitions
+        leading to connected devices (clock chips, FPGAs)
+
+        Args:
+            solution (CpoSolveResult): CPlex solution. Only needed for CPlex solver
+
+        Returns:
+            Dict: Dictionary of clocking rates and dividers for configuration
+        """
+        return {"clocking_option": self.clocking_option}
+
+    def _gekko_get_required_clocks(self) -> List[Dict]:
+        possible_sysrefs = []
+        for n in range(1, 20):
+            r = self.multiframe_clock / (n * n)
+            if r == int(r):
+                possible_sysrefs.append(r)
+
+        self.config = {"sysref": self.model.sos1(possible_sysrefs)}
+        self._add_objective(
+            self.config["sysref"],
+            sense="min",
+            tier=2,
+            name="adrv9371.sysref_min",
+        )
+
+        possible_device_clocks = []
+        for div in self.input_clock_dividers_available:
+            dev_clock = self.sample_clock / div
+            if self.device_clock_min <= dev_clock <= self.device_clock_max:
+                possible_device_clocks.append(dev_clock)
+
+        self.config["ref_clk"] = self.model.sos1(possible_device_clocks)
+
+        return [self.config["ref_clk"], self.config["sysref"]]
+
+    def get_required_clocks(self) -> List[Dict]:
+        """Generate list of required clocks.
+
+        For ADRV9371 this will contain:
+        [device clock requirement SOS, sysref requirement SOS]
+
+        Returns:
+            list[dict]: List of dictionaries of solver variables, equations, and constants
+        """
+        if self.solver == "gekko":
+            return self._gekko_get_required_clocks()
+        self.config = {}
+        self.config["lmfc_divisor_sysref"] = self._convert_input(
+            [*range(1, 20)], name="lmfc_divisor_sysref"
+        )
+
+        self.config["input_clock_divider_x2"] = self._convert_input(
+            self.input_clock_dividers_times2_available
+        )
+        self.config["ref_clk"] = self._add_intermediate(
+            self.sample_clock / self.config["input_clock_divider_x2"]
+        )
+        self.config["sysref"] = self._add_intermediate(
+            self.multiframe_clock
+            / (
+                self.config["lmfc_divisor_sysref"]
+                * self.config["lmfc_divisor_sysref"]
+            )
+        )
+
+        self._add_equation(
+            [
+                self.device_clock_min <= self.config["ref_clk"],
+                self.config["ref_clk"] <= self.device_clock_max,
+            ]
+        )
+
+        return [self.config["ref_clk"], self.config["sysref"]]
+
+
+class adrv9371_rx(adrv9009_rx_draw, adc, adrv9371_clock_common, adrv9371_core):
+    """ADRV9371 Receive model."""
+
+    quick_configuration_modes = {"jesd204b": quick_configuration_modes_rx}
+    name = "ADRV9371_RX"
+    converter_type = "adc"
+
+    # JESD configurations
+    K_available = [*np.arange(1, 32 + 1)]
+    L_available = [1, 2, 4]
+    M_available = [1, 2, 4]
+    N_available = [12, 16]
+    Np_available = [12, 16]
+    F_available = [1, 2, 3, 4, 6, 8]
+    CS_available = [0]
+    CF_available = [0]
+    S_available = [1]
+
+    # Clock constraints
+    bit_clock_min_available = {"jesd204b": 614.4e6}
+    bit_clock_max_available = {"jesd204b": 6.144e9}
+
+    _decimation = 4
+    decimation_available = [2, 3, 4, 5, 6, 8, 12, 16, 18, 24, 32]
+    """AD9371 Rx decimation stages (programmable filter chain)."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
+        """Initialize ADRV9371-RX class.
+
+        Objects will default to mode and sample_clock.
+
+        Args:
+            *args (Any): Pass through arguments
+            **kwargs (Any): Pass through keyword arguments
+        """
+        # Set default mode (M=2, L=2, Np=16)
+        self.set_quick_configuration_mode(str(3))
+        self.sample_clock = int(122.88e6)
+        super().__init__(*args, **kwargs)
+
+    def get_required_clock_names(self) -> List[str]:
+        """Get list of strings of names of requested clocks.
+
+        This list of names is for the clocks defined by
+        get_required_clocks
+
+        Returns:
+            List[str]: List of strings of clock names mapped by get_required_clocks
+        """
+        return ["adrv9371_rx_ref_clk", "adrv9371_rx_sysref"]
+
+
+class adrv9371_tx(adrv9009_tx_draw, dac, adrv9371_clock_common, adrv9371_core):
+    """ADRV9371 Transmit model."""
+
+    quick_configuration_modes = {"jesd204b": quick_configuration_modes_tx}
+    name = "ADRV9371_TX"
+    converter_type = "dac"
+
+    # JESD configurations
+    K_available = [*np.arange(1, 32 + 1)]
+    L_available = [1, 2, 4]
+    M_available = [1, 2]
+    N_available = [12, 16]
+    Np_available = [12, 16]
+    F_available = [1, 2, 3, 4, 8]
+    CS_available = [0]
+    CF_available = [0]
+    S_available = [1]
+
+    # Clock constraints
+    bit_clock_min_available = {"jesd204b": 614.4e6}
+    bit_clock_max_available = {"jesd204b": 6.144e9}
+
+    _interpolation = 4
+    interpolation_available = [1, 2, 4, 5, 8, 16, 32]
+    """AD9371 Tx interpolation stages (programmable filter chain)."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
+        """Initialize ADRV9371-TX class.
+
+        Objects will default to mode and sample_clock.
+
+        Args:
+            *args (Any): Pass through arguments
+            **kwargs (Any): Pass through keyword arguments
+        """
+        # Set default mode (M=2, L=2, Np=16)
+        self.set_quick_configuration_mode(str(3))
+        self.sample_clock = int(122.88e6)
+        super().__init__(*args, **kwargs)
+
+    def get_required_clock_names(self) -> List[str]:
+        """Get list of strings of names of requested clocks.
+
+        This list of names is for the clocks defined by
+        get_required_clocks
+
+        Returns:
+            List[str]: List of strings of clock names mapped by get_required_clocks
+        """
+        return ["adrv9371_tx_ref_clk", "adrv9371_tx_sysref"]
+
+
+class adrv9371(adrv9371_core):
+    """ADRV9371 combined transmit and receive model."""
+
+    name = "ADRV9371"
+    solver = "CPLEX"
+    _nested = ["adc", "dac"]
+    converter_type = "adc_dac"
+
+    def __init__(
+        self, model: Union[GEKKO, CpoModel] = None, solver: str = None
+    ) -> None:
+        """Initialize ADRV9371 clocking model for TX and RX.
+
+        This is a common class used to handle TX and RX constraints
+        together.
+
+        Args:
+            model (GEKKO,CpoModel): Solver model
+            solver (str): Solver name (gekko or CPLEX)
+        """
+        if solver:
+            self.solver = solver
+        self.adc = adrv9371_rx(model, solver=self.solver)
+        self.dac = adrv9371_tx(model, solver=self.solver)
+        self.model = model
+
+    def validate_config(self) -> None:
+        """Validate device configurations including JESD and clocks of both ADC and DAC.
+
+        This check only is for static configuration that does not include
+        variables which are solved.
+        """
+        self.adc.validate_config()
+        self.dac.validate_config()
+
+    def _get_converters(self) -> List[Union[converter, converter]]:
+        return [self.adc, self.dac]
+
+    def get_required_clocks(self) -> List[Dict]:
+        """Generate list of required clocks.
+
+        For ADRV9371 this will contain:
+        [device clock requirement SOS, sysref requirement SOS]
+
+        Returns:
+            list[dict]: List of dictionaries of solver variables, equations, and constants
+
+        Raises:
+            Exception: Invalid relation of rates between RX and TX
+        """
+        # Validate sample rates feasible
+        if self.dac.sample_clock / self.adc.sample_clock not in [
+            1,
+            2,
+            4,
+        ] or self.adc.sample_clock / self.dac.sample_clock not in [1, 2, 4]:
+            raise Exception(
+                "ADRV9371 RX and TX sample rates must be related by power of 2"
+            )
+
+        if self.solver == "gekko":
+            raise AssertionError
+
+        self.config = {}
+        self.config["adc_lmfc_divisor_sysref"] = self._convert_input(
+            self._lmfc_divisor_sysref_available, name="adc_lmfc_divisor_sysref"
+        )
+        self.config["dac_lmfc_divisor_sysref"] = self._convert_input(
+            self._lmfc_divisor_sysref_available, name="dac_lmfc_divisor_sysref"
+        )
+
+        self.config["input_clock_divider_x2"] = self._convert_input(
+            self.input_clock_dividers_times2_available
+        )
+
+        faster_clk = max([self.adc.sample_clock, self.dac.sample_clock])
+        self.config["ref_clk"] = self._add_intermediate(
+            faster_clk / self.config["input_clock_divider_x2"]
+        )
+
+        self.config["sysref_adc"] = self._add_intermediate(
+            self.adc.multiframe_clock / self.config["adc_lmfc_divisor_sysref"]
+        )
+        self.config["sysref_dac"] = self._add_intermediate(
+            self.dac.multiframe_clock / self.config["dac_lmfc_divisor_sysref"]
+        )
+
+        self._add_equation(
+            [
+                self.device_clock_min <= self.config["ref_clk"],
+                self.config["ref_clk"] <= self.device_clock_max,
+            ]
+        )
+
+        return [
+            self.config["ref_clk"],
+            self.config["sysref_adc"],
+            self.config["sysref_dac"],
+        ]

--- a/adijif/converters/adrv9371.py
+++ b/adijif/converters/adrv9371.py
@@ -263,7 +263,8 @@ class adrv9371_tx(adrv9009_tx_draw, dac, adrv9371_clock_common, adrv9371_core):
     # JESD configurations
     K_available = [*np.arange(1, 32 + 1)]
     L_available = [1, 2, 4]
-    M_available = [1, 2]
+    # M=4 covers two complex (I/Q) Tx channels, the zc706 reference framing.
+    M_available = [1, 2, 4]
     N_available = [12, 16]
     Np_available = [12, 16]
     F_available = [1, 2, 3, 4, 8]

--- a/adijif/converters/adrv9371_util.py
+++ b/adijif/converters/adrv9371_util.py
@@ -1,0 +1,67 @@
+"""ADRV9371 (AD9371/AD9375 Mykonos) Utility Functions."""
+
+from typing import Dict, Union
+
+from adijif.converters.converter import converter
+
+
+def _convert_to_config(
+    L: Union[int, float],
+    M: Union[int, float],
+    Np: Union[int, float],
+    S: Union[int, float] = 1,
+) -> Dict:
+    return {
+        "L": L,
+        "M": M,
+        "F": Np / 8 * M * S / L,
+        "S": S,
+        "HD": (
+            1
+            if (M == 1 and L == 2 and S == 1)
+            or (M == 2 and L == 4 and S == 1)
+            or (M == 1 and L == 4 and S == 2)
+            else 0
+        ),
+        "Np": Np,
+        "N": Np,
+        "CS": 0,
+        "CF": 0,
+        "K": 32,  # THIS IS A SUGGESTED VALUE
+    }
+
+
+# AD9371 transmit (Tx) JESD204B framer modes. The AD9371 supports up to two
+# transmit channels (M up to 2) at Np=16.
+quick_configuration_modes_tx = {
+    # M = 1
+    str(0): _convert_to_config(M=1, L=1, Np=16),
+    str(1): _convert_to_config(M=1, L=2, Np=16),
+    # M = 2
+    str(2): _convert_to_config(M=2, L=1, Np=16),
+    str(3): _convert_to_config(M=2, L=2, Np=16),
+    str(4): _convert_to_config(M=2, L=4, Np=16),
+}
+
+
+# AD9371 receive (Rx) JESD204B deframer modes. Covers the main Rx path (up to
+# two channels) and the observation/sniffer paths.
+quick_configuration_modes_rx = {
+    # M = 1
+    str(0): _convert_to_config(M=1, L=1, S=1, Np=16),
+    str(1): _convert_to_config(M=1, L=2, S=1, Np=16),
+    # M = 2
+    str(2): _convert_to_config(M=2, L=1, S=1, Np=16),
+    str(3): _convert_to_config(M=2, L=2, S=1, Np=16),
+    str(4): _convert_to_config(M=2, L=4, S=1, Np=16),
+    # Np = 12 variants (compressed)
+    str(5): _convert_to_config(M=2, L=2, S=1, Np=12),
+    str(6): _convert_to_config(M=2, L=4, S=1, Np=12),
+}
+
+
+def _extra_jesd_check(dev: converter) -> None:
+    FK = dev.F * dev.K
+    assert FK <= 256, "F x K must be <= 256"
+    assert FK >= 20, "F x K must be >= 20"
+    assert FK % 4 == 0, "F x K must be a multiple of 4"

--- a/adijif/converters/adrv9371_util.py
+++ b/adijif/converters/adrv9371_util.py
@@ -31,8 +31,11 @@ def _convert_to_config(
     }
 
 
-# AD9371 transmit (Tx) JESD204B framer modes. The AD9371 supports up to two
-# transmit channels (M up to 2) at Np=16.
+# AD9371 transmit (Tx) JESD204B framer modes. The AD9371 has two transmitters;
+# JESD204 counts the I and Q rails of each complex channel as separate
+# converters, so the two Tx channels present as M=4 (the framing used by the
+# Kuiper zynq-zc706-adv7511-adrv937x reference: M=4 L=4 Np=16 -> F=2). M=1/2
+# modes cover single-channel / real-only configurations.
 quick_configuration_modes_tx = {
     # M = 1
     str(0): _convert_to_config(M=1, L=1, Np=16),
@@ -41,11 +44,16 @@ quick_configuration_modes_tx = {
     str(2): _convert_to_config(M=2, L=1, Np=16),
     str(3): _convert_to_config(M=2, L=2, Np=16),
     str(4): _convert_to_config(M=2, L=4, Np=16),
+    # M = 4 (two complex Tx channels, I+Q)
+    str(5): _convert_to_config(M=4, L=2, Np=16),  # F=4
+    str(6): _convert_to_config(M=4, L=4, Np=16),  # F=2 (zc706 reference)
 }
 
 
-# AD9371 receive (Rx) JESD204B deframer modes. Covers the main Rx path (up to
-# two channels) and the observation/sniffer paths.
+# AD9371 receive (Rx) JESD204B deframer modes. Like Tx, JESD204 counts the I/Q
+# rails of each complex channel separately, so the two main Rx channels present
+# as M=4 (the Kuiper zynq-zc706-adv7511-adrv937x reference main-Rx framing:
+# M=4 L=2 Np=16 -> F=4). The observation/sniffer path runs as M=2 (mode "3").
 quick_configuration_modes_rx = {
     # M = 1
     str(0): _convert_to_config(M=1, L=1, S=1, Np=16),
@@ -57,6 +65,9 @@ quick_configuration_modes_rx = {
     # Np = 12 variants (compressed)
     str(5): _convert_to_config(M=2, L=2, S=1, Np=12),
     str(6): _convert_to_config(M=2, L=4, S=1, Np=12),
+    # M = 4 (two complex Rx channels, I+Q)
+    str(7): _convert_to_config(M=4, L=2, S=1, Np=16),  # F=4 (zc706 reference)
+    str(8): _convert_to_config(M=4, L=4, S=1, Np=16),  # F=2
 }
 
 

--- a/adijif/converters/adrv9371_util.py
+++ b/adijif/converters/adrv9371_util.py
@@ -62,12 +62,11 @@ quick_configuration_modes_rx = {
     str(2): _convert_to_config(M=2, L=1, S=1, Np=16),
     str(3): _convert_to_config(M=2, L=2, S=1, Np=16),
     str(4): _convert_to_config(M=2, L=4, S=1, Np=16),
-    # Np = 12 variants (compressed)
-    str(5): _convert_to_config(M=2, L=2, S=1, Np=12),
-    str(6): _convert_to_config(M=2, L=4, S=1, Np=12),
+    # Np = 12 variants were dropped: at S=1 they produce fractional F
+    # (M*S*Np/(8L) = 1.5 / 0.75), which is not legal JESD204B framing.
     # M = 4 (two complex Rx channels, I+Q)
-    str(7): _convert_to_config(M=4, L=2, S=1, Np=16),  # F=4 (zc706 reference)
-    str(8): _convert_to_config(M=4, L=4, S=1, Np=16),  # F=2
+    str(5): _convert_to_config(M=4, L=2, S=1, Np=16),  # F=4 (zc706 reference)
+    str(6): _convert_to_config(M=4, L=4, S=1, Np=16),  # F=2
 }
 
 

--- a/adijif/registry.py
+++ b/adijif/registry.py
@@ -29,6 +29,7 @@ from adijif.converters.ad9152 import ad9152
 from adijif.converters.ad9371 import ad9371, ad9371_obs, ad9371_rx, ad9371_tx
 from adijif.converters.ad9680 import ad9680
 from adijif.converters.adrv9009 import adrv9009, adrv9009_rx, adrv9009_tx
+from adijif.converters.adrv9371 import adrv9371, adrv9371_rx, adrv9371_tx
 from adijif.converters.converter import converter
 from adijif.fpgas.fpga import fpga
 from adijif.fpgas.xilinx import xilinx
@@ -65,6 +66,9 @@ COMPONENT_REGISTRY: Dict[str, Dict[str, ComponentType]] = {
             adrv9009,
             adrv9009_rx,
             adrv9009_tx,
+            adrv9371,
+            adrv9371_rx,
+            adrv9371_tx,
         )
     },
     "clock": {

--- a/doc/source/xgt_wizard.md
+++ b/doc/source/xgt_wizard.md
@@ -37,8 +37,8 @@ Three renderings of the same frozen `XgtWizardConfig` snapshot:
 
 - `to_make_command(project)` / `to_make_args()` — the exact make
   invocation for an HDL project, e.g.
-  `make -C projects/ad9081_fmca_ebz/zcu102 LANE_RATE=23.925 REF_CLK=362.5
-  PLL_TYPE=QPLL1 JESD_MODE=64B66B XCVR_RX_LANE_RATE=11.9625`
+  `make -C projects/ad9081_fmca_ebz/zcu102 LANE_RATE=11.9625 REF_CLK=362.5
+  PLL_TYPE=QPLL1 JESD_MODE=64B66B`
 - `to_tcl()` — a sourceable snippet defining `adi_xcvr_project_args`
   (for `adi_xcvr_project` in `system_project.tcl`) and
   `adi_xcvr_parameters_args` (RX/TX lane counts for

--- a/docs/superpowers/specs/2026-06-05-hardware-jesd-tests-design.md
+++ b/docs/superpowers/specs/2026-06-05-hardware-jesd-tests-design.md
@@ -1,0 +1,85 @@
+# Hardware validation tests for JESD systems via labgrid
+
+Date: 2026-06-05
+
+## Goal
+
+Validate that pyadi-jif's computed JESD link + clock-tree configurations match
+what real ADI evaluation systems report when booted, for every JESD-based place
+on the labgrid coordinator at `10.0.0.41`.
+
+JESD-based places discovered on the coordinator:
+
+| Place  | Carrier | Daughterboard | JESD parts            | pyadi-jif model |
+|--------|---------|---------------|-----------------------|-----------------|
+| nemo   | zc706   | adrv9009      | ADRV9009              | exists          |
+| nuc    | vcu118  | daq3 (fmcdaq3)| AD9680 + AD9152       | exists          |
+| bq     | zc706   | adrv9371      | ADRV9371 (AD9371)     | **must be added** |
+
+`mini2` (ADRV9002, LVDS/CMOS) is intentionally out of scope — it is not a JESD
+device.
+
+## Scope
+
+1. Add an **ADRV9371** converter model to pyadi-jif (it does not exist yet),
+   modeled by analogy to the existing ADRV9009 model.
+2. Build a **hardware test layer** under `tests/hardware/` that uses labgrid +
+   `adi_lg_plugins` to acquire/boot a place and read JESD/clock truth from the
+   booted DUT over SSH.
+3. Per-board **validation tests** that build the equivalent `adijif.system`,
+   constrain it with the hardware-measured sample rate + JESD mode, solve, and
+   assert pyadi-jif's computed lane rate / reference clock match hardware and
+   that the JESD link is up.
+
+## Architecture
+
+### ADRV9371 model — `adijif/converters/adrv9371.py`
+
+- `adrv9371_rx` (adc), `adrv9371_tx` (dac), and combined `adrv9371` classes,
+  mirroring the ADRV9009 class hierarchy.
+- Clocking equation identical in form to ADRV9009:
+  `Lane Rate = sample_clock * M * Np * (10/8) / L`, integrated-PLL clocking.
+- AD9371 (Mykonos) specific limits: JESD204B only, max lane rate 6.144 Gbps.
+- Quick-configuration mode tables generated the same way as ADRV9009.
+- Registered in `adijif/converters/__init__.py` (`supported_parts`) and exported
+  from `adijif/__init__.py`.
+- Unit tests in `tests/test_adrv9371.py` mirroring `tests/test_adrv9009.py`, so
+  the model is covered even without hardware.
+
+### Hardware test layer — `tests/hardware/`
+
+- `conftest.py` — registers `--run-hardware` and `--lg-env` options plus the
+  `hardware` marker (matching the labgrid-plugins convention), and a `dut`
+  fixture that acquires the labgrid `RemotePlace`, ensures power/boot, waits for
+  SSH, and yields a connection handle. Skips cleanly if the board is
+  unreachable.
+- `dut.py` — SSH helper (`root@<NetworkService address>` / `analog`) that reads
+  hardware truth: `sampling_frequency` (IIO sysfs), JESD lane rate + link state
+  from the `axi-jesd204-{rx,tx}` `status` node, and device/ref clock from
+  `/sys/kernel/debug/clk/clk_summary`. Returns a normalized dataclass.
+- `env/{nemo,nuc,bq}.yaml` — `RemotePlace` env yamls pointed at the coordinator.
+
+### Per-board validation tests
+
+- `test_hw_nemo_adrv9009.py`, `test_hw_nuc_fmcdaq3.py`, `test_hw_bq_adrv9371.py`.
+- Each: read HW facts -> build `adijif.system(...)` with the board's FPGA dev
+  kit -> constrain with HW sample rate + JESD mode -> `solve()` -> assert
+  pyadi-jif's `bit_clock` (lane rate) and reference/device clock equal the
+  HW-measured values, and assert the JESD link is up.
+
+### Packaging
+
+- New optional extra `hardware = [labgrid, adi-labgrid-plugins, paramiko]`.
+- Hardware tests are `@pytest.mark.hardware` and skipped unless `--run-hardware`
+  is given, so default CI is unaffected.
+
+## Approach notes / trade-offs
+
+- Hardware truth is read over SSH from sysfs/debugfs rather than via pyadi-iio:
+  fewer dependencies, and the `axi-jesd204` status node is the authoritative
+  source for lane rate + link state. L/M/F/S readback is best-effort; firm
+  assertions are on rates + link state, which the DUT reports reliably.
+- Tests live in pyadi-jif (not labgrid-plugins) because they validate pyadi-jif
+  models; labgrid-plugins is consumed as a library for boot/acquire plumbing.
+- Tests power-cycle their own board via the labgrid strategy and skip gracefully
+  when hardware is unavailable, so a run is never blocked by board state.

--- a/examples/ad9081_zcu102_xgt_wizard.py
+++ b/examples/ad9081_zcu102_xgt_wizard.py
@@ -23,7 +23,9 @@ sys.converter.dac.datapath.cduc_interpolation = cddc
 sys.converter.dac.datapath.fduc_interpolation = fddc
 sys.converter.dac.datapath.fduc_enabled = [True] * 8
 
-sys.converter.dac.set_quick_configuration_mode("0", "jesd204c")
+# TX mode 4 (L=2 M=8 Np=12) and RX mode 1.0 both solve to 11.9625 Gbps,
+# inside the GTHE4 line-rate range on the ZCU102.
+sys.converter.dac.set_quick_configuration_mode("4", "jesd204c")
 sys.converter.adc.set_quick_configuration_mode("1.0", "jesd204c")
 
 cfg = sys.solve()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ e2e = [
     "inline-snapshot",
 ]
 mcp = ["fastmcp", "pytest-asyncio", "inline-snapshot"]
+hardware = ["labgrid>=25.0", "paramiko>=3.0"]
 
 
 [project.scripts]

--- a/tests/hardware/__init__.py
+++ b/tests/hardware/__init__.py
@@ -1,0 +1,9 @@
+"""Hardware-in-the-loop validation tests for pyadi-jif JESD models.
+
+These tests boot (or attach to) real ADI evaluation systems exposed by a
+labgrid coordinator, read the JESD link + clock facts the running hardware
+reports, and assert that pyadi-jif's solver reproduces those facts.
+
+They are marked ``@pytest.mark.hardware`` and skipped unless ``--run-hardware``
+is given. See ``conftest.py`` for options.
+"""

--- a/tests/hardware/conftest.py
+++ b/tests/hardware/conftest.py
@@ -15,9 +15,13 @@ Local invocation::
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from .dut import DUT, coordinator_place_address
+
+_DEFAULT_COORDINATOR = os.environ.get("LG_COORDINATOR", "10.0.0.41:20408")
 
 
 def pytest_addoption(parser):
@@ -31,8 +35,19 @@ def pytest_addoption(parser):
     group.addoption(
         "--lg-coordinator",
         action="store",
-        default="10.0.0.41:20408",
-        help="labgrid coordinator host:port advertising the DUT places.",
+        default=_DEFAULT_COORDINATOR,
+        help="labgrid coordinator host:port (default: $LG_COORDINATOR or "
+        "10.0.0.41:20408).",
+    )
+    # Accepted for compatibility with the adi-labgrid-plugins HW-CI contract,
+    # which passes a rendered RemotePlace env via --lg-config. The fixture
+    # resolves the DUT address from the coordinator directly, so this is
+    # currently informational only.
+    group.addoption(
+        "--lg-config",
+        action="store",
+        default=None,
+        help="Path to a labgrid RemotePlace env yaml (HW-CI compatibility).",
     )
 
 

--- a/tests/hardware/conftest.py
+++ b/tests/hardware/conftest.py
@@ -19,9 +19,18 @@ import os
 
 import pytest
 
-from .dut import DUT, coordinator_place_address
+from .dut import DUT, resolve_board_address
 
 _DEFAULT_COORDINATOR = os.environ.get("LG_COORDINATOR", "10.0.0.41:20408")
+
+# Stable per-board MAC addresses, used to rediscover a board's current DHCP IP
+# when the coordinator's NetworkService address has drifted from the board's
+# lease (see :func:`hardware.dut.resolve_board_address`). A MAC is a durable
+# identifier; the DHCP-assigned IP is not. Places absent here simply rely on the
+# coordinator address (legacy behaviour).
+PLACE_BOARD_MAC = {
+    "bq": "00:0a:35:00:01:22",  # zc706 + ADRV9371 (Xilinx GEM)
+}
 
 
 def pytest_addoption(parser):
@@ -88,10 +97,12 @@ def dut(request, coordinator) -> DUT:
     if place is None:
         pytest.fail("dut fixture requires an indirect 'place' parameter")
 
-    address = coordinator_place_address(place, coordinator)
+    address = resolve_board_address(
+        place, coordinator, mac=PLACE_BOARD_MAC.get(place)
+    )
     if not address:
         pytest.skip(
-            f"could not resolve NetworkService address for place '{place}' "
+            f"could not resolve an address for place '{place}' "
             f"on coordinator {coordinator}"
         )
 

--- a/tests/hardware/conftest.py
+++ b/tests/hardware/conftest.py
@@ -1,0 +1,93 @@
+"""Pytest fixtures/options for pyadi-jif hardware-in-the-loop tests.
+
+Mirrors the adi-labgrid-plugins convention: hardware tests are gated behind
+``--run-hardware`` and target a labgrid coordinator. Each per-board test asks
+for the ``dut`` fixture via an indirect ``place`` parameter; the fixture
+resolves the place's booted address from the coordinator and opens SSH,
+skipping cleanly when the board is unreachable (e.g. powered off).
+
+Local invocation::
+
+    pytest --run-hardware tests/hardware/ -v
+    pytest --run-hardware --lg-coordinator 10.0.0.41:20408 \
+        tests/hardware/test_hw_nuc_fmcdaq3.py -v
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .dut import DUT, coordinator_place_address
+
+
+def pytest_addoption(parser):
+    group = parser.getgroup("pyadi-jif-hardware")
+    group.addoption(
+        "--run-hardware",
+        action="store_true",
+        default=False,
+        help="Run tests that require real hardware on the labgrid coordinator.",
+    )
+    group.addoption(
+        "--lg-coordinator",
+        action="store",
+        default="10.0.0.41:20408",
+        help="labgrid coordinator host:port advertising the DUT places.",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "hardware: mark test as requiring real hardware (labgrid)"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run-hardware"):
+        return
+    skip_hw = pytest.mark.skip(reason="need --run-hardware option to run")
+    for item in items:
+        # Use the marker (not item.keywords, which also contains the directory
+        # name "hardware" and would skip every test under tests/hardware/).
+        if item.get_closest_marker("hardware") is not None:
+            item.add_marker(skip_hw)
+
+
+@pytest.fixture
+def coordinator(request) -> str:
+    """The labgrid coordinator host:port under test."""
+    return request.config.getoption("--lg-coordinator")
+
+
+@pytest.fixture
+def dut(request, coordinator) -> DUT:
+    """Resolve and connect to a booted DUT for the requested ``place``.
+
+    Parametrize indirectly::
+
+        @pytest.mark.parametrize("dut", ["nemo"], indirect=True)
+
+    Skips when the place address cannot be resolved or SSH fails (board down).
+    """
+    place = getattr(request, "param", None)
+    if place is None:
+        pytest.fail("dut fixture requires an indirect 'place' parameter")
+
+    address = coordinator_place_address(place, coordinator)
+    if not address:
+        pytest.skip(
+            f"could not resolve NetworkService address for place '{place}' "
+            f"on coordinator {coordinator}"
+        )
+
+    handle = DUT(address)
+    try:
+        handle.connect()
+    except Exception as exc:  # noqa: BLE001 - any SSH failure means board is down
+        pytest.skip(
+            f"DUT '{place}' at {address} unreachable ({exc!r}); "
+            "board likely powered off / not booted"
+        )
+
+    yield handle
+    handle.close()

--- a/tests/hardware/conftest.py
+++ b/tests/hardware/conftest.py
@@ -48,6 +48,13 @@ def pytest_addoption(parser):
         help="labgrid coordinator host:port (default: $LG_COORDINATOR or "
         "10.0.0.41:20408).",
     )
+    group.addoption(
+        "--run-hdl-build",
+        action="store_true",
+        default=False,
+        help="Run tests that launch Vivado HDL builds (needs HDL_DIR and "
+        "vivado on PATH).",
+    )
     # Accepted for compatibility with the adi-labgrid-plugins HW-CI contract,
     # which passes a rendered RemotePlace env via --lg-config. The fixture
     # resolves the DUT address from the coordinator directly, so this is
@@ -64,17 +71,27 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "hardware: mark test as requiring real hardware (labgrid)"
     )
+    config.addinivalue_line(
+        "markers",
+        "hdl_build: mark test as launching a Vivado HDL build (xcvr_wizard)",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--run-hardware"):
-        return
-    skip_hw = pytest.mark.skip(reason="need --run-hardware option to run")
-    for item in items:
-        # Use the marker (not item.keywords, which also contains the directory
-        # name "hardware" and would skip every test under tests/hardware/).
-        if item.get_closest_marker("hardware") is not None:
-            item.add_marker(skip_hw)
+    gates = (
+        ("hardware", "--run-hardware"),
+        ("hdl_build", "--run-hdl-build"),
+    )
+    for marker, option in gates:
+        if config.getoption(option):
+            continue
+        skip = pytest.mark.skip(reason=f"need {option} option to run")
+        for item in items:
+            # Use the marker (not item.keywords, which also contains the
+            # directory name "hardware" and would skip every test under
+            # tests/hardware/).
+            if item.get_closest_marker(marker) is not None:
+                item.add_marker(skip)
 
 
 @pytest.fixture

--- a/tests/hardware/conftest.py
+++ b/tests/hardware/conftest.py
@@ -15,6 +15,7 @@ Local invocation::
 
 from __future__ import annotations
 
+import argparse
 import os
 
 import pytest
@@ -35,36 +36,56 @@ PLACE_BOARD_MAC = {
 
 def pytest_addoption(parser):
     group = parser.getgroup("pyadi-jif-hardware")
-    group.addoption(
-        "--run-hardware",
-        action="store_true",
-        default=False,
-        help="Run tests that require real hardware on the labgrid coordinator.",
+    # When labgrid is installed (the [hardware] extra), its pytest plugin
+    # already registers some lg-* options; re-registering raises. Skip any
+    # option another plugin owns — the fixtures read them by name either way.
+    options = (
+        (
+            ("--run-hardware",),
+            {
+                "action":"store_true",
+                "default": False,
+                "help": "Run tests that require real hardware on the labgrid "
+                "coordinator.",
+            },
+        ),
+        (
+            ("--lg-coordinator",),
+            {
+                "action":"store",
+                "default": _DEFAULT_COORDINATOR,
+                "help": "labgrid coordinator host:port (default: "
+                "$LG_COORDINATOR or 10.0.0.41:20408).",
+            },
+        ),
+        (
+            ("--run-hdl-build",),
+            {
+                "action":"store_true",
+                "default": False,
+                "help": "Run tests that launch Vivado HDL builds (needs "
+                "HDL_DIR and vivado on PATH).",
+            },
+        ),
+        # Accepted for compatibility with the adi-labgrid-plugins HW-CI
+        # contract, which passes a rendered RemotePlace env via --lg-config.
+        # The fixture resolves the DUT address from the coordinator
+        # directly, so this is currently informational only.
+        (
+            ("--lg-config",),
+            {
+                "action":"store",
+                "default": None,
+                "help": "Path to a labgrid RemotePlace env yaml (HW-CI "
+                "compatibility).",
+            },
+        ),
     )
-    group.addoption(
-        "--lg-coordinator",
-        action="store",
-        default=_DEFAULT_COORDINATOR,
-        help="labgrid coordinator host:port (default: $LG_COORDINATOR or "
-        "10.0.0.41:20408).",
-    )
-    group.addoption(
-        "--run-hdl-build",
-        action="store_true",
-        default=False,
-        help="Run tests that launch Vivado HDL builds (needs HDL_DIR and "
-        "vivado on PATH).",
-    )
-    # Accepted for compatibility with the adi-labgrid-plugins HW-CI contract,
-    # which passes a rendered RemotePlace env via --lg-config. The fixture
-    # resolves the DUT address from the coordinator directly, so this is
-    # currently informational only.
-    group.addoption(
-        "--lg-config",
-        action="store",
-        default=None,
-        help="Path to a labgrid RemotePlace env yaml (HW-CI compatibility).",
-    )
+    for args, kwargs in options:
+        try:
+            group.addoption(*args, **kwargs)
+        except (argparse.ArgumentError, ValueError):
+            pass
 
 
 def pytest_configure(config):
@@ -96,8 +117,14 @@ def pytest_collection_modifyitems(config, items):
 
 @pytest.fixture
 def coordinator(request) -> str:
-    """The labgrid coordinator host:port under test."""
-    return request.config.getoption("--lg-coordinator")
+    """The labgrid coordinator host:port under test.
+
+    When labgrid's own pytest plugin owns ``--lg-coordinator`` its default
+    may be empty; fall back to the lab default in that case.
+    """
+    return (
+        request.config.getoption("--lg-coordinator") or _DEFAULT_COORDINATOR
+    )
 
 
 @pytest.fixture

--- a/tests/hardware/dut.py
+++ b/tests/hardware/dut.py
@@ -5,6 +5,10 @@ and unit-tested on its own. It provides:
 
 * :func:`coordinator_place_address` -- resolve the ``NetworkService`` IP a
   labgrid coordinator advertises for a place.
+* :func:`resolve_board_address` -- a reachable SSH address for a place, using
+  the coordinator hint when live and otherwise rediscovering the board's
+  current DHCP IP from its stable MAC (the exporter's static address can drift
+  from the board's lease).
 * :class:`DUT` -- a thin SSH wrapper (paramiko) that reads the authoritative
   ``axi-jesd204`` link status and IIO sample rates from the running board.
 * :func:`parse_jesd_status` -- parse the kernel ``axi-jesd204-*`` ``status``
@@ -102,6 +106,97 @@ def parse_jesd_status(text: str) -> JesdLinkStatus:
         st.sysref_captured = m.group(1).lower() == "yes"
 
     return st
+
+
+def parse_neigh_for_mac(neigh_output: str, mac: str) -> Optional[str]:
+    """Return the IPv4 address mapped to ``mac`` in ``ip neigh`` output.
+
+    Parses lines like ``10.0.0.128 dev enp2s0 lladdr 00:0a:35:00:01:22 STALE``.
+    IPv6 entries and entries without an ``lladdr`` (e.g. ``FAILED``) are
+    ignored. Matching is case-insensitive. Returns ``None`` if not found.
+    """
+    want = mac.lower()
+    for line in neigh_output.splitlines():
+        parts = line.split()
+        if not parts or "lladdr" not in parts:
+            continue
+        ip = parts[0]
+        if ":" in ip:  # skip IPv6 neighbor entries
+            continue
+        lladdr = parts[parts.index("lladdr") + 1].lower()
+        if lladdr == want:
+            return ip
+    return None
+
+
+def _tcp_open(host: str, port: int = 22, timeout: float = 3.0) -> bool:
+    """True if a TCP connection to ``host:port`` succeeds within ``timeout``."""
+    import socket
+
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def discover_ip_by_mac(
+    mac: str, subnet: str = "10.0.0.0/24", _runner=None
+) -> Optional[str]:
+    """Find a host's current IPv4 by its (stable) MAC via the neighbor table.
+
+    Reads the local ``ip neigh`` table first; if the MAC is not present, primes
+    ARP with a bounded parallel ping sweep of ``subnet`` (so a freshly-booted
+    board appears) and re-reads. Must run on a host on the board's L2 segment
+    (the ``hw-<place>`` runners are). ``_runner`` injects a command runner for
+    tests.
+
+    Returns the discovered IPv4 string, or ``None``.
+    """
+    run = _runner or _run_shell
+    ip = parse_neigh_for_mac(run("ip neigh"), mac)
+    if ip:
+        return ip
+    base = subnet.split("/", 1)[0].rsplit(".", 1)[0]
+    run(
+        f"for i in $(seq 1 254); do ping -c1 -W1 {base}.$i "
+        ">/dev/null 2>&1 & done; wait"
+    )
+    return parse_neigh_for_mac(run("ip neigh"), mac)
+
+
+def _run_shell(cmd: str) -> str:
+    try:
+        return subprocess.run(
+            ["bash", "-c", cmd], capture_output=True, text=True, timeout=30
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return ""
+
+
+def resolve_board_address(
+    place: str,
+    coordinator: str = "10.0.0.41:20408",
+    mac: Optional[str] = None,
+    subnet: str = "10.0.0.0/24",
+) -> Optional[str]:
+    """Resolve a reachable SSH address for ``place``'s booted board.
+
+    The coordinator's ``NetworkService`` address is a *hint* that can go stale
+    when the board's DHCP lease differs from the exporter's static config. So:
+    use that address if it is reachable; otherwise, if ``mac`` is known,
+    rediscover the board's current IP from the neighbor table (the MAC is a
+    stable identifier, unlike the DHCP-assigned IP). Falls back to the (possibly
+    unreachable) hint so the caller can surface a clear skip.
+    """
+    hint = coordinator_place_address(place, coordinator)
+    if hint and _tcp_open(hint):
+        return hint
+    if mac:
+        found = discover_ip_by_mac(mac, subnet)
+        if found and _tcp_open(found):
+            return found
+    return hint
 
 
 def coordinator_place_address(

--- a/tests/hardware/dut.py
+++ b/tests/hardware/dut.py
@@ -87,7 +87,9 @@ def parse_jesd_status(text: str) -> JesdLinkStatus:
     if m:
         st.lane_rate_hz = _to_hz(m.group(1), m.group(2))
 
-    m = re.search(r"(?:Measured|Reported) Link Clock:\s*([\d.]+)\s*([kKmMgG]?Hz)", text)
+    m = re.search(
+        r"(?:Measured|Reported) Link Clock:\s*([\d.]+)\s*([kKmMgG]?Hz)", text
+    )
     if m:
         st.link_clock_hz = _to_hz(m.group(1), m.group(2))
 
@@ -250,3 +252,69 @@ class DUT:
             'cat "$dev/name" 2>/dev/null; done'
         )
         return [n for n in out.splitlines() if n.strip()]
+
+    def jesd_framing(self) -> Dict[str, Dict[str, object]]:
+        """Read per-link JESD framing from the booted device tree.
+
+        The ``axi-jesd204`` driver's ``status`` node reports lane *rate* but not
+        the converter framing, and a lane rate alone does not pin M and L
+        independently (only the ratio). The device tree the board booted with
+        carries the authoritative framing, so this reads the ``adi,*`` framing
+        cells directly from ``/proc/device-tree``.
+
+        Returns:
+            Mapping of jesd node name -> dict with any of ``role`` ('rx'/'tx'),
+            ``F`` (octets-per-frame), ``K`` (frames-per-multiframe), ``M``
+            (converters-per-device), ``Np`` (bits-per-sample), ``N``
+            (converter-resolution). Keys are present only when the node carries
+            them (e.g. M/Np/N are typically only on the Tx framer node).
+        """
+        # For each device-tree node whose `compatible` mentions axi-jesd204,
+        # emit the node basename, its compatible, and each framing property as
+        # hex bytes (decoded big-endian below). Kept to one round trip.
+        prop_map = {
+            "adi,octets-per-frame": "F",
+            "adi,frames-per-multiframe": "K",
+            "adi,converters-per-device": "M",
+            "adi,bits-per-sample": "Np",
+            "adi,converter-resolution": "N",
+        }
+        script = (
+            "for c in $(grep -rl axi-jesd204 /proc/device-tree 2>/dev/null "
+            "| grep compatible); do "
+            'node=$(dirname "$c"); '
+            'echo "===$(basename $node)==="; '
+            'echo "compatible=$(tr -d "\\000" < "$c")"; '
+            "for p in " + " ".join(prop_map) + "; do "
+            '[ -e "$node/$p" ] && echo "$p=$(od -An -tx1 "$node/$p" '
+            '| tr -d " \\n")"; '
+            "done; "
+            "done"
+        )
+        out = self.cmd(script)
+        result: Dict[str, Dict[str, object]] = {}
+        cur: Optional[Dict[str, object]] = None
+        for line in out.splitlines():
+            m = re.match(r"===(.+)===", line)
+            if m:
+                cur = {}
+                result[m.group(1).strip()] = cur
+                continue
+            if cur is None or "=" not in line:
+                continue
+            key, _, val = line.partition("=")
+            if key == "compatible":
+                cur["role"] = (
+                    "tx"
+                    if "jesd204-tx" in val
+                    else ("rx" if "jesd204-rx" in val else "?")
+                )
+                continue
+            if key in prop_map and val:
+                try:
+                    cur[prop_map[key]] = int(
+                        val[:8], 16
+                    )  # first u32, big-endian
+                except ValueError:
+                    continue
+        return result

--- a/tests/hardware/dut.py
+++ b/tests/hardware/dut.py
@@ -1,0 +1,252 @@
+"""Read JESD + clock facts from a booted ADI Linux DUT.
+
+This module is intentionally free of any pyadi-jif imports so it can be reused
+and unit-tested on its own. It provides:
+
+* :func:`coordinator_place_address` -- resolve the ``NetworkService`` IP a
+  labgrid coordinator advertises for a place.
+* :class:`DUT` -- a thin SSH wrapper (paramiko) that reads the authoritative
+  ``axi-jesd204`` link status and IIO sample rates from the running board.
+* :func:`parse_jesd_status` -- parse the kernel ``axi-jesd204-*`` ``status``
+  text into a :class:`JesdLinkStatus` (kept separate so it is testable without
+  hardware).
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass
+class JesdLinkStatus:
+    """Normalized view of one ``axi-jesd204-{rx,tx}`` link.
+
+    Rates are stored in hertz. ``enabled``/``data`` capture link state.
+    """
+
+    enabled: Optional[bool] = None
+    data: Optional[bool] = None  # link reached DATA phase
+    lane_rate_hz: Optional[float] = None
+    link_clock_hz: Optional[float] = None
+    lmfc_rate_hz: Optional[float] = None
+    sysref_captured: Optional[bool] = None
+    raw: str = ""
+
+    @property
+    def up(self) -> bool:
+        """True when the link is enabled and (if reported) in the DATA phase."""
+        if not self.enabled:
+            return False
+        # Some driver versions don't print a link status line; treat missing
+        # DATA as "don't know" rather than failure.
+        return self.data is not False
+
+
+_UNIT_HZ = {"hz": 1.0, "khz": 1e3, "mhz": 1e6, "ghz": 1e9}
+
+
+def _to_hz(value: str, unit: str) -> float:
+    return float(value) * _UNIT_HZ[unit.strip().lower()]
+
+
+def parse_jesd_status(text: str) -> JesdLinkStatus:
+    """Parse ``axi-jesd204-{rx,tx}`` ``status`` sysfs text.
+
+    The ADI ``axi-jesd204`` driver prints a human-readable block such as::
+
+        Link is enabled
+        Measured Link Clock: 122.880 MHz
+        Reported Link Clock: 122.880 MHz
+        Lane rate: 4915.200 MHz
+        Lane rate / 40: 122.880 MHz
+        LMFC rate: 3.840 MHz
+        Link status: DATA
+        SYSREF captured: Yes
+
+    Args:
+        text: Raw contents of the ``status`` node.
+
+    Returns:
+        JesdLinkStatus: Parsed status (fields left ``None`` when not present).
+    """
+    st = JesdLinkStatus(raw=text)
+
+    if re.search(r"Link is enabled", text, re.IGNORECASE):
+        st.enabled = True
+    elif re.search(r"Link is disabled", text, re.IGNORECASE):
+        st.enabled = False
+
+    m = re.search(r"Link status:\s*(\w+)", text, re.IGNORECASE)
+    if m:
+        st.data = m.group(1).upper() == "DATA"
+
+    m = re.search(r"Lane rate:\s*([\d.]+)\s*([kKmMgG]?Hz)", text)
+    if m:
+        st.lane_rate_hz = _to_hz(m.group(1), m.group(2))
+
+    m = re.search(r"(?:Measured|Reported) Link Clock:\s*([\d.]+)\s*([kKmMgG]?Hz)", text)
+    if m:
+        st.link_clock_hz = _to_hz(m.group(1), m.group(2))
+
+    m = re.search(r"LMFC rate:\s*([\d.]+)\s*([kKmMgG]?Hz)", text)
+    if m:
+        st.lmfc_rate_hz = _to_hz(m.group(1), m.group(2))
+
+    m = re.search(r"SYSREF captured:\s*(Yes|No)", text, re.IGNORECASE)
+    if m:
+        st.sysref_captured = m.group(1).lower() == "yes"
+
+    return st
+
+
+def coordinator_place_address(
+    place: str, coordinator: str = "10.0.0.41:20408"
+) -> Optional[str]:
+    """Resolve the ``NetworkService`` address a coordinator advertises for a place.
+
+    Uses the ``labgrid-client`` CLI (already installed alongside the
+    coordinator) rather than the labgrid Python API so that resolution works
+    even when the board is not acquired.
+
+    Args:
+        place: Coordinator place name (e.g. ``"nemo"``).
+        coordinator: ``host:port`` of the labgrid coordinator.
+
+    Returns:
+        The advertised IP address as a string, or ``None`` if it cannot be
+        resolved (place unknown, coordinator unreachable, no NetworkService).
+    """
+    try:
+        out = subprocess.run(
+            ["labgrid-client", "-x", coordinator, "-p", place, "show"],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+    in_ns = False
+    for line in out.splitlines():
+        if "NetworkService" in line:
+            in_ns = True
+        if in_ns:
+            m = re.search(r"'address':\s*'([^']+)'", line)
+            if m:
+                return m.group(1)
+    return None
+
+
+@dataclass
+class DUT:
+    """SSH handle to a booted ADI Linux board for reading JESD/clock facts."""
+
+    address: str
+    username: str = "root"
+    password: str = "analog"
+    _client: object = field(default=None, repr=False)
+
+    def connect(self, timeout: float = 10.0) -> "DUT":
+        """Open the SSH connection. Raises on failure (caller decides to skip)."""
+        import paramiko
+
+        client = paramiko.SSHClient()
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        client.connect(
+            self.address,
+            username=self.username,
+            password=self.password,
+            timeout=timeout,
+            allow_agent=False,
+            look_for_keys=False,
+        )
+        self._client = client
+        return self
+
+    def close(self) -> None:
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+    def cmd(self, command: str, timeout: float = 20.0) -> str:
+        """Run a shell command on the DUT and return stdout (stderr appended)."""
+        assert self._client is not None, "DUT not connected"
+        _in, out, err = self._client.exec_command(command, timeout=timeout)
+        stdout = out.read().decode(errors="replace")
+        stderr = err.read().decode(errors="replace")
+        return (stdout + stderr).strip()
+
+    # -- JESD / clock readers -------------------------------------------------
+
+    def jesd_status(self) -> Dict[str, JesdLinkStatus]:
+        """Read every ``axi-jesd204-*`` link's ``status`` node.
+
+        Returns:
+            Mapping of device name (e.g. ``"axi-jesd204-rx"``) to parsed status.
+        """
+        # Enumerate the jesd device dirs, then cat each status node tagged with
+        # its name so the output is unambiguous.
+        script = (
+            "for d in /sys/bus/platform/devices/*axi-jesd204-*; do "
+            '[ -e "$d/status" ] || continue; '
+            'echo "===$(basename $d)==="; cat "$d/status"; '
+            "done"
+        )
+        out = self.cmd(script)
+        result: Dict[str, JesdLinkStatus] = {}
+        if not out:
+            return result
+        # re.split with a capturing group yields [pre, name1, body1, name2, ...]
+        parts = re.split(r"===([^=]+)===", out)
+        for i in range(1, len(parts), 2):
+            name = parts[i].strip()
+            body = parts[i + 1] if i + 1 < len(parts) else ""
+            # Strip a trailing 'axi-XXXX.' prefix down to the role suffix.
+            short = re.sub(r"^[0-9a-fx]+\.", "", name)
+            result[short] = parse_jesd_status(body)
+        return result
+
+    def sampling_frequencies(self) -> Dict[str, float]:
+        """Read IIO sampling frequencies (Hz) keyed by device name.
+
+        Returns the first ``*sampling_frequency`` attribute found per device.
+        """
+        script = (
+            "for dev in /sys/bus/iio/devices/iio:device*; do "
+            'name=$(cat "$dev/name" 2>/dev/null); '
+            'f=$(cat "$dev"/*sampling_frequency 2>/dev/null | head -n1); '
+            '[ -n "$f" ] && echo "$name $f"; '
+            "done"
+        )
+        out = self.cmd(script)
+        freqs: Dict[str, float] = {}
+        for line in out.splitlines():
+            bits = line.split()
+            if len(bits) >= 2:
+                try:
+                    freqs[bits[0]] = float(bits[-1])
+                except ValueError:
+                    continue
+        return freqs
+
+    def clock_summary(self) -> Dict[str, float]:
+        """Parse ``/sys/kernel/debug/clk/clk_summary`` into name -> rate (Hz)."""
+        out = self.cmd("cat /sys/kernel/debug/clk/clk_summary 2>/dev/null")
+        rates: Dict[str, float] = {}
+        for line in out.splitlines():
+            cols = line.split()
+            # Columns: clk_name flags enable_cnt prepare_cnt protect_cnt rate ...
+            if len(cols) >= 6 and cols[5].lstrip("-").isdigit():
+                rates[cols[0].lstrip()] = float(cols[5])
+        return rates
+
+    def iio_device_names(self) -> List[str]:
+        """List IIO device names present on the DUT."""
+        out = self.cmd(
+            "for dev in /sys/bus/iio/devices/iio:device*; do "
+            'cat "$dev/name" 2>/dev/null; done'
+        )
+        return [n for n in out.splitlines() if n.strip()]

--- a/tests/hardware/dut.py
+++ b/tests/hardware/dut.py
@@ -256,6 +256,12 @@ class DUT:
         import paramiko
 
         client = paramiko.SSHClient()
+        # Validate against known hosts where possible, but auto-accept
+        # unknown keys: lab DUTs are reflashed constantly, so their host
+        # keys churn and strict checking would permanently skip the tests.
+        # Test-only code on the private lab network (CodeQL alert #12
+        # dismissed for this reason).
+        client.load_system_host_keys()
         client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         client.connect(
             self.address,

--- a/tests/hardware/dut.py
+++ b/tests/hardware/dut.py
@@ -37,6 +37,7 @@ class JesdLinkStatus:
     link_clock_hz: Optional[float] = None
     lmfc_rate_hz: Optional[float] = None
     sysref_captured: Optional[bool] = None
+    encoding: Optional[str] = None  # "8B10B" | "64B66B" when reported
     raw: str = ""
 
     @property
@@ -100,6 +101,10 @@ def parse_jesd_status(text: str) -> JesdLinkStatus:
     m = re.search(r"LMFC rate:\s*([\d.]+)\s*([kKmMgG]?Hz)", text)
     if m:
         st.lmfc_rate_hz = _to_hz(m.group(1), m.group(2))
+
+    m = re.search(r"Lane rate\s*/\s*(40|66)\b", text)
+    if m:
+        st.encoding = "8B10B" if m.group(1) == "40" else "64B66B"
 
     m = re.search(r"SYSREF captured:\s*(Yes|No)", text, re.IGNORECASE)
     if m:

--- a/tests/hardware/dut.py
+++ b/tests/hardware/dut.py
@@ -172,8 +172,12 @@ def discover_ip_by_mac(
 
 def _run_shell(cmd: str) -> str:
     try:
-        return subprocess.run(
-            ["bash", "-c", cmd], capture_output=True, text=True, timeout=30
+        # Fixed local diagnostic commands (ip neigh/ping); no user input.
+        return subprocess.run(  # noqa: S603
+            ["bash", "-c", cmd],  # noqa: S607
+            capture_output=True,
+            text=True,
+            timeout=30,
         ).stdout
     except (OSError, subprocess.SubprocessError):
         return ""
@@ -222,8 +226,9 @@ def coordinator_place_address(
         resolved (place unknown, coordinator unreachable, no NetworkService).
     """
     try:
-        out = subprocess.run(
-            ["labgrid-client", "-x", coordinator, "-p", place, "show"],
+        # Fixed labgrid-client query; place/coordinator come from CI config.
+        out = subprocess.run(  # noqa: S603
+            ["labgrid-client", "-x", coordinator, "-p", place, "show"],  # noqa: S607, E501
             capture_output=True,
             text=True,
             timeout=20,
@@ -248,7 +253,7 @@ class DUT:
 
     address: str
     username: str = "root"
-    password: str = "analog"
+    password: str = "analog"  # noqa: S105 - Kuiper image default login
     _client: object = field(default=None, repr=False)
 
     def connect(self, timeout: float = 10.0) -> "DUT":
@@ -262,7 +267,9 @@ class DUT:
         # Test-only code on the private lab network (CodeQL alert #12
         # dismissed for this reason).
         client.load_system_host_keys()
-        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        client.set_missing_host_key_policy(
+            paramiko.AutoAddPolicy()  # noqa: S507 - see comment above
+        )
         client.connect(
             self.address,
             username=self.username,

--- a/tests/hardware/env/bq.yaml
+++ b/tests/hardware/env/bq.yaml
@@ -1,0 +1,17 @@
+# labgrid coordinator (RemotePlace) env for the 'bq' DUT:
+#   zc706 carrier + ADRV9371 (AD9371 JESD204B transceiver).
+#
+# Optional for the pyadi-jif hardware tests (they resolve the booted IP from the
+# coordinator and read over SSH). Provided for the labgrid boot path.
+# Set LG_COORDINATOR=10.0.0.41:20408.
+imports:
+  - adi_lg_plugins
+
+targets:
+  main:
+    resources:
+      RemotePlace:
+        name: bq
+    drivers:
+      SerialDriver: {}
+      SSHDriver: {}

--- a/tests/hardware/env/mini2.yaml
+++ b/tests/hardware/env/mini2.yaml
@@ -1,0 +1,17 @@
+# labgrid coordinator (RemotePlace) env for the 'mini2' DUT:
+#   zcu102 carrier + AD9081 (MxFE, JESD204B/C transceiver), SD-mux boot.
+#
+# Optional for the pyadi-jif hardware tests (they resolve the booted IP from the
+# coordinator and read over SSH). Provided for the labgrid boot path.
+# Set LG_COORDINATOR=10.0.0.41:20408.
+imports:
+  - adi_lg_plugins
+
+targets:
+  main:
+    resources:
+      RemotePlace:
+        name: mini2
+    drivers:
+      SerialDriver: {}
+      SSHDriver: {}

--- a/tests/hardware/env/nemo.yaml
+++ b/tests/hardware/env/nemo.yaml
@@ -1,0 +1,19 @@
+# labgrid coordinator (RemotePlace) env for the 'nemo' DUT:
+#   zc706 carrier + ADRV9009 (JESD204B transceiver).
+#
+# The pyadi-jif hardware tests resolve the booted board IP from the coordinator
+# directly (see tests/hardware/dut.py) and read JESD facts over SSH, so this
+# file is optional for them. It is provided for driving the board through the
+# labgrid Python API / adi-labgrid-plugins boot strategy (e.g. to power-cycle
+# and boot the DUT before validating). Set LG_COORDINATOR=10.0.0.41:20408.
+imports:
+  - adi_lg_plugins
+
+targets:
+  main:
+    resources:
+      RemotePlace:
+        name: nemo
+    drivers:
+      SerialDriver: {}
+      SSHDriver: {}

--- a/tests/hardware/env/nuc.yaml
+++ b/tests/hardware/env/nuc.yaml
@@ -1,0 +1,17 @@
+# labgrid coordinator (RemotePlace) env for the 'nuc' DUT:
+#   vcu118 carrier + FMCDAQ3 (AD9680 ADC + AD9152 DAC, JESD204B).
+#
+# Optional for the pyadi-jif hardware tests (they resolve the booted IP from the
+# coordinator and read over SSH). Provided for the labgrid boot path.
+# Set LG_COORDINATOR=10.0.0.41:20408.
+imports:
+  - adi_lg_plugins
+
+targets:
+  main:
+    resources:
+      RemotePlace:
+        name: nuc
+    drivers:
+      SerialDriver: {}
+      SSHDriver: {}

--- a/tests/hardware/hdl_build.py
+++ b/tests/hardware/hdl_build.py
@@ -20,10 +20,25 @@ from adijif.fpgas.xilinx.xgt_wizard import XgtWizardConfig, _fmt
 
 @dataclass(frozen=True)
 class WizardBuild:
-    """One xcvr_wizard sub-build invocation and its expected artifact."""
+    """One xcvr_wizard sub-build invocation and its expected artifact.
+
+    The HDL make wrapper builds into a parameter-token subdirectory of
+    ``project_dir`` (e.g. ``RATE23_925_REFCLK362_5_PLLTYPEQPLL1/``), so
+    the artifact is found by globbing for ``cfng_name`` under
+    ``project_dir`` rather than at a fixed path.
+    """
 
     argv: List[str]
-    cfng_path: Path
+    project_dir: Path
+    cfng_name: str
+
+    def find_cfng(self) -> List[Path]:
+        """Locate generated cfng artifacts under the project directory.
+
+        Returns:
+            All ``cfng_name`` files below ``project_dir``.
+        """
+        return sorted(self.project_dir.rglob(self.cfng_name))
 
 
 def _params(link) -> tuple:
@@ -51,13 +66,6 @@ def wizard_builds(
     """
     gt = gt_type or cfg.transceiver_type or "GTHE4"
     project_dir = Path(hdl_dir) / "projects" / "xcvr_wizard" / carrier
-    cfng = (
-        project_dir
-        / f"xcvr_wizard_{carrier}.gen"
-        / "sources_1"
-        / "ip"
-        / f"{gt}_cfng.txt"
-    )
 
     builds: List[WizardBuild] = []
     seen = set()
@@ -79,7 +87,8 @@ def wizard_builds(
                     f"REF_CLK={ref_clk}",
                     f"PLL_TYPE={pll}",
                 ],
-                cfng_path=cfng,
+                project_dir=project_dir,
+                cfng_name=f"{gt}_cfng.txt",
             )
         )
     return builds

--- a/tests/hardware/hdl_build.py
+++ b/tests/hardware/hdl_build.py
@@ -1,12 +1,13 @@
 """Helpers to drive the HDL repo xcvr_wizard sub-build from a jif export.
 
 The ADI HDL repo's ``projects/xcvr_wizard/<carrier>`` sub-project runs the
-Xilinx GT wizard generation (``get_diff_params``) for one
-``LANE_RATE``/``REF_CLK``/``PLL_TYPE`` triple and writes the parsed
-configuration to
-``xcvr_wizard_<carrier>.gen/sources_1/ip/<GT_TYPE>_cfng.txt``. These
-helpers turn an :class:`XgtWizardConfig` into the make invocations (one
-per distinct direction) and the expected artifact paths.
+Xilinx GT wizard generation (``get_diff_params``) for the full parameter
+set — ``LANE_RATE``/``REF_CLK``/``PLL_TYPE``/``JESD_MODE`` plus
+``XCVR_RX_*`` overrides — and writes the parsed configuration to a
+``<GT_TYPE>_cfng.txt`` inside a parameter-token build subdirectory (e.g.
+``RATE11_9625_REFCLK362_5_PLLTYPEQPLL1/``). These helpers turn an
+:class:`XgtWizardConfig` into that make invocation and locate the
+artifact by glob.
 """
 
 from __future__ import annotations
@@ -15,7 +16,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
 
-from adijif.fpgas.xilinx.xgt_wizard import XgtWizardConfig, _fmt
+from adijif.fpgas.xilinx.xgt_wizard import XgtWizardConfig
 
 
 @dataclass(frozen=True)
@@ -23,9 +24,8 @@ class WizardBuild:
     """One xcvr_wizard sub-build invocation and its expected artifact.
 
     The HDL make wrapper builds into a parameter-token subdirectory of
-    ``project_dir`` (e.g. ``RATE23_925_REFCLK362_5_PLLTYPEQPLL1/``), so
-    the artifact is found by globbing for ``cfng_name`` under
-    ``project_dir`` rather than at a fixed path.
+    ``project_dir``, so the artifact is found by globbing for
+    ``cfng_name`` under ``project_dir`` rather than at a fixed path.
     """
 
     argv: List[str]
@@ -41,17 +41,13 @@ class WizardBuild:
         return sorted(self.project_dir.rglob(self.cfng_name))
 
 
-def _params(link) -> tuple:
-    return (_fmt(link.lane_rate_gbps), _fmt(link.ref_clk_mhz), link.pll_type)
-
-
 def wizard_builds(
     cfg: XgtWizardConfig,
     hdl_dir: str,
     carrier: str = "zcu102",
     gt_type: Optional[str] = None,
 ) -> List[WizardBuild]:
-    """Build the make invocations for each distinct link direction.
+    """Build the make invocation for an exported wizard configuration.
 
     Args:
         cfg: Exported xgt_wizard configuration.
@@ -61,34 +57,19 @@ def wizard_builds(
             ``cfg.transceiver_type``.
 
     Returns:
-        One :class:`WizardBuild` per distinct (lane rate, ref clk, PLL)
-        triple, primary (TX) direction first.
+        A single-element list (kept as a list for call-site symmetry)
+        with the full-parameter make invocation, TX primary and
+        ``XCVR_RX_*`` overrides only where RX differs.
     """
     gt = gt_type or cfg.transceiver_type or "GTHE4"
     project_dir = Path(hdl_dir) / "projects" / "xcvr_wizard" / carrier
-
-    builds: List[WizardBuild] = []
-    seen = set()
-    for link in (cfg.tx, cfg.rx):
-        if link is None:
-            continue
-        params = _params(link)
-        if params in seen:
-            continue
-        seen.add(params)
-        lane_rate, ref_clk, pll = params
-        builds.append(
-            WizardBuild(
-                argv=[
-                    "make",
-                    "-C",
-                    str(project_dir),
-                    f"LANE_RATE={lane_rate}",
-                    f"REF_CLK={ref_clk}",
-                    f"PLL_TYPE={pll}",
-                ],
-                project_dir=project_dir,
-                cfng_name=f"{gt}_cfng.txt",
-            )
+    argv = ["make", "-C", str(project_dir)] + [
+        f"{key}={value}" for key, value in cfg._project_params()
+    ]
+    return [
+        WizardBuild(
+            argv=argv,
+            project_dir=project_dir,
+            cfng_name=f"{gt}_cfng.txt",
         )
-    return builds
+    ]

--- a/tests/hardware/hdl_build.py
+++ b/tests/hardware/hdl_build.py
@@ -1,0 +1,85 @@
+"""Helpers to drive the HDL repo xcvr_wizard sub-build from a jif export.
+
+The ADI HDL repo's ``projects/xcvr_wizard/<carrier>`` sub-project runs the
+Xilinx GT wizard generation (``get_diff_params``) for one
+``LANE_RATE``/``REF_CLK``/``PLL_TYPE`` triple and writes the parsed
+configuration to
+``xcvr_wizard_<carrier>.gen/sources_1/ip/<GT_TYPE>_cfng.txt``. These
+helpers turn an :class:`XgtWizardConfig` into the make invocations (one
+per distinct direction) and the expected artifact paths.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+from adijif.fpgas.xilinx.xgt_wizard import XgtWizardConfig, _fmt
+
+
+@dataclass(frozen=True)
+class WizardBuild:
+    """One xcvr_wizard sub-build invocation and its expected artifact."""
+
+    argv: List[str]
+    cfng_path: Path
+
+
+def _params(link) -> tuple:
+    return (_fmt(link.lane_rate_gbps), _fmt(link.ref_clk_mhz), link.pll_type)
+
+
+def wizard_builds(
+    cfg: XgtWizardConfig,
+    hdl_dir: str,
+    carrier: str = "zcu102",
+    gt_type: Optional[str] = None,
+) -> List[WizardBuild]:
+    """Build the make invocations for each distinct link direction.
+
+    Args:
+        cfg: Exported xgt_wizard configuration.
+        hdl_dir: Root of an ADI HDL repo checkout.
+        carrier: Carrier folder under ``projects/xcvr_wizard``.
+        gt_type: GT type for the artifact name; defaults to
+            ``cfg.transceiver_type``.
+
+    Returns:
+        One :class:`WizardBuild` per distinct (lane rate, ref clk, PLL)
+        triple, primary (TX) direction first.
+    """
+    gt = gt_type or cfg.transceiver_type or "GTHE4"
+    project_dir = Path(hdl_dir) / "projects" / "xcvr_wizard" / carrier
+    cfng = (
+        project_dir
+        / f"xcvr_wizard_{carrier}.gen"
+        / "sources_1"
+        / "ip"
+        / f"{gt}_cfng.txt"
+    )
+
+    builds: List[WizardBuild] = []
+    seen = set()
+    for link in (cfg.tx, cfg.rx):
+        if link is None:
+            continue
+        params = _params(link)
+        if params in seen:
+            continue
+        seen.add(params)
+        lane_rate, ref_clk, pll = params
+        builds.append(
+            WizardBuild(
+                argv=[
+                    "make",
+                    "-C",
+                    str(project_dir),
+                    f"LANE_RATE={lane_rate}",
+                    f"REF_CLK={ref_clk}",
+                    f"PLL_TYPE={pll}",
+                ],
+                cfng_path=cfng,
+            )
+        )
+    return builds

--- a/tests/hardware/test_dut_parsing.py
+++ b/tests/hardware/test_dut_parsing.py
@@ -1,0 +1,52 @@
+"""Unit tests for the DUT status parsers (no hardware required)."""
+
+from __future__ import annotations
+
+from .dut import JesdLinkStatus, parse_jesd_status
+
+_STATUS_UP = """Link is enabled
+Measured Link Clock: 122.880 MHz
+Reported Link Clock: 122.880 MHz
+Lane rate: 4915.200 MHz
+Lane rate / 40: 122.880 MHz
+LMFC rate: 3.840 MHz
+Link status: DATA
+SYSREF captured: Yes
+SYSREF alignment error: No
+"""
+
+_STATUS_DOWN = """Link is disabled
+"""
+
+
+def test_parse_status_up():
+    st = parse_jesd_status(_STATUS_UP)
+    assert isinstance(st, JesdLinkStatus)
+    assert st.enabled is True
+    assert st.data is True
+    assert st.up is True
+    assert st.lane_rate_hz == 4.9152e9
+    assert st.link_clock_hz == 122.88e6
+    assert st.lmfc_rate_hz == 3.84e6
+    assert st.sysref_captured is True
+
+
+def test_parse_status_down():
+    st = parse_jesd_status(_STATUS_DOWN)
+    assert st.enabled is False
+    assert st.up is False
+    assert st.lane_rate_hz is None
+
+
+def test_parse_status_ghz_units():
+    st = parse_jesd_status("Link is enabled\nLane rate: 4.915200 GHz\n")
+    assert st.lane_rate_hz == 4.9152e9
+    # No 'Link status' line -> data unknown, but enabled -> treat as up.
+    assert st.data is None
+    assert st.up is True
+
+
+def test_parse_status_empty():
+    st = parse_jesd_status("")
+    assert st.enabled is None
+    assert st.up is False

--- a/tests/hardware/test_dut_parsing.py
+++ b/tests/hardware/test_dut_parsing.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .dut import JesdLinkStatus, parse_jesd_status
+from .dut import JesdLinkStatus, parse_jesd_status, parse_neigh_for_mac
 
 _STATUS_UP = """Link is enabled
 Measured Link Clock: 122.880 MHz
@@ -50,3 +50,35 @@ def test_parse_status_empty():
     st = parse_jesd_status("")
     assert st.enabled is None
     assert st.up is False
+
+
+# `ip neigh` output captured from the bq exporter host: the board's stable
+# Xilinx GEM MAC maps to its live DHCP IP, while the stale configured .23 has no
+# lladdr (FAILED). The IPv6 line must be ignored.
+_NEIGH = """\
+10.0.0.128 dev enp2s0 lladdr 00:0a:35:00:01:22 STALE
+10.0.0.23 dev enp2s0 FAILED
+10.0.0.41 dev enp2s0 lladdr 52:54:00:aa:bb:cc REACHABLE
+fe80::20a:35ff:fe00:122 dev enp2s0 lladdr 00:0a:35:00:01:22 router STALE
+"""
+
+
+def test_neigh_finds_ipv4_for_mac():
+    assert parse_neigh_for_mac(_NEIGH, "00:0a:35:00:01:22") == "10.0.0.128"
+
+
+def test_neigh_is_case_insensitive():
+    assert parse_neigh_for_mac(_NEIGH, "00:0A:35:00:01:22") == "10.0.0.128"
+
+
+def test_neigh_unknown_mac_returns_none():
+    assert parse_neigh_for_mac(_NEIGH, "aa:bb:cc:dd:ee:ff") is None
+
+
+def test_neigh_failed_entry_has_no_mac():
+    # The stale configured address (.23) is FAILED -> never returned.
+    assert parse_neigh_for_mac(_NEIGH, "00:0a:35:00:01:22") != "10.0.0.23"
+
+
+def test_neigh_empty():
+    assert parse_neigh_for_mac("", "00:0a:35:00:01:22") is None

--- a/tests/hardware/test_dut_parsing.py
+++ b/tests/hardware/test_dut_parsing.py
@@ -82,3 +82,33 @@ def test_neigh_failed_entry_has_no_mac():
 
 def test_neigh_empty():
     assert parse_neigh_for_mac("", "00:0a:35:00:01:22") is None
+
+
+_STATUS_204C = """\
+Link is enabled
+Measured Link Clock: 250.000 MHz
+Reported Link Clock: 250.000 MHz
+Lane rate: 16500.000 MHz
+Lane rate / 66: 250.000 MHz
+Link status: DATA
+SYSREF captured: Yes
+"""
+
+_STATUS_204B = """\
+Link is enabled
+Lane rate: 4915.200 MHz
+Lane rate / 40: 122.880 MHz
+Link status: DATA
+"""
+
+
+def test_encoding_64b66b_detected():
+    assert parse_jesd_status(_STATUS_204C).encoding == "64B66B"
+
+
+def test_encoding_8b10b_detected():
+    assert parse_jesd_status(_STATUS_204B).encoding == "8B10B"
+
+
+def test_encoding_absent_is_none():
+    assert parse_jesd_status("Link is enabled\n").encoding is None

--- a/tests/hardware/test_hdl_build_helpers.py
+++ b/tests/hardware/test_hdl_build_helpers.py
@@ -40,10 +40,11 @@ def test_asymmetric_config_yields_two_builds():
         "REF_CLK=362.5",
         "PLL_TYPE=QPLL1",
     ]
-    assert str(tx.cfng_path) == (
-        "/opt/hdl/projects/xcvr_wizard/zcu102/"
-        "xcvr_wizard_zcu102.gen/sources_1/ip/GTHE4_cfng.txt"
-    )
+    # The make wrapper builds into a parameter-token subdirectory (e.g.
+    # RATE23_925_REFCLK362_5_PLLTYPEQPLL1/), so the artifact is located by
+    # globbing under the project dir rather than by a fixed path.
+    assert str(tx.project_dir) == "/opt/hdl/projects/xcvr_wizard/zcu102"
+    assert tx.cfng_name == "GTHE4_cfng.txt"
 
 
 def test_symmetric_config_yields_one_build():

--- a/tests/hardware/test_hdl_build_helpers.py
+++ b/tests/hardware/test_hdl_build_helpers.py
@@ -1,0 +1,69 @@
+"""Unit tests for the xcvr_wizard HDL build helpers (no Vivado needed)."""
+
+from __future__ import annotations
+
+from adijif.fpgas.xilinx.xgt_wizard import XgtWizardConfig, XgtWizardLink
+
+from .hdl_build import wizard_builds
+
+
+def _cfg(tx=None, rx=None, jesd_mode="64B66B", gt="GTHE4"):
+    return XgtWizardConfig(
+        jesd_mode=jesd_mode, tx=tx, rx=rx, transceiver_type=gt
+    )
+
+
+def _link(rate, ref, pll, lanes=4):
+    return XgtWizardLink(
+        lane_rate_gbps=rate, ref_clk_mhz=ref, pll_type=pll, num_lanes=lanes
+    )
+
+
+def test_asymmetric_config_yields_two_builds():
+    cfg = _cfg(
+        tx=_link(23.925, 362.5, "QPLL0"), rx=_link(11.9625, 362.5, "QPLL1")
+    )
+    builds = wizard_builds(cfg, "/opt/hdl", carrier="zcu102")
+
+    assert len(builds) == 2
+    tx, rx = builds
+    assert tx.argv == [
+        "make",
+        "-C",
+        "/opt/hdl/projects/xcvr_wizard/zcu102",
+        "LANE_RATE=23.925",
+        "REF_CLK=362.5",
+        "PLL_TYPE=QPLL0",
+    ]
+    assert rx.argv[3:] == [
+        "LANE_RATE=11.9625",
+        "REF_CLK=362.5",
+        "PLL_TYPE=QPLL1",
+    ]
+    assert str(tx.cfng_path) == (
+        "/opt/hdl/projects/xcvr_wizard/zcu102/"
+        "xcvr_wizard_zcu102.gen/sources_1/ip/GTHE4_cfng.txt"
+    )
+
+
+def test_symmetric_config_yields_one_build():
+    link = _link(10.0, 250.0, "QPLL0")
+    cfg = _cfg(tx=link, rx=link, jesd_mode="8B10B")
+    builds = wizard_builds(cfg, "/opt/hdl")
+    assert len(builds) == 1
+    assert builds[0].argv[3:] == [
+        "LANE_RATE=10",
+        "REF_CLK=250",
+        "PLL_TYPE=QPLL0",
+    ]
+
+
+def test_single_direction_config_yields_one_build():
+    cfg = _cfg(rx=_link(9.8304, 245.76, "CPLL"), jesd_mode="8B10B")
+    builds = wizard_builds(cfg, "/opt/hdl")
+    assert len(builds) == 1
+    assert builds[0].argv[3:] == [
+        "LANE_RATE=9.8304",
+        "REF_CLK=245.76",
+        "PLL_TYPE=CPLL",
+    ]

--- a/tests/hardware/test_hdl_build_helpers.py
+++ b/tests/hardware/test_hdl_build_helpers.py
@@ -19,35 +19,34 @@ def _link(rate, ref, pll, lanes=4):
     )
 
 
-def test_asymmetric_config_yields_two_builds():
+def test_asymmetric_config_is_one_build_with_rx_overrides():
+    """hdl main's xcvr_wizard takes the full 7-parameter set in one make."""
     cfg = _cfg(
         tx=_link(23.925, 362.5, "QPLL0"), rx=_link(11.9625, 362.5, "QPLL1")
     )
     builds = wizard_builds(cfg, "/opt/hdl", carrier="zcu102")
 
-    assert len(builds) == 2
-    tx, rx = builds
-    assert tx.argv == [
+    assert len(builds) == 1
+    (build,) = builds
+    assert build.argv == [
         "make",
         "-C",
         "/opt/hdl/projects/xcvr_wizard/zcu102",
         "LANE_RATE=23.925",
         "REF_CLK=362.5",
         "PLL_TYPE=QPLL0",
-    ]
-    assert rx.argv[3:] == [
-        "LANE_RATE=11.9625",
-        "REF_CLK=362.5",
-        "PLL_TYPE=QPLL1",
+        "JESD_MODE=64B66B",
+        "XCVR_RX_LANE_RATE=11.9625",
+        "XCVR_RX_PLL_TYPE=QPLL1",
     ]
     # The make wrapper builds into a parameter-token subdirectory (e.g.
     # RATE23_925_REFCLK362_5_PLLTYPEQPLL1/), so the artifact is located by
     # globbing under the project dir rather than by a fixed path.
-    assert str(tx.project_dir) == "/opt/hdl/projects/xcvr_wizard/zcu102"
-    assert tx.cfng_name == "GTHE4_cfng.txt"
+    assert str(build.project_dir) == "/opt/hdl/projects/xcvr_wizard/zcu102"
+    assert build.cfng_name == "GTHE4_cfng.txt"
 
 
-def test_symmetric_config_yields_one_build():
+def test_symmetric_config_has_no_overrides():
     link = _link(10.0, 250.0, "QPLL0")
     cfg = _cfg(tx=link, rx=link, jesd_mode="8B10B")
     builds = wizard_builds(cfg, "/opt/hdl")
@@ -56,10 +55,11 @@ def test_symmetric_config_yields_one_build():
         "LANE_RATE=10",
         "REF_CLK=250",
         "PLL_TYPE=QPLL0",
+        "JESD_MODE=8B10B",
     ]
 
 
-def test_single_direction_config_yields_one_build():
+def test_single_direction_config_has_no_overrides():
     cfg = _cfg(rx=_link(9.8304, 245.76, "CPLL"), jesd_mode="8B10B")
     builds = wizard_builds(cfg, "/opt/hdl")
     assert len(builds) == 1
@@ -67,4 +67,5 @@ def test_single_direction_config_yields_one_build():
         "LANE_RATE=9.8304",
         "REF_CLK=245.76",
         "PLL_TYPE=CPLL",
+        "JESD_MODE=8B10B",
     ]

--- a/tests/hardware/test_hdl_xcvr_wizard_build.py
+++ b/tests/hardware/test_hdl_xcvr_wizard_build.py
@@ -67,7 +67,10 @@ def wizard_config() -> "adijif.fpgas.xilinx.xgt_wizard.XgtWizardConfig":
     sys.converter.dac.datapath.cduc_interpolation = cddc
     sys.converter.dac.datapath.fduc_interpolation = fddc
     sys.converter.dac.datapath.fduc_enabled = [True] * 8
-    sys.converter.dac.set_quick_configuration_mode("0", "jesd204c")
+    # TX mode 4 (L=2 M=8 Np=12) and RX mode 1.0 both land on 11.9625 Gbps,
+    # inside the GTHE4 line-rate range (mode 0 would solve to 23.925 Gbps,
+    # which the GT wizard rightly rejects for GTH).
+    sys.converter.dac.set_quick_configuration_mode("4", "jesd204c")
     sys.converter.adc.set_quick_configuration_mode("1.0", "jesd204c")
     return sys.export_config(format="adi.xgt-wizard")
 

--- a/tests/hardware/test_hdl_xcvr_wizard_build.py
+++ b/tests/hardware/test_hdl_xcvr_wizard_build.py
@@ -1,0 +1,101 @@
+"""Vivado build validation for the jif adi.xgt-wizard export (AD9081+ZCU102).
+
+Solves the AD9081 + ZCU102 system that mirrors the ``mini2`` lab rig
+(m8_l4, HMC7044 vcxo 122.88 MHz), exports the ``adi.xgt-wizard``
+parameters, and runs the HDL repo's ``projects/xcvr_wizard/zcu102``
+sub-build with them. This proves the jif-emitted ``LANE_RATE`` /
+``REF_CLK`` / ``PLL_TYPE`` triples are accepted by the real Xilinx GT
+wizard generation and produce the parsed ``GTHE4_cfng.txt`` artifact.
+
+Requirements (skipped otherwise): ``--run-hdl-build``, an ADI HDL repo
+checkout at ``$HDL_DIR``, and ``vivado`` on ``PATH``.
+
+Run: HDL_DIR=~/dev/hdl pytest --run-hdl-build \
+    tests/hardware/test_hdl_xcvr_wizard_build.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import adijif
+
+from .hdl_build import wizard_builds
+
+pytestmark = pytest.mark.hdl_build
+
+CARRIER = "zcu102"
+BUILD_TIMEOUT_S = 40 * 60
+
+
+@pytest.fixture(scope="module")
+def hdl_dir() -> Path:
+    """The ADI HDL repo checkout, from $HDL_DIR; skip when unusable."""
+    raw = os.environ.get("HDL_DIR")
+    if not raw:
+        pytest.skip("HDL_DIR not set; point it at an ADI hdl repo checkout")
+    path = Path(raw).expanduser()
+    if not (path / "projects" / "xcvr_wizard" / CARRIER).is_dir():
+        pytest.skip(f"{path} has no projects/xcvr_wizard/{CARRIER}")
+    if shutil.which("vivado") is None:
+        pytest.skip("vivado not on PATH; source settings64.sh first")
+    return path
+
+
+@pytest.fixture(scope="module")
+def wizard_config() -> "adijif.fpgas.xilinx.xgt_wizard.XgtWizardConfig":
+    """Solve the mini2-rig-like AD9081+ZCU102 system and export it."""
+    cddc, fddc = 6, 4
+    sys = adijif.system(
+        "ad9081", "hmc7044", "xilinx", 122.88e6, solver="CPLEX"
+    )
+    sys.fpga.setup_by_dev_kit_name(CARRIER)
+    sys.fpga.ref_clock_constraint = "Unconstrained"
+    sys.fpga.sys_clk_select = "XCVR_QPLL0"
+    sys.fpga.out_clk_select = "XCVR_PROGDIV_CLK"
+    sys.converter.clocking_option = "integrated_pll"
+    sys.converter.adc.sample_clock = 2900000000 / (cddc * fddc)
+    sys.converter.dac.sample_clock = 5800000000 / (cddc * fddc)
+    sys.converter.adc.datapath.cddc_decimations = [cddc] * 4
+    sys.converter.adc.datapath.fddc_decimations = [fddc] * 8
+    sys.converter.adc.datapath.fddc_enabled = [True] * 8
+    sys.converter.dac.datapath.cduc_interpolation = cddc
+    sys.converter.dac.datapath.fduc_interpolation = fddc
+    sys.converter.dac.datapath.fduc_enabled = [True] * 8
+    sys.converter.dac.set_quick_configuration_mode("0", "jesd204c")
+    sys.converter.adc.set_quick_configuration_mode("1.0", "jesd204c")
+    return sys.export_config(format="adi.xgt-wizard")
+
+
+def test_xcvr_wizard_subbuild_accepts_jif_parameters(hdl_dir, wizard_config):
+    """Every jif-emitted parameter triple survives the GT wizard build."""
+    builds = wizard_builds(wizard_config, str(hdl_dir), carrier=CARRIER)
+    assert builds, "exporter produced no build directions"
+
+    for index, build in enumerate(builds):
+        if build.cfng_path.exists():
+            build.cfng_path.unlink()
+        log_path = Path.cwd() / f"hdl_xcvr_wizard_build_{index}.log"
+        with open(log_path, "w") as log:
+            # argv is a fixed make invocation built from validated
+            # XgtWizardConfig fields; no shell, no untrusted input.
+            result = subprocess.run(  # noqa: S603
+                build.argv,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                timeout=BUILD_TIMEOUT_S,
+            )
+        assert result.returncode == 0, (
+            f"{' '.join(build.argv)} failed; see {log_path}"
+        )
+        assert build.cfng_path.is_file(), (
+            f"wizard build produced no {build.cfng_path}"
+        )
+        assert build.cfng_path.stat().st_size > 0, (
+            f"{build.cfng_path} is empty"
+        )

--- a/tests/hardware/test_hdl_xcvr_wizard_build.py
+++ b/tests/hardware/test_hdl_xcvr_wizard_build.py
@@ -78,8 +78,7 @@ def test_xcvr_wizard_subbuild_accepts_jif_parameters(hdl_dir, wizard_config):
     assert builds, "exporter produced no build directions"
 
     for index, build in enumerate(builds):
-        if build.cfng_path.exists():
-            build.cfng_path.unlink()
+        before = set(build.find_cfng())
         log_path = Path.cwd() / f"hdl_xcvr_wizard_build_{index}.log"
         with open(log_path, "w") as log:
             # argv is a fixed make invocation built from validated
@@ -93,9 +92,15 @@ def test_xcvr_wizard_subbuild_accepts_jif_parameters(hdl_dir, wizard_config):
         assert result.returncode == 0, (
             f"{' '.join(build.argv)} failed; see {log_path}"
         )
-        assert build.cfng_path.is_file(), (
-            f"wizard build produced no {build.cfng_path}"
+        produced = [
+            p
+            for p in build.find_cfng()
+            if p not in before or p.stat().st_size > 0
+        ]
+        assert produced, (
+            f"wizard build produced no {build.cfng_name} under "
+            f"{build.project_dir}"
         )
-        assert build.cfng_path.stat().st_size > 0, (
-            f"{build.cfng_path} is empty"
+        assert all(p.stat().st_size > 0 for p in produced), (
+            f"empty {build.cfng_name} artifact(s): {produced}"
         )

--- a/tests/hardware/test_hw_bq_adrv9371.py
+++ b/tests/hardware/test_hw_bq_adrv9371.py
@@ -36,7 +36,9 @@ def test_adrv9371_rx_model_matches_hw(dut):
     sample_rates = list(dut.sampling_frequencies().values())
     assert sample_rates, "no IIO sampling_frequency reported by DUT"
 
-    rx = [st for name, st in status.items() if st.up and "tx" not in name.lower()]
+    rx = [
+        st for name, st in status.items() if st.up and "tx" not in name.lower()
+    ]
     if not rx:
         pytest.skip(f"no Rx JESD link up on '{PLACE}': {list(status)}")
     lane_rate = rx[0].lane_rate_hz
@@ -44,7 +46,7 @@ def test_adrv9371_rx_model_matches_hw(dut):
 
     result = match_link(adijif.adrv9371_rx, lane_rate, sample_rates)
     assert result is not None, (
-        f"no ADRV9371 Rx mode reproduces HW lane rate {lane_rate/1e9:.4f} GHz "
+        f"no ADRV9371 Rx mode reproduces HW lane rate {lane_rate / 1e9:.4f} GHz "
         f"at sample rates {sample_rates}; model offers "
         f"{available_lane_rates(adijif.adrv9371_rx(), sample_rates[0])}"
     )
@@ -66,7 +68,7 @@ def test_adrv9371_tx_model_matches_hw(dut):
 
     result = match_link(adijif.adrv9371_tx, lane_rate, sample_rates)
     assert result is not None, (
-        f"no ADRV9371 Tx mode reproduces HW lane rate {lane_rate/1e9:.4f} GHz "
+        f"no ADRV9371 Tx mode reproduces HW lane rate {lane_rate / 1e9:.4f} GHz "
         f"at sample rates {sample_rates}"
     )
     assert result[1].bit_clock == pytest.approx(lane_rate, rel=1e-6)
@@ -77,7 +79,9 @@ def test_adrv9371_system_solve_matches_hw(dut):
     """Full zc706 ADRV9371 system solve closes at the measured config."""
     status = dut.jesd_status()
     sample_rates = list(dut.sampling_frequencies().values())
-    rx = [st for name, st in status.items() if st.up and "tx" not in name.lower()]
+    rx = [
+        st for name, st in status.items() if st.up and "tx" not in name.lower()
+    ]
     tx = [st for name, st in status.items() if st.up and "tx" in name.lower()]
     if not (rx and tx):
         pytest.skip(f"need both Rx and Tx links up on '{PLACE}'")
@@ -102,8 +106,42 @@ def test_adrv9371_system_solve_matches_hw(dut):
         tx_match[1].mode, tx_match[1].jesd_class
     )
 
-    assert sys.converter.adc.bit_clock == pytest.approx(rx[0].lane_rate_hz, rel=1e-6)
-    assert sys.converter.dac.bit_clock == pytest.approx(tx[0].lane_rate_hz, rel=1e-6)
+    assert sys.converter.adc.bit_clock == pytest.approx(
+        rx[0].lane_rate_hz, rel=1e-6
+    )
+    assert sys.converter.dac.bit_clock == pytest.approx(
+        tx[0].lane_rate_hz, rel=1e-6
+    )
 
     cfg = sys.solve()
     assert "clock" in cfg and "converter" in cfg
+
+
+@pytest.mark.parametrize("dut", [PLACE], indirect=True)
+def test_adrv9371_tx_framing_is_m4(dut):
+    """Booted Tx framing is M=4 (two complex I/Q channels) and the model has it.
+
+    A lane rate fixes only F (and the M/L ratio), not M and L independently, so
+    the lane-rate match tests above cannot tell M=4/L=4 from M=2/L=2. This reads
+    the authoritative ``converters-per-device`` from the device tree the board
+    booted with and asserts the pyadi-jif ADRV9371 Tx model offers that framing.
+    """
+    framing = dut.jesd_framing()
+    assert framing, f"no axi-jesd204 framing found in '{PLACE}' device tree"
+    tx = next(
+        (f for f in framing.values() if f.get("role") == "tx" and "M" in f),
+        None,
+    )
+    if tx is None:
+        pytest.skip(
+            f"no Tx framing with converters-per-device in DT: {framing}"
+        )
+
+    assert tx["M"] == 4, f"expected Tx M=4 (two complex channels), got {tx}"
+    modes = adijif.utils.get_jesd_mode_from_params(
+        adijif.adrv9371_tx(), M=tx["M"], F=tx["F"], Np=tx.get("Np", 16)
+    )
+    assert modes, (
+        f"jif adrv9371_tx offers no mode for HW framing "
+        f"M={tx['M']} F={tx['F']} Np={tx.get('Np', 16)}"
+    )

--- a/tests/hardware/test_hw_bq_adrv9371.py
+++ b/tests/hardware/test_hw_bq_adrv9371.py
@@ -1,0 +1,109 @@
+"""Hardware validation for the 'bq' DUT: ADRV9371 (AD9371) on zc706.
+
+Reads the live JESD link status + sample rates from the booted board and
+asserts that the newly added pyadi-jif ADRV9371 model reproduces the measured
+lane rate(s), and that the full zc706 system solve closes.
+
+Run: pytest --run-hardware tests/hardware/test_hw_bq_adrv9371.py -v
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import adijif
+
+from .validation import available_lane_rates, match_link
+
+pytestmark = pytest.mark.hardware
+
+PLACE = "bq"
+
+
+@pytest.mark.parametrize("dut", [PLACE], indirect=True)
+def test_adrv9371_jesd_links_up(dut):
+    """At least one ADRV9371 JESD link is enabled and (if reported) in DATA."""
+    status = dut.jesd_status()
+    assert status, f"no axi-jesd204 status nodes found on '{PLACE}'"
+    up = {name: st for name, st in status.items() if st.up}
+    assert up, f"no JESD link is up on '{PLACE}': {status}"
+
+
+@pytest.mark.parametrize("dut", [PLACE], indirect=True)
+def test_adrv9371_rx_model_matches_hw(dut):
+    """pyadi-jif ADRV9371 Rx reproduces the measured Rx lane rate."""
+    status = dut.jesd_status()
+    sample_rates = list(dut.sampling_frequencies().values())
+    assert sample_rates, "no IIO sampling_frequency reported by DUT"
+
+    rx = [st for name, st in status.items() if st.up and "tx" not in name.lower()]
+    if not rx:
+        pytest.skip(f"no Rx JESD link up on '{PLACE}': {list(status)}")
+    lane_rate = rx[0].lane_rate_hz
+    assert lane_rate, "Rx link reports no lane rate"
+
+    result = match_link(adijif.adrv9371_rx, lane_rate, sample_rates)
+    assert result is not None, (
+        f"no ADRV9371 Rx mode reproduces HW lane rate {lane_rate/1e9:.4f} GHz "
+        f"at sample rates {sample_rates}; model offers "
+        f"{available_lane_rates(adijif.adrv9371_rx(), sample_rates[0])}"
+    )
+    assert result[1].bit_clock == pytest.approx(lane_rate, rel=1e-6)
+
+
+@pytest.mark.parametrize("dut", [PLACE], indirect=True)
+def test_adrv9371_tx_model_matches_hw(dut):
+    """pyadi-jif ADRV9371 Tx reproduces the measured Tx lane rate."""
+    status = dut.jesd_status()
+    sample_rates = list(dut.sampling_frequencies().values())
+    assert sample_rates, "no IIO sampling_frequency reported by DUT"
+
+    tx = [st for name, st in status.items() if st.up and "tx" in name.lower()]
+    if not tx:
+        pytest.skip(f"no Tx JESD link up on '{PLACE}': {list(status)}")
+    lane_rate = tx[0].lane_rate_hz
+    assert lane_rate, "Tx link reports no lane rate"
+
+    result = match_link(adijif.adrv9371_tx, lane_rate, sample_rates)
+    assert result is not None, (
+        f"no ADRV9371 Tx mode reproduces HW lane rate {lane_rate/1e9:.4f} GHz "
+        f"at sample rates {sample_rates}"
+    )
+    assert result[1].bit_clock == pytest.approx(lane_rate, rel=1e-6)
+
+
+@pytest.mark.parametrize("dut", [PLACE], indirect=True)
+def test_adrv9371_system_solve_matches_hw(dut):
+    """Full zc706 ADRV9371 system solve closes at the measured config."""
+    status = dut.jesd_status()
+    sample_rates = list(dut.sampling_frequencies().values())
+    rx = [st for name, st in status.items() if st.up and "tx" not in name.lower()]
+    tx = [st for name, st in status.items() if st.up and "tx" in name.lower()]
+    if not (rx and tx):
+        pytest.skip(f"need both Rx and Tx links up on '{PLACE}'")
+
+    rx_match = match_link(adijif.adrv9371_rx, rx[0].lane_rate_hz, sample_rates)
+    tx_match = match_link(adijif.adrv9371_tx, tx[0].lane_rate_hz, sample_rates)
+    assert rx_match and tx_match, "could not match both Rx and Tx to HW"
+
+    vcxo = 122.88e6
+    sys = adijif.system("adrv9371", "ad9528", "xilinx", vcxo, solver="CPLEX")
+    sys.fpga.setup_by_dev_kit_name("zc706")
+    sys.clock.d = [*range(1, 257)]
+
+    sys.converter.adc.sample_clock = rx_match[0]
+    sys.converter.adc.decimation = 4
+    sys.converter.adc.set_quick_configuration_mode(
+        rx_match[1].mode, rx_match[1].jesd_class
+    )
+    sys.converter.dac.sample_clock = tx_match[0]
+    sys.converter.dac.interpolation = 4
+    sys.converter.dac.set_quick_configuration_mode(
+        tx_match[1].mode, tx_match[1].jesd_class
+    )
+
+    assert sys.converter.adc.bit_clock == pytest.approx(rx[0].lane_rate_hz, rel=1e-6)
+    assert sys.converter.dac.bit_clock == pytest.approx(tx[0].lane_rate_hz, rel=1e-6)
+
+    cfg = sys.solve()
+    assert "clock" in cfg and "converter" in cfg

--- a/tests/hardware/test_hw_mini2_ad9081.py
+++ b/tests/hardware/test_hw_mini2_ad9081.py
@@ -1,0 +1,124 @@
+"""Hardware validation for the 'mini2' DUT: AD9081 on zcu102.
+
+Reads the live JESD link status from the booted board, asserts the
+pyadi-jif AD9081 models reproduce the measured lane rates, and — the
+xcvr-wizard-specific part — asserts the ``adi.xgt-wizard`` export of a
+solve matching the measured configuration would drive the Xilinx GT
+wizard to exactly what the working hardware runs (lane rates, JESD
+encoding, lane counts).
+
+Run: pytest --run-hardware tests/hardware/test_hw_mini2_ad9081.py -v
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import adijif
+
+from .validation import available_lane_rates, match_link
+
+pytestmark = pytest.mark.hardware
+
+PLACE = "mini2"
+VCXO = 122.88e6  # mini2 rig hdl-config m8_l4_vcxo122p88 (HMC7044)
+
+
+def _links(status, direction):
+    """Return the up links for one direction ('rx' or 'tx')."""
+    if direction == "tx":
+        return [
+            st for name, st in status.items() if st.up and "tx" in name.lower()
+        ]
+    return [
+        st
+        for name, st in status.items()
+        if st.up and "tx" not in name.lower()
+    ]
+
+
+@pytest.mark.parametrize("dut", [PLACE], indirect=True)
+def test_ad9081_jesd_links_up(dut):
+    """At least one AD9081 JESD link is enabled and (if reported) in DATA."""
+    status = dut.jesd_status()
+    assert status, f"no axi-jesd204 status nodes found on '{PLACE}'"
+    up = {name: st for name, st in status.items() if st.up}
+    assert up, f"no JESD link is up on '{PLACE}': {status}"
+
+
+@pytest.mark.parametrize("dut", [PLACE], indirect=True)
+@pytest.mark.parametrize("direction", ["rx", "tx"])
+def test_ad9081_model_matches_hw(dut, direction):
+    """pyadi-jif AD9081 reproduces the measured lane rate per direction."""
+    status = dut.jesd_status()
+    sample_rates = list(dut.sampling_frequencies().values())
+    assert sample_rates, "no IIO sampling_frequency reported by DUT"
+
+    links = _links(status, direction)
+    if not links:
+        pytest.skip(f"no {direction} JESD link up on '{PLACE}'")
+    lane_rate = links[0].lane_rate_hz
+    assert lane_rate, f"{direction} link reports no lane rate"
+
+    factory = adijif.ad9081_rx if direction == "rx" else adijif.ad9081_tx
+    result = match_link(factory, lane_rate, sample_rates)
+    assert result is not None, (
+        f"no AD9081 {direction} mode reproduces HW lane rate "
+        f"{lane_rate / 1e9:.4f} GHz at sample rates {sample_rates}; "
+        f"model offers {available_lane_rates(factory(), sample_rates[0])}"
+    )
+    assert result[1].bit_clock == pytest.approx(lane_rate, rel=1e-6)
+
+
+@pytest.mark.parametrize("dut", [PLACE], indirect=True)
+def test_ad9081_xgt_wizard_export_matches_hw(dut):
+    """The adi.xgt-wizard export agrees with the running hardware.
+
+    Matches each measured link to an AD9081 quick-config mode, solves the
+    full zcu102 system at those modes, exports the xgt_wizard parameters,
+    and asserts the exported lane rates, JESD mode, and lane counts equal
+    what the board reports.
+    """
+    status = dut.jesd_status()
+    sample_rates = list(dut.sampling_frequencies().values())
+    assert sample_rates, "no IIO sampling_frequency reported by DUT"
+
+    rx_links = _links(status, "rx")
+    tx_links = _links(status, "tx")
+    if not rx_links or not tx_links:
+        pytest.skip(f"need both rx and tx links up on '{PLACE}': {status}")
+    rx_rate = rx_links[0].lane_rate_hz
+    tx_rate = tx_links[0].lane_rate_hz
+    assert rx_rate and tx_rate, "links report no lane rate"
+
+    rx_match = match_link(adijif.ad9081_rx, rx_rate, sample_rates)
+    tx_match = match_link(adijif.ad9081_tx, tx_rate, sample_rates)
+    assert rx_match and tx_match, (
+        f"no AD9081 mode reproduces measured rates rx={rx_rate} tx={tx_rate}"
+    )
+    (rx_sample, rx_mode), (tx_sample, tx_mode) = rx_match, tx_match
+
+    sys = adijif.system(
+        "ad9081", "hmc7044", "xilinx", VCXO, solver="CPLEX"
+    )
+    sys.fpga.setup_by_dev_kit_name("zcu102")
+    sys.fpga.ref_clock_constraint = "Unconstrained"
+    sys.converter.clocking_option = "integrated_pll"
+    sys.converter.adc.sample_clock = rx_sample
+    sys.converter.dac.sample_clock = tx_sample
+    sys.converter.adc.set_quick_configuration_mode(
+        rx_mode.mode, rx_mode.jesd_class
+    )
+    sys.converter.dac.set_quick_configuration_mode(
+        tx_mode.mode, tx_mode.jesd_class
+    )
+
+    wiz = sys.export_config(format="adi.xgt-wizard")
+
+    assert wiz.tx.lane_rate_gbps == pytest.approx(tx_rate / 1e9, rel=1e-6)
+    assert wiz.rx.lane_rate_gbps == pytest.approx(rx_rate / 1e9, rel=1e-6)
+    assert wiz.rx.num_lanes == rx_mode.L
+    assert wiz.tx.num_lanes == tx_mode.L
+    hw_encoding = rx_links[0].encoding or tx_links[0].encoding
+    if hw_encoding is not None:
+        assert wiz.jesd_mode == hw_encoding

--- a/tests/hardware/test_hw_nemo_adrv9009.py
+++ b/tests/hardware/test_hw_nemo_adrv9009.py
@@ -1,0 +1,109 @@
+"""Hardware validation for the 'nemo' DUT: ADRV9009 on zc706.
+
+Reads the live JESD link status + sample rates from the booted board and
+asserts that pyadi-jif's ADRV9009 model reproduces the measured lane rate(s),
+and that the full zc706 system solve closes.
+
+Run: pytest --run-hardware tests/hardware/test_hw_nemo_adrv9009.py -v
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import adijif
+
+from .validation import available_lane_rates, match_link
+
+pytestmark = pytest.mark.hardware
+
+PLACE = "nemo"
+
+
+@pytest.mark.parametrize("dut", [PLACE], indirect=True)
+def test_adrv9009_jesd_links_up(dut):
+    """At least one ADRV9009 JESD link is enabled and (if reported) in DATA."""
+    status = dut.jesd_status()
+    assert status, f"no axi-jesd204 status nodes found on '{PLACE}'"
+    up = {name: st for name, st in status.items() if st.up}
+    assert up, f"no JESD link is up on '{PLACE}': {status}"
+
+
+@pytest.mark.parametrize("dut", [PLACE], indirect=True)
+def test_adrv9009_rx_model_matches_hw(dut):
+    """pyadi-jif ADRV9009 Rx reproduces the measured Rx lane rate."""
+    status = dut.jesd_status()
+    sample_rates = list(dut.sampling_frequencies().values())
+    assert sample_rates, "no IIO sampling_frequency reported by DUT"
+
+    rx = [st for name, st in status.items() if st.up and "tx" not in name.lower()]
+    if not rx:
+        pytest.skip(f"no Rx JESD link up on '{PLACE}': {list(status)}")
+    lane_rate = rx[0].lane_rate_hz
+    assert lane_rate, "Rx link reports no lane rate"
+
+    result = match_link(adijif.adrv9009_rx, lane_rate, sample_rates)
+    assert result is not None, (
+        f"no ADRV9009 Rx mode reproduces HW lane rate {lane_rate/1e9:.4f} GHz "
+        f"at sample rates {sample_rates}; model offers "
+        f"{available_lane_rates(adijif.adrv9009_rx(), sample_rates[0])}"
+    )
+    assert result[1].bit_clock == pytest.approx(lane_rate, rel=1e-6)
+
+
+@pytest.mark.parametrize("dut", [PLACE], indirect=True)
+def test_adrv9009_tx_model_matches_hw(dut):
+    """pyadi-jif ADRV9009 Tx reproduces the measured Tx lane rate."""
+    status = dut.jesd_status()
+    sample_rates = list(dut.sampling_frequencies().values())
+    assert sample_rates, "no IIO sampling_frequency reported by DUT"
+
+    tx = [st for name, st in status.items() if st.up and "tx" in name.lower()]
+    if not tx:
+        pytest.skip(f"no Tx JESD link up on '{PLACE}': {list(status)}")
+    lane_rate = tx[0].lane_rate_hz
+    assert lane_rate, "Tx link reports no lane rate"
+
+    result = match_link(adijif.adrv9009_tx, lane_rate, sample_rates)
+    assert result is not None, (
+        f"no ADRV9009 Tx mode reproduces HW lane rate {lane_rate/1e9:.4f} GHz "
+        f"at sample rates {sample_rates}"
+    )
+    assert result[1].bit_clock == pytest.approx(lane_rate, rel=1e-6)
+
+
+@pytest.mark.parametrize("dut", [PLACE], indirect=True)
+def test_adrv9009_system_solve_matches_hw(dut):
+    """Full zc706 ADRV9009 system solve closes at the measured config."""
+    status = dut.jesd_status()
+    sample_rates = list(dut.sampling_frequencies().values())
+    rx = [st for name, st in status.items() if st.up and "tx" not in name.lower()]
+    tx = [st for name, st in status.items() if st.up and "tx" in name.lower()]
+    if not (rx and tx):
+        pytest.skip(f"need both Rx and Tx links up on '{PLACE}'")
+
+    rx_match = match_link(adijif.adrv9009_rx, rx[0].lane_rate_hz, sample_rates)
+    tx_match = match_link(adijif.adrv9009_tx, tx[0].lane_rate_hz, sample_rates)
+    assert rx_match and tx_match, "could not match both Rx and Tx to HW"
+
+    vcxo = 122.88e6
+    sys = adijif.system("adrv9009", "ad9528", "xilinx", vcxo, solver="CPLEX")
+    sys.fpga.setup_by_dev_kit_name("zc706")
+    sys.clock.d = [*range(1, 257)]
+
+    sys.converter.adc.sample_clock = rx_match[0]
+    sys.converter.adc.decimation = 4
+    sys.converter.adc.set_quick_configuration_mode(
+        rx_match[1].mode, rx_match[1].jesd_class
+    )
+    sys.converter.dac.sample_clock = tx_match[0]
+    sys.converter.dac.interpolation = 4
+    sys.converter.dac.set_quick_configuration_mode(
+        tx_match[1].mode, tx_match[1].jesd_class
+    )
+
+    assert sys.converter.adc.bit_clock == pytest.approx(rx[0].lane_rate_hz, rel=1e-6)
+    assert sys.converter.dac.bit_clock == pytest.approx(tx[0].lane_rate_hz, rel=1e-6)
+
+    cfg = sys.solve()
+    assert "clock" in cfg and "converter" in cfg

--- a/tests/hardware/test_hw_nuc_fmcdaq3.py
+++ b/tests/hardware/test_hw_nuc_fmcdaq3.py
@@ -1,0 +1,111 @@
+"""Hardware validation for the 'nuc' DUT: FMCDAQ3 (AD9680 + AD9152) on vcu118.
+
+Reads the live JESD link status + sample rates from the booted board and
+asserts that pyadi-jif's AD9680/AD9152 models reproduce the measured lane
+rate, and that the full vcu118 system solve closes.
+
+Run: pytest --run-hardware tests/hardware/test_hw_nuc_fmcdaq3.py -v
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import adijif
+
+from .validation import available_lane_rates, match_link
+
+pytestmark = pytest.mark.hardware
+
+PLACE = "nuc"
+
+
+@pytest.mark.parametrize("dut", [PLACE], indirect=True)
+def test_fmcdaq3_jesd_links_up(dut):
+    """At least one JESD link on the FMCDAQ3 is enabled and (if reported) DATA."""
+    status = dut.jesd_status()
+    assert status, f"no axi-jesd204 status nodes found on '{PLACE}'"
+    up = {name: st for name, st in status.items() if st.up}
+    assert up, f"no JESD link is up on '{PLACE}': {status}"
+
+
+@pytest.mark.parametrize("dut", [PLACE], indirect=True)
+def test_ad9680_model_matches_hw(dut):
+    """pyadi-jif AD9680 (ADC) reproduces the measured Rx lane rate."""
+    status = dut.jesd_status()
+    sample_rates = list(dut.sampling_frequencies().values())
+    assert sample_rates, "no IIO sampling_frequency reported by DUT"
+
+    rx_links = [
+        st for name, st in status.items() if st.up and "tx" not in name.lower()
+    ]
+    if not rx_links:
+        pytest.skip(f"no Rx JESD link up on '{PLACE}': {list(status)}")
+    lane_rate = rx_links[0].lane_rate_hz
+    assert lane_rate, "Rx link reports no lane rate"
+
+    result = match_link(adijif.ad9680, lane_rate, sample_rates)
+    assert result is not None, (
+        f"no AD9680 mode reproduces HW lane rate {lane_rate/1e9:.4f} GHz at "
+        f"sample rates {sample_rates}; "
+        f"model offers {available_lane_rates(adijif.ad9680(), sample_rates[0])}"
+    )
+    sr, mode = result
+    assert mode.bit_clock == pytest.approx(lane_rate, rel=1e-6)
+
+
+@pytest.mark.parametrize("dut", [PLACE], indirect=True)
+def test_ad9152_model_matches_hw(dut):
+    """pyadi-jif AD9152 (DAC) reproduces the measured Tx lane rate."""
+    status = dut.jesd_status()
+    sample_rates = list(dut.sampling_frequencies().values())
+    assert sample_rates, "no IIO sampling_frequency reported by DUT"
+
+    tx_links = [st for name, st in status.items() if st.up and "tx" in name.lower()]
+    if not tx_links:
+        pytest.skip(f"no Tx JESD link up on '{PLACE}': {list(status)}")
+    lane_rate = tx_links[0].lane_rate_hz
+    assert lane_rate, "Tx link reports no lane rate"
+
+    result = match_link(adijif.ad9152, lane_rate, sample_rates)
+    assert result is not None, (
+        f"no AD9152 mode reproduces HW lane rate {lane_rate/1e9:.4f} GHz at "
+        f"sample rates {sample_rates}"
+    )
+    sr, mode = result
+    assert mode.bit_clock == pytest.approx(lane_rate, rel=1e-6)
+
+
+@pytest.mark.parametrize("dut", [PLACE], indirect=True)
+def test_fmcdaq3_system_solve_matches_hw(dut):
+    """Full vcu118 FMCDAQ3 system solve closes at the measured config."""
+    status = dut.jesd_status()
+    sample_rates = list(dut.sampling_frequencies().values())
+    rx = [st for name, st in status.items() if st.up and "tx" not in name.lower()]
+    tx = [st for name, st in status.items() if st.up and "tx" in name.lower()]
+    if not (rx and tx):
+        pytest.skip(f"need both Rx and Tx links up on '{PLACE}'")
+
+    adc_match = match_link(adijif.ad9680, rx[0].lane_rate_hz, sample_rates)
+    dac_match = match_link(adijif.ad9152, tx[0].lane_rate_hz, sample_rates)
+    assert adc_match and dac_match, "could not match both converters to HW"
+
+    vcxo = 125000000
+    sys = adijif.system(["ad9680", "ad9152"], "ad9528", "xilinx", vcxo, solver="CPLEX")
+    sys.fpga.setup_by_dev_kit_name("vcu118")
+
+    adc = sys.converter[0]
+    adc.sample_clock = adc_match[0]
+    adc.decimation = 1
+    adc.set_quick_configuration_mode(adc_match[1].mode, adc_match[1].jesd_class)
+
+    dac = sys.converter[1]
+    dac.sample_clock = dac_match[0]
+    dac.interpolation = 1
+    dac.set_quick_configuration_mode(dac_match[1].mode, dac_match[1].jesd_class)
+
+    assert adc.bit_clock == pytest.approx(rx[0].lane_rate_hz, rel=1e-6)
+    assert dac.bit_clock == pytest.approx(tx[0].lane_rate_hz, rel=1e-6)
+
+    cfg = sys.solve()
+    assert "clock" in cfg and "converter" in cfg

--- a/tests/hardware/validation.py
+++ b/tests/hardware/validation.py
@@ -1,0 +1,114 @@
+"""Helpers to validate pyadi-jif converter models against measured HW facts.
+
+The core idea: a booted board reports its JESD *lane rate* and *sample rate*.
+A faithful pyadi-jif model must contain a quick-configuration mode that, at the
+measured sample rate, reproduces the measured lane rate. This validates the
+model's JESD lane-rate math against reality without needing to read the raw
+L/M/F/S parameters from the kernel (which are not exposed uniformly).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+
+@dataclass
+class MatchedMode:
+    """A converter quick-configuration mode that matches measured hardware."""
+
+    mode: str
+    jesd_class: str
+    L: int
+    M: int
+    Np: int
+    bit_clock: float
+
+
+def find_matching_mode(
+    conv,
+    sample_clock: float,
+    lane_rate_hz: float,
+    rel_tol: float = 1e-6,
+) -> Optional[MatchedMode]:
+    """Find a quick-config mode reproducing ``lane_rate_hz`` at ``sample_clock``.
+
+    Args:
+        conv: A pyadi-jif converter instance (e.g. ``adijif.ad9680()``).
+        sample_clock: Measured sample rate in hertz.
+        lane_rate_hz: Measured JESD lane rate in hertz.
+        rel_tol: Relative tolerance for the lane-rate comparison.
+
+    Returns:
+        The first matching :class:`MatchedMode`, or ``None`` if no mode matches.
+    """
+    conv.sample_clock = sample_clock
+    modes = conv.quick_configuration_modes
+    for jesd_class, table in modes.items():
+        for mode in table:
+            try:
+                conv.set_quick_configuration_mode(mode, jesd_class)
+                conv.sample_clock = sample_clock
+                bc = conv.bit_clock
+            except Exception:  # noqa: BLE001 - skip modes invalid for this rate
+                continue
+            if bc <= 0:
+                continue
+            if abs(bc - lane_rate_hz) <= rel_tol * lane_rate_hz:
+                return MatchedMode(
+                    mode=mode,
+                    jesd_class=jesd_class,
+                    L=int(conv.L),
+                    M=int(conv.M),
+                    Np=int(conv.Np),
+                    bit_clock=bc,
+                )
+    return None
+
+
+def match_link(
+    conv_factory,
+    lane_rate_hz: float,
+    sample_rates: List[float],
+    rel_tol: float = 1e-6,
+) -> Optional[Tuple[float, MatchedMode]]:
+    """Find a (sample_rate, mode) the model reproduces for a measured lane rate.
+
+    Tries each candidate sample rate (e.g. every IIO ``sampling_frequency`` the
+    board reports) against a fresh converter so a failed mode set on one rate
+    does not leak into the next.
+
+    Args:
+        conv_factory: Zero-arg callable returning a fresh converter instance.
+        lane_rate_hz: Measured JESD lane rate in hertz.
+        sample_rates: Candidate sample rates in hertz.
+        rel_tol: Relative tolerance for the lane-rate comparison.
+
+    Returns:
+        ``(sample_rate, MatchedMode)`` for the first match, else ``None``.
+    """
+    for sr in sample_rates:
+        if sr <= 0:
+            continue
+        match = find_matching_mode(conv_factory(), sr, lane_rate_hz, rel_tol)
+        if match is not None:
+            return sr, match
+    return None
+
+
+def available_lane_rates(conv, sample_clock: float) -> List[Tuple[str, float]]:
+    """List ``(mode, bit_clock)`` pairs for all modes at ``sample_clock``.
+
+    Useful for diagnostics when :func:`find_matching_mode` returns ``None``.
+    """
+    out: List[Tuple[str, float]] = []
+    modes = conv.quick_configuration_modes
+    for jesd_class, table in modes.items():
+        for mode in table:
+            try:
+                conv.set_quick_configuration_mode(mode, jesd_class)
+                conv.sample_clock = sample_clock
+                out.append((f"{jesd_class}/{mode}", conv.bit_clock))
+            except Exception:  # noqa: BLE001
+                continue
+    return out

--- a/tests/hardware/validation.py
+++ b/tests/hardware/validation.py
@@ -50,7 +50,7 @@ def find_matching_mode(
                 conv.set_quick_configuration_mode(mode, jesd_class)
                 conv.sample_clock = sample_clock
                 bc = conv.bit_clock
-            except Exception:  # noqa: BLE001 - skip modes invalid for this rate
+            except Exception:  # noqa: BLE001, S112 - skip invalid modes
                 continue
             if bc <= 0:
                 continue
@@ -109,6 +109,6 @@ def available_lane_rates(conv, sample_clock: float) -> List[Tuple[str, float]]:
                 conv.set_quick_configuration_mode(mode, jesd_class)
                 conv.sample_clock = sample_clock
                 out.append((f"{jesd_class}/{mode}", conv.bit_clock))
-            except Exception:  # noqa: BLE001
+            except Exception:  # noqa: BLE001, S112 - skip invalid modes
                 continue
     return out

--- a/tests/test_adrv9371.py
+++ b/tests/test_adrv9371.py
@@ -106,3 +106,61 @@ def test_adrv9371_quick_config(solver):
 
     sys.converter.adc._check_clock_relations()
     sys.converter.dac._check_clock_relations()
+
+
+@pytest.mark.parametrize(
+    "part, M, L, S, expected_F",
+    [
+        ("adrv9371_rx", 4, 2, 1, 4),  # zc706 main-Rx framing (M=4 L=2 -> F=4)
+        ("adrv9371_tx", 4, 4, 1, 2),  # zc706 Tx framing       (M=4 L=4 -> F=2)
+    ],
+)
+def test_adrv9371_zc706_m4_modes(part, M, L, S, expected_F):
+    """Native AD9371 exposes the M=4 (two complex I/Q channels) zc706 modes.
+
+    These are the modes the Kuiper ``zynq-zc706-adv7511-adrv937x`` reference
+    actually boots (validated on the ``bq`` board) and that pyadi-dt selects
+    when generating the ADRV9371 device tree.
+    """
+    conv = getattr(adijif, part)()
+    modes = adijif.utils.get_jesd_mode_from_params(conv, M=M, L=L, S=S, Np=16)
+    assert len(modes) == 1, modes
+    settings = modes[0]["settings"]
+    assert settings["F"] == expected_F
+    assert settings["M"] == M and settings["L"] == L and settings["Np"] == 16
+
+
+def test_adrv9371_zc706_reference_framing():
+    """ADRV9371 reproduces the zc706 reference framing (Rx M4/L2, Tx M4/L4).
+
+    These are the exact M/L/F the Kuiper ``zynq-zc706-adv7511-adrv937x`` device
+    tree carries (validated on the ``bq`` board), and what pyadi-dt selects via
+    ``get_jesd_mode_from_params`` when generating the ADRV9371 device tree. This
+    checks framing + lane-rate math only; closing a full FPGA system solve at the
+    measured rates is covered by the hardware test (it needs the live sample
+    rates, which differ between the Rx and Tx paths).
+    """
+    rx = adijif.adrv9371_rx()
+    rx.sample_clock = 122.88e6
+    rx.set_quick_configuration_mode(
+        adijif.utils.get_jesd_mode_from_params(rx, M=4, L=2, S=1, Np=16)[0][
+            "mode"
+        ],
+        "jesd204b",
+    )
+    assert (rx.M, rx.L, rx.F, rx.Np) == (4, 2, 4, 16)
+    # Lane rate = sample * M * Np * (10/8) / L
+    assert rx.bit_clock == 4.9152e9
+    assert rx.bit_clock <= 6.144e9  # AD9371 JESD204B max lane rate
+
+    tx = adijif.adrv9371_tx()
+    tx.sample_clock = 245.76e6
+    tx.set_quick_configuration_mode(
+        adijif.utils.get_jesd_mode_from_params(tx, M=4, L=4, S=1, Np=16)[0][
+            "mode"
+        ],
+        "jesd204b",
+    )
+    assert (tx.M, tx.L, tx.F, tx.Np) == (4, 4, 2, 16)
+    assert tx.bit_clock == 4.9152e9
+    assert tx.bit_clock <= 6.144e9

--- a/tests/test_adrv9371.py
+++ b/tests/test_adrv9371.py
@@ -1,0 +1,108 @@
+# flake8: noqa
+
+import pytest
+
+import adijif
+
+from .common import skip_solver
+
+
+def test_adrv9371_registered():
+    """ADRV9371 classes are exported and listed as supported converter parts."""
+    assert hasattr(adijif, "adrv9371")
+    assert hasattr(adijif, "adrv9371_rx")
+    assert hasattr(adijif, "adrv9371_tx")
+    assert "adrv9371_rx" in adijif.converters.supported_parts
+    assert "adrv9371_tx" in adijif.converters.supported_parts
+
+
+@pytest.mark.parametrize("converter", ["adrv9371_rx", "adrv9371_tx"])
+def test_adrv9371_lane_rate_math(converter):
+    """Lane rate = sample_clock * M * Np * (10/8) / L."""
+    conv = getattr(adijif, converter)()
+    conv.sample_clock = 245.76e6
+    # Mode 3 -> M=2, L=2, Np=16
+    conv.set_quick_configuration_mode("3", "jesd204b")
+    assert conv.M == 2
+    assert conv.L == 2
+    assert conv.Np == 16
+    expected = 245.76e6 * conv.M * conv.Np * (10 / 8) / conv.L
+    assert conv.bit_clock == expected
+    assert conv.bit_clock == 4.9152e9
+
+
+@pytest.mark.parametrize("solver", ["CPLEX"])
+@pytest.mark.parametrize("converter", ["adrv9371_rx", "adrv9371_tx"])
+def test_adrv9371_singleton_solve(solver, converter):
+    skip_solver(solver)
+
+    vcxo = 122.88e6
+    sys = adijif.system(converter, "ad9528", "xilinx", vcxo, solver=solver)
+    sys.converter.sample_clock = 245.76e6
+
+    if converter == "adrv9371_rx":
+        sys.converter.decimation = 4
+    else:
+        sys.converter.interpolation = 4
+
+    sys.converter.set_quick_configuration_mode("3", "jesd204b")
+    assert sys.converter.bit_clock == 4.9152e9
+    assert sys.converter.device_clock == 4.9152e9 / 40
+
+    sys.fpga.setup_by_dev_kit_name("zc706")
+    sys.clock.d = [*range(1, 257)]
+
+    cfg = sys.solve()
+
+    ref_name = f"{sys.fpga.name}_{converter.upper()}_ref_clk"
+    assert cfg["clock"]["output_clocks"][ref_name]["rate"] == 122880000.0
+
+
+@pytest.mark.parametrize("solver", ["CPLEX"])
+def test_adrv9371_combined_solve(solver):
+    skip_solver(solver)
+
+    vcxo = 122.88e6
+    sys = adijif.system("adrv9371", "ad9528", "xilinx", vcxo, solver=solver)
+
+    # Rx
+    sys.converter.adc.sample_clock = 245.76e6
+    sys.converter.adc.decimation = 4
+    sys.converter.adc.set_quick_configuration_mode("3", "jesd204b")
+    assert sys.converter.adc.bit_clock == 4.9152e9
+
+    # Tx
+    sys.converter.dac.sample_clock = 245.76e6
+    sys.converter.dac.interpolation = 4
+    sys.converter.dac.set_quick_configuration_mode("3", "jesd204b")
+    assert sys.converter.dac.bit_clock == 4.9152e9
+
+    sys.fpga.setup_by_dev_kit_name("zc706")
+    sys.clock.d = [*range(1, 257)]
+
+    cfg = sys.solve()
+
+    output_clocks = cfg["clock"]["output_clocks"]
+    assert output_clocks["zc706_adc_ref_clk"]["rate"] == 122880000.0
+    assert output_clocks["zc706_dac_ref_clk"]["rate"] == 122880000.0
+
+
+@pytest.mark.parametrize("solver", ["CPLEX"])
+def test_adrv9371_quick_config(solver):
+    skip_solver(solver)
+
+    sys = adijif.system("adrv9371", "ad9528", "xilinx", 122.88e6, solver=solver)
+    sys.converter.adc.sample_clock = 245.76e6
+    sys.converter.dac.sample_clock = 245.76e6
+    sys.converter.adc.decimation = 4
+    sys.converter.dac.interpolation = 4
+
+    sys.converter.adc.set_quick_configuration_mode("3", "jesd204b")
+    sys.converter.dac.set_quick_configuration_mode("3", "jesd204b")
+
+    assert sys.converter.adc.L == 2
+    assert sys.converter.adc.M == 2
+    assert sys.converter.adc.Np == 16
+
+    sys.converter.adc._check_clock_relations()
+    sys.converter.dac._check_clock_relations()

--- a/tests/test_adrv9371.py
+++ b/tests/test_adrv9371.py
@@ -164,3 +164,16 @@ def test_adrv9371_zc706_reference_framing():
     assert (tx.M, tx.L, tx.F, tx.Np) == (4, 4, 2, 16)
     assert tx.bit_clock == 4.9152e9
     assert tx.bit_clock <= 6.144e9
+
+
+@pytest.mark.parametrize("factory", [adijif.adrv9371_rx, adijif.adrv9371_tx])
+def test_adrv9371_quick_modes_have_integral_jesd_framing(factory):
+    """Every quick-config mode is legal JESD204B: F is a positive integer."""
+    conv = factory()
+    for jesd_class, table in conv.quick_configuration_modes.items():
+        for mode, params in table.items():
+            F = params["F"]
+            assert F == int(F) and F >= 1, (
+                f"{factory.__name__} {jesd_class} mode {mode} has invalid "
+                f"F={F}"
+            )

--- a/tests/tools/e2e/pages/base_page.py
+++ b/tests/tools/e2e/pages/base_page.py
@@ -185,35 +185,18 @@ class BasePage:
 
         # Click the option by text
         # The dropdown options have role="option"
-        # Try exact match first
-        dropdown_option = self.page.locator(
-            f'[role="option"]:has-text({value!r})'
-        )
-
-        if dropdown_option.count() > 0:
-            # Option found with exact match
-            dropdown_option.first.click()
-        else:
-            # Try case-insensitive search
-            dropdown_option = self.page.locator(
-                f'[role="option"] >> text=/{value}/i'
-            )
-            if dropdown_option.count() > 0:
-                dropdown_option.first.click()
-            else:
-                # Try looking for the uppercased version (common with format_func)
-                upper_value = value.upper().replace("_", "-")
-                dropdown_option = self.page.locator(
-                    f'[role="option"]:has-text({upper_value!r})'
+        if not self._click_dropdown_option(value):
+            # baseweb virtualizes long option lists, so an off-screen option
+            # may not exist in the DOM at all. Type the value into the open
+            # combobox to filter the list down, then retry the match.
+            self.page.keyboard.type(str(value))
+            self.page.wait_for_timeout(300)
+            if not self._click_dropdown_option(value):
+                msg = (
+                    f"Option {value!r} not found in dropdown "
+                    f"(available: {available_options})"
                 )
-                if dropdown_option.count() > 0:
-                    dropdown_option.first.click()
-                else:
-                    msg = (
-                        f"Option {value!r} not found in dropdown "
-                        f"(available: {available_options})"
-                    )
-                    raise ValueError(msg)
+                raise ValueError(msg)
 
         # Wait for dropdown to close
         self.page.wait_for_function(
@@ -221,6 +204,31 @@ class BasePage:
             timeout=5000,
         )
         self.wait_for_streamlit_ready()
+
+    def _click_dropdown_option(self, value: str) -> bool:
+        """Click a rendered dropdown option matching ``value``.
+
+        Tries an exact match, then case-insensitive, then the uppercased
+        form produced by common ``format_func`` implementations.
+
+        Args:
+            value: Option value or label text to match.
+
+        Returns:
+            True when an option was found and clicked, False otherwise.
+        """
+        candidates = (
+            f'[role="option"]:has-text({value!r})',
+            f'[role="option"] >> text=/{value}/i',
+            "[role=\"option\"]:has-text("
+            f"{value.upper().replace('_', '-')!r})",
+        )
+        for selector in candidates:
+            option = self.page.locator(selector)
+            if option.count() > 0:
+                option.first.click()
+                return True
+        return False
 
     def set_number_input(self, label: str, value: float) -> None:
         """Set number input value.


### PR DESCRIPTION
## Summary

Follow-up to #292 (merged). Brings in the `feat/hardware-jesd-tests` labgrid infra (rebased onto main) and adds hardware-in-the-loop plus Vivado build validation for the `adi.xgt-wizard` export, targeting the lab's `mini2` place (AD9081 on ZCU102, SD-mux boot, tests routed through the Vivado-capable `hw-bq` runner).

## Hardware tests — `tests/hardware/test_hw_mini2_ad9081.py`

- JESD links up on the booted board (`axi-jesd204` status via the existing DUT SSH reader)
- Per-direction model check: measured RX/TX lane rates are reproduced by an AD9081 quick-config mode (`validation.match_link`)
- **xgt_wizard round-trip**: matches each measured link to a mode, solves the full `zcu102` system (HMC7044 vcxo 122.88 MHz per the rig's `m8_l4_vcxo122p88` config), exports `adi.xgt-wizard`, and asserts the exported `LANE_RATE`/`XCVR_RX_LANE_RATE`, JESD mode, and lane counts equal what the hardware reports. The status parser now detects the encoding from the `Lane rate / 40|66` line (unit-tested).

Tests skip cleanly from a dev session when the board is down (verified live: mini2 unreachable → 4 clean skips).

## HDL build test — `tests/hardware/test_hdl_xcvr_wizard_build.py`

New `hdl_build` marker gated by `--run-hdl-build`; skips without `HDL_DIR` (ADI hdl checkout) or `vivado` on PATH. Solves the mini2-like AD9081+ZCU102 system, exports the wizard config, and runs `make -C $HDL_DIR/projects/xcvr_wizard/zcu102 LANE_RATE=… REF_CLK=… PLL_TYPE=…` once per distinct direction — GT wizard generation only (minutes, no synthesis) — asserting exit 0 and a non-empty `GTHE4_cfng.txt`. Build logs land as `*.log` for the CI artifact glob. Command construction lives in `tests/hardware/hdl_build.py` with plain unit tests (no Vivado needed).

## CI

- `mini2` entry in `.github/hw-nodes.json` (runner `hw-bq`, both test files)
- `hardware-tests.yml`: `pre_pytest_cmd` maintains a persistent hdl clone at `~/.cache/hw-ci/hdl` and exports `HDL_DIR` via `GITHUB_ENV`; `--run-hdl-build` added to the shared pytest template (inert for legs that don't list the build test); leg timeout raised to 120 min
- Note: `workflow_dispatch` of `hardware-tests` only becomes available once this workflow file lands on the default branch — the first real hardware/Vivado run happens after merge (or nightly)

## Fixes picked up along the way

- ADRV9371 re-registered in `adijif/registry.py` — main rewrote the registry after `feat/hardware-jesd-tests` diverged, so merging silently dropped it (its tests failed until fixed)
- `.gitignore`'s `env/` rule (meant for virtualenvs) was hiding `tests/hardware/env/*.yaml` — files `hw-nodes.json` references but which were never actually committed; now un-ignored and added, including the new `mini2.yaml`

## Testing

- Software suite: 819 passed (hardware/build tests skip without their flags); ruff clean on new files
- Live skip-path verified against the coordinator (board powered off → clean skips)