### PR TITLE
Enforce per-transceiver line-rate ceilings in the Xilinx FPGA model

### DIFF
--- a/adijif/fpgas/xilinx/__init__.py
+++ b/adijif/fpgas/xilinx/__init__.py
@@ -110,6 +110,39 @@ class xilinx(xilinx_bf, xilinx_draw):
     ]
     transceiver_type = "GTXE2"
 
+    # Serializer line-rate ceilings per transceiver type (max speed grade),
+    # from the Xilinx family datasheets (DS181/DS191 7-series, DS892/DS925
+    # UltraScale(+), DS957 Versal). The PLL models only bound the VCO, which
+    # permits line rates the SERDES itself cannot do (e.g. a GTHE4 QPLL VCO
+    # of 11.9625 GHz with D=1 implies 23.925 Gbps, beyond GTH's 16.375).
+    _max_lane_rates = {
+        "GTXE2": 12.5e9,
+        "GTHE2": 13.1e9,
+        "GTHE3": 16.375e9,
+        "GTHE4": 16.375e9,
+        "GTYE3": 30.5e9,
+        "GTYE4": 32.75e9,
+        "GTYE5": 32.75e9,
+        "GTYP": 32.75e9,
+    }
+
+    @property
+    def max_lane_rate(self) -> float:
+        """Maximum serializer line rate for the configured transceiver type.
+
+        Returns:
+            float: Line-rate ceiling in bits/second.
+
+        Raises:
+            Exception: If the transceiver type has no known ceiling.
+        """
+        if self.transceiver_type not in self._max_lane_rates:
+            raise Exception(
+                "Unknown max lane rate for transceiver type "
+                f"{self.transceiver_type}"
+            )
+        return self._max_lane_rates[self.transceiver_type]
+
     def trx_gen(self) -> int:
         """Get transceiver generation (2,3,4,5).
 
@@ -905,8 +938,24 @@ class xilinx(xilinx_bf, xilinx_draw):
             Dict: Dictionary of clocking rates and dividers for configuration
 
         Raises:
-            Exception: Unsupported solver
+            Exception: Unsupported solver, or the converter's lane rate
+                exceeds the transceiver's line-rate ceiling.
         """
+        # The GT wizard rejects out-of-range line rates; fail the solve
+        # early with a clear message instead of emitting an unbuildable
+        # configuration. In rate-search flows bit_clock is a solver
+        # expression, so the ceiling becomes a solver constraint there.
+        if isinstance(converter.bit_clock, (int, float)):
+            if converter.bit_clock > self.max_lane_rate:
+                raise Exception(
+                    f"Lane rate {converter.bit_clock / 1e9:.4f} Gbps for "
+                    f"converter {converter.name} exceeds the "
+                    f"{self.transceiver_type} maximum of "
+                    f"{self.max_lane_rate / 1e9} Gbps"
+                )
+        else:
+            self._add_equation([converter.bit_clock <= self.max_lane_rate])
+
         # Add reference clock constraints
         self._add_equation(
             [fpga_ref >= self.ref_clock_min, fpga_ref <= self.ref_clock_max]

--- a/doc/source/fpgas/fpgas.md
+++ b/doc/source/fpgas/fpgas.md
@@ -49,6 +49,15 @@ sys.fpga.force_qpll = 0
 
 The solver tries to use the CPLL since it is more flexible architecturally. For more detail on the 7000 Series PLL architecture consult [ug476](https://www.xilinx.com/support/documentation/user_guides/ug476_7Series_Transceivers.pdf).
 
+### Line-rate limits
+
+Each transceiver type enforces its serializer line-rate ceiling (max speed
+grade, per the Xilinx family datasheets): GTXE2 12.5, GTHE2 13.1,
+GTHE3/GTHE4 16.375, GTYE3 30.5, and GTYE4/GTYE5/GTYP 32.75 Gbps. A solve
+whose JESD lane rate exceeds the configured transceiver's ceiling raises
+immediately with a descriptive error rather than emitting a configuration
+the GT wizard would reject.
+
 ### Current known limitations
 
 -   When multiple converters are connected to the same FPGA, or RX and TX from the same converter, the solver does not force the clocks to come from a single QTile.

--- a/examples/ad9081_rx_hmc7044_ext_pll_adf4371.py
+++ b/examples/ad9081_rx_hmc7044_ext_pll_adf4371.py
@@ -25,7 +25,9 @@ sys.converter.clocking_option = "direct"
 sys.add_pll_inline("adf4371", sys.clock, sys.converter)
 
 
-mode_tx = "0"
+# TX mode 4 stays within the ZCU102 GTHE4 line-rate ceiling
+# (mode 0 solves to 23.925 Gbps > 16.375 Gbps and is rejected).
+mode_tx = "4"
 mode_rx = "1.0"
 
 sys.converter.dac.set_quick_configuration_mode(mode_tx, "jesd204c")

--- a/examples/ad9081_rxtx_adf4030.py
+++ b/examples/ad9081_rxtx_adf4030.py
@@ -27,7 +27,9 @@ assert sys.converter.dac.interpolation == cddc * fddc
 # sys.add_pll_inline("adf4371", sys.clock, sys.converter)
 sys.add_pll_sysref("adf4030", vcxo, sys.converter, sys.fpga)
 
-mode_tx = "0"
+# TX mode 4 stays within the ZCU102 GTHE4 line-rate ceiling
+# (mode 0 solves to 23.925 Gbps > 16.375 Gbps and is rejected).
+mode_tx = "4"
 mode_rx = "1.0"
 
 sys.converter.dac.set_quick_configuration_mode(mode_tx, "jesd204c")

--- a/examples/ad9081_rxtx_hmc7044.py
+++ b/examples/ad9081_rxtx_hmc7044.py
@@ -23,7 +23,10 @@ sys.converter.dac.datapath.cduc_interpolation = cddc
 sys.converter.dac.datapath.fduc_interpolation = fddc
 sys.converter.dac.datapath.fduc_enabled = [True]*8
 
-mode_tx = "0"
+# TX mode 4 (L=2 M=8 Np=12) and RX mode 1.0 both land on 11.9625 Gbps.
+# TX mode 0 would solve to 23.925 Gbps, which exceeds the ZCU102's GTHE4
+# line-rate ceiling (16.375 Gbps) and is now rejected by the FPGA model.
+mode_tx = "4"
 mode_rx = "1.0"
 
 sys.converter.dac.set_quick_configuration_mode(mode_tx, "jesd204c")

--- a/examples/ad9082_rxtx_hmc7044.py
+++ b/examples/ad9082_rxtx_hmc7044.py
@@ -23,7 +23,9 @@ sys.converter.dac.datapath.cduc_interpolation = cddc
 sys.converter.dac.datapath.fduc_interpolation = fddc
 sys.converter.dac.datapath.fduc_enabled = [True]*8
 
-mode_tx = "0"
+# TX mode 4 stays within the ZCU102 GTHE4 line-rate ceiling
+# (mode 0 solves to 23.925 Gbps > 16.375 Gbps and is rejected).
+mode_tx = "4"
 mode_rx = "1.0"
 
 sys.converter.dac.set_quick_configuration_mode(mode_tx, "jesd204c")

--- a/tests/test_adf4030.py
+++ b/tests/test_adf4030.py
@@ -59,7 +59,9 @@ def test_adf4030_system():
     # sys.add_pll_inline("adf4371", sys.clock, sys.converter)
     sys.add_pll_sysref("adf4030", vcxo, sys.converter, sys.fpga)
 
-    mode_tx = "0"
+    # TX mode 4 stays within the ZCU102 GTHE4 line-rate ceiling
+    # (mode 0 solves to 23.925 Gbps > 16.375 Gbps and is rejected).
+    mode_tx = "4"
     mode_rx = "1.0"
 
     sys.converter.dac.set_quick_configuration_mode(mode_tx, "jesd204c")

--- a/tests/test_adf4371.py
+++ b/tests/test_adf4371.py
@@ -68,7 +68,9 @@ def test_adf4371_ad9081_sys_example():
     sys.converter.clocking_option = "direct"
     sys.add_pll_inline("adf4371", sys.clock, sys.converter)
 
-    mode_tx = "0"
+    # TX mode 4 stays within the ZCU102 GTHE4 line-rate ceiling
+    # (mode 0 solves to 23.925 Gbps > 16.375 Gbps and is rejected).
+    mode_tx = "4"
     mode_rx = "1.0"
 
     sys.converter.dac.set_quick_configuration_mode(mode_tx, "jesd204c")

--- a/tests/test_xilinx_lane_rate.py
+++ b/tests/test_xilinx_lane_rate.py
@@ -1,0 +1,67 @@
+"""Per-transceiver-type maximum lane (line) rate enforcement."""
+
+import pytest
+
+import adijif
+
+from .common import skip_solver
+
+
+def _ad9081_zcu102(mode_tx: str, mode_rx: str):
+    cddc, fddc = 6, 4
+    sys = adijif.system("ad9081", "hmc7044", "xilinx", 100e6, solver="CPLEX")
+    sys.fpga.setup_by_dev_kit_name("zcu102")
+    sys.fpga.ref_clock_constraint = "Unconstrained"
+    sys.fpga.sys_clk_select = "XCVR_QPLL0"
+    sys.fpga.out_clk_select = "XCVR_PROGDIV_CLK"
+    sys.converter.clocking_option = "integrated_pll"
+    sys.converter.adc.sample_clock = 2900000000 / (cddc * fddc)
+    sys.converter.dac.sample_clock = 5800000000 / (cddc * fddc)
+    sys.converter.adc.datapath.cddc_decimations = [cddc] * 4
+    sys.converter.adc.datapath.fddc_decimations = [fddc] * 8
+    sys.converter.adc.datapath.fddc_enabled = [True] * 8
+    sys.converter.dac.datapath.cduc_interpolation = cddc
+    sys.converter.dac.datapath.fduc_interpolation = fddc
+    sys.converter.dac.datapath.fduc_enabled = [True] * 8
+    sys.converter.dac.set_quick_configuration_mode(mode_tx, "jesd204c")
+    sys.converter.adc.set_quick_configuration_mode(mode_rx, "jesd204c")
+    return sys
+
+
+def test_max_lane_rate_per_transceiver_type():
+    fpga = adijif.xilinx()
+    for trx, expected in (
+        ("GTXE2", 12.5e9),
+        ("GTHE3", 16.375e9),
+        ("GTHE4", 16.375e9),
+        ("GTYE3", 30.5e9),
+        ("GTYE4", 32.75e9),
+        ("GTYE5", 32.75e9),
+        ("GTYP", 32.75e9),
+    ):
+        fpga.transceiver_type = trx
+        assert fpga.max_lane_rate == expected
+
+
+def test_unknown_transceiver_type_max_lane_rate_raises():
+    fpga = adijif.xilinx()
+    fpga.transceiver_type = "GTFAKE9"
+    with pytest.raises(Exception, match="[Uu]nknown"):
+        _ = fpga.max_lane_rate
+
+
+def test_out_of_range_lane_rate_rejected_on_gthe4():
+    """AD9081 TX mode 0 solves to 23.925 Gbps: beyond GTHE4's 16.375."""
+    skip_solver("CPLEX")
+    sys = _ad9081_zcu102(mode_tx="0", mode_rx="1.0")
+    with pytest.raises(Exception, match="exceeds.*GTHE4.*16\\.375"):
+        sys.solve()
+
+
+def test_in_range_lane_rate_still_solves_on_gthe4():
+    """TX mode 4 / RX mode 1.0 (11.9625 Gbps) stays solvable."""
+    skip_solver("CPLEX")
+    sys = _ad9081_zcu102(mode_tx="4", mode_rx="1.0")
+    cfg = sys.solve()
+    assert cfg["jesd_dac"]["bit_clock"] == pytest.approx(11.9625e9)
+    assert cfg["jesd_adc"]["bit_clock"] == pytest.approx(11.9625e9)


### PR DESCRIPTION
## Summary

Follow-up from #293's lab verification: jif's Xilinx PLL models bound only the VCO, so solves could emit line rates the SERDES silicon cannot do — AD9081 TX jesd204c mode 0 solved to **23.925 Gbps on the ZCU102's GTHE4** (VCO 11.9625 GHz × 2 / D=1), which the HDL GT wizard rejects ("out of QPLL1 range"; GTH tops out at 16.375 Gbps).

Stacked on #293 (retargets to main when it merges).

## Changes

- **Per-type ceilings** (`adijif/fpgas/xilinx/__init__.py`): new `max_lane_rate` property with datasheet limits at max speed grade — GTXE2 12.5, GTHE2 13.1, GTHE3/GTHE4 16.375, GTYE3 30.5, GTYE4/GTYE5/GTYP 32.75 Gbps.
- **Enforcement in `_setup_quad_tile`**: a concrete `bit_clock` above the ceiling raises immediately with a descriptive error (`Lane rate 23.9250 Gbps for converter AD9081_TX exceeds the GTHE4 maximum of 16.375 Gbps`); a symbolic `bit_clock` (rate-search flows like `utils.find_extreme_rate`) becomes a solver constraint instead — the first implementation broke the extreme-rate search tests until this split.
- **Fallout fixes**: every AD9081/AD9082 + ZCU102 example and test using TX mode 0 was asserting a physically unbuildable config; all moved to TX mode 4 (11.9625 Gbps, verified in real Vivado in #293): `examples/ad9081_rxtx_hmc7044.py`, `ad9081_rxtx_adf4030.py`, `ad9082_rxtx_hmc7044.py`, `ad9081_rx_hmc7044_ext_pll_adf4371.py`, `tests/test_adf4030.py`, `tests/test_adf4371.py`.
- **Docs**: line-rate limits section in `doc/source/fpgas/fpgas.md`.

## Testing

- New `tests/test_xilinx_lane_rate.py`: ceiling table, unknown-type error, GTHE4 rejection of the 23.925 Gbps solve, and the in-range 11.9625 Gbps solve still closing (written first, watched fail).
- Full suite: 825 passed, ruff clean. All four previously-affected examples re-solve.