### PR TITLE
fix(ad9084): fix JESD mode table parsing and 204B/204C categorization

### DIFF
--- a/adijif/converters/ad9084_util.py
+++ b/adijif/converters/ad9084_util.py
@@ -72,22 +72,18 @@ def _load_tx_config_modes(part: str) -> Dict:
         AssertionError: If the part is not supported.
     """
     assert part in ["AD9084", "AD9088"], f"Unsupported part: {part}"
-    return _read_tx_table_xlsx(
+    return _read_table_xlsx(
         "AD9084_JTX_JRX.xlsx", part, sheet_name="JRX_TxPath"
     )
 
 
-def _read_tx_table_xlsx(filename: str, part: str, sheet_name: str) -> Dict:
-    r"""Parse TX-path JESD configuration table from an Excel file.
-
-    The TX sheet uses different column names than the RX sheet
-    ('Parameter\\n/Mode' instead of 'Mode', 'M ' instead of 'M',
-    and \"N'\" instead of 'Np'), so it needs its own reader.
+def _read_table_xlsx(filename: str, part: str, sheet_name: str) -> Dict:
+    """Parse JESD configuration table from an Excel file.
 
     Args:
         filename (str): Excel filename inside the resources directory.
         part (str): Part name, either "AD9084" or "AD9088".
-        sheet_name (str): Worksheet name to read.
+        sheet_name (str): Worksheet name to read ("JTX_RxPath" or "JRX_TxPath").
 
     Returns:
         Dict: Nested dict keyed by jesd class then mode number string.
@@ -96,8 +92,7 @@ def _read_tx_table_xlsx(filename: str, part: str, sheet_name: str) -> Dict:
     fn = os.path.join(loc, "resources", filename)
     table = pd.read_excel(open(fn, "rb"), sheet_name=sheet_name)
 
-    # Normalize TX-specific column names to match the shared field names used
-    # throughout the rest of the codebase.
+    # Normalize TX-specific column names if reading the TX sheet
     table = table.rename(
         columns={
             "Parameter\n/Mode": "Mode",
@@ -106,75 +101,44 @@ def _read_tx_table_xlsx(filename: str, part: str, sheet_name: str) -> Dict:
         }
     )
 
+    field = "8T8R" if part == "AD9088" else "4T4R"
+    ratio_cols = [
+        c
+        for c in table.columns
+        if "x" in c and c not in ["Rev Changes", "8T8R", "4T4R"]
+    ]
+
     modes_204b = {}
     modes_204c = {}
-    for prow in table.iterrows():
-        row = prow[1].to_dict()
-
-        field = "8T8R" if part == "AD9088" else "4T4R"
-        data = str(row[field])
-
-        if "nan" in data:
-            continue
-        if "Not Supported" in data:
+    for _, row in table.iterrows():
+        if pd.notna(row[field]) and str(row[field]).strip() == "Not Supported":
             continue
 
-        modes_204c[str(int(row["Mode"]))] = {
-            "L": row["L"],
-            "M": row["M"],
-            "F": row["F"],
-            "S": row["S"],
+        ratio_vals = [str(row[c]) for c in ratio_cols if pd.notna(row[c])]
+        has_204b = any("B" in v for v in ratio_vals)
+        has_204c = any("C" in v for v in ratio_vals)
+
+        mode_str = str(int(row["Mode"]))
+        cfg = {
+            "L": int(row["L"]),
+            "M": int(row["M"]),
+            "F": int(row["F"]),
+            "S": int(row["S"]),
             "HD": 1,
-            "Np": row["Np"],
-            "jesd_class": "jesd204c",
+            "Np": int(row["Np"]),
         }
 
-    for mode, config in modes_204c.items():
-        modes_204b[mode] = config.copy()
-        modes_204b[mode]["jesd_class"] = "jesd204b"
+        if has_204b:
+            b_cfg = cfg.copy()
+            b_cfg["jesd_class"] = "jesd204b"
+            modes_204b[mode_str] = b_cfg
+
+        if has_204c:
+            c_cfg = cfg.copy()
+            c_cfg["jesd_class"] = "jesd204c"
+            modes_204c[mode_str] = c_cfg
 
     return {"jesd204b": modes_204b, "jesd204c": modes_204c}
-
-
-def _read_table_xlsx(filename: str, part: str, sheet_name: str) -> Dict:
-    loc = os.path.dirname(__file__)
-    fn = os.path.join(loc, "resources", filename)
-    table = pd.read_excel(open(fn, "rb"), sheet_name=sheet_name)
-
-    # strip out unique JESD modes
-    # table = table.drop_duplicates(subset=["JTX_MODE NUMBER"])
-    jrx_modes_204b = {}
-    jrx_modes_204c = {}
-    for prow in table.iterrows():
-        row = prow[1].to_dict()
-
-        field = "8T8R" if part == "AD9088" else "4T4R"
-        data = str(row[field])
-
-        if "nan" in data:
-            continue
-        if "Not Supported" in data:
-            continue
-
-        jrx_modes_204c[str(row["Mode"])] = {
-            "L": row["L"],
-            "M": row["M"],
-            "F": row["F"],
-            "S": row["S"],
-            "HD": 1,
-            # 'K': row['K'],
-            "Np": row["Np"],
-            "DL": row["DL"],
-            "jesd_class": "jesd204c",
-        }
-
-    # Copy settings to 204b
-    for mode, config in jrx_modes_204c.items():
-        jrx_modes_204b[mode] = config.copy()
-        jrx_modes_204b[mode]["jesd_class"] = "jesd204b"
-        # jrx_modes_204b[mode]["HD"] = 0  # HD is always 0 for 204b
-
-    return {"jesd204b": jrx_modes_204b, "jesd204c": jrx_modes_204c}
 
 
 def parse_json_config(

--- a/tests/test_ad9084_tx.py
+++ b/tests/test_ad9084_tx.py
@@ -110,13 +110,17 @@ def test_load_tx_config_modes_unsupported_part():
         _load_tx_config_modes(part="AD9999")
 
 
-def test_load_tx_config_modes_204b_mirrors_204c():
-    """Verify jesd204b modes are a copy of 204c modes with class field updated."""
+def test_load_tx_config_modes_204b_and_204c():
+    """Verify jesd204b and jesd204c modes are correctly categorized."""
     modes = _load_tx_config_modes(part="AD9084")
     b_modes = modes["jesd204b"]
     c_modes = modes["jesd204c"]
-    assert b_modes.keys() == c_modes.keys()
-    for key in c_modes:
+    common_keys = set(b_modes.keys()) & set(c_modes.keys())
+    assert len(common_keys) > 0
+    # Mode 70 is 204B-only, Mode 76 is 204C-only
+    assert "70" in b_modes and "70" not in c_modes
+    assert "76" in c_modes and "76" not in b_modes
+    for key in common_keys:
         assert b_modes[key]["L"] == c_modes[key]["L"]
         assert b_modes[key]["M"] == c_modes[key]["M"]
         assert b_modes[key]["jesd_class"] == "jesd204b"

--- a/tests/test_ad9084_util_coverage.py
+++ b/tests/test_ad9084_util_coverage.py
@@ -77,3 +77,32 @@ def test_ad9084_util_apply_settings_mode_not_found():
     }
     with pytest.raises(Exception, match="No JESD mode found"):
         apply_settings(conv, profile_settings)
+
+
+def test_ad9084_util_load_rx_modes_categorization():
+    """Verify _load_rx_config_modes correctly parses 204B and 204C modes."""
+    from adijif.converters.ad9084_util import _load_rx_config_modes
+
+    modes_84 = _load_rx_config_modes("AD9084")
+    assert "jesd204b" in modes_84
+    assert "jesd204c" in modes_84
+
+    # AD9084 4T4R: M=2 modes (such as 6, 13, 29) should be loaded
+    assert "6" in modes_84["jesd204b"]
+    assert "6" in modes_84["jesd204c"]
+    assert "29" in modes_84["jesd204b"]
+    assert "29" in modes_84["jesd204c"]
+
+    # Mode 70 is 204B-only, Mode 76 is 204C-only
+    assert "70" in modes_84["jesd204b"]
+    assert "70" not in modes_84["jesd204c"]
+    assert "76" in modes_84["jesd204c"]
+    assert "76" not in modes_84["jesd204b"]
+
+    # AD9088 8T8R modes
+    modes_88 = _load_rx_config_modes("AD9088")
+    assert "0" in modes_88["jesd204b"]
+    assert "0" in modes_88["jesd204c"]
+    # M=4 modes like 47 should be loaded
+    assert "47" in modes_88["jesd204b"]
+    assert "47" in modes_88["jesd204c"]

--- a/tests/test_ad9088_tx.py
+++ b/tests/test_ad9088_tx.py
@@ -127,13 +127,17 @@ def test_ad9088_tx_set_invalid_jesd_class_raises():
 # ── Mode loader (8T8R) ───────────────────────────────────────────────────────
 
 
-def test_load_tx_config_modes_ad9088_204b_mirrors_204c():
-    """Verify jesd204b modes mirror jesd204c modes with class field updated."""
+def test_load_tx_config_modes_ad9088_204b_and_204c():
+    """Verify jesd204b and jesd204c modes are correctly categorized for AD9088."""
     modes = _load_tx_config_modes(part="AD9088")
     b_modes = modes["jesd204b"]
     c_modes = modes["jesd204c"]
-    assert b_modes.keys() == c_modes.keys()
-    for key in c_modes:
+    common_keys = set(b_modes.keys()) & set(c_modes.keys())
+    assert len(common_keys) > 0
+    # Mode 70 is 204B-only, Mode 76 is 204C-only
+    assert "70" in b_modes and "70" not in c_modes
+    assert "76" in c_modes and "76" not in b_modes
+    for key in common_keys:
         assert b_modes[key]["L"] == c_modes[key]["L"]
         assert b_modes[key]["M"] == c_modes[key]["M"]
         assert b_modes[key]["jesd_class"] == "jesd204b"


### PR DESCRIPTION
### Summary
Fixes issues in AD9084/AD9088 JESD mode table parsing:
- Correctly parse valid modes when 4T4R/8T8R cells are blank (only filter out explicitly 'Not Supported' modes, preventing valid M=2 and M=4 modes from being dropped).
- Properly categorize JESD204B vs JESD204C modes based on ratio column entries ('B', 'C', 'BC') rather than mirroring all 204C modes into 204B.
- Standardize mode dictionary fields across RX and TX paths and normalize mode key formatting.
- Update and expand test coverage for RX and TX mode loading and 204B/204C partitioning.